### PR TITLE
Add script to summarize attention heads from JSON files

### DIFF
--- a/attention_summary.py
+++ b/attention_summary.py
@@ -1,0 +1,29 @@
+import os
+import json
+
+# Path to attention files
+ATTENTION_DIR = os.path.join(os.path.dirname(__file__), "outputs", "attention_files")
+
+def summarize_attention():
+    if not os.path.exists(ATTENTION_DIR):
+        print(f"No attention files found in {ATTENTION_DIR}.")
+        return
+
+    files = [f for f in os.listdir(ATTENTION_DIR) if f.endswith(".json")]
+    if not files:
+        print("No JSON attention files found.")
+        return
+
+    print(f"Found {len(files)} attention files:\n")
+    for fname in files:
+        path = os.path.join(ATTENTION_DIR, fname)
+        try:
+            with open(path, "r") as f:
+                data = json.load(f)
+            num_heads = len(data.get("attentions", []))  # assuming 'attentions' key
+            print(f"{fname}: {num_heads} attention heads")
+        except Exception as e:
+            print(f"{fname}: Error reading file - {e}")
+
+if __name__ == "__main__":
+    summarize_attention()


### PR DESCRIPTION
This adds a script attention_summary.py that summarizes attention head data from JSON files stored in outputs/attention_files. Each JSON file contains attention information for a sequence or model head. The script reads these files and provides a summary of the attention patterns. If no files exist, the script will indicate that the directory is empty. Example JSON files can be added to outputs/attention_files for testing. This is for issue #7 