### PR TITLE
SSO for web interface

### DIFF
--- a/web_app/README-auth.md
+++ b/web_app/README-auth.md
@@ -1,0 +1,40 @@
+## Keycloak Setup
+0. **Create keycloak instance**
+```docker
+docker run -p 8080:8080 -e KEYCLOAK_ADMIN=admin -e KEYCLOAK_ADMIN_PASSWORD=admin quay.io/keycloak/keycloak:21.1.1 start-dev
+```
+- Admin console at http://localhost:8080/
+- Username and password: `admin`
+
+1. **Create a Realm**  
+   - Go to Keycloak Admin → Realms → Add Realm
+
+2. **Create a Client**  
+   - Go to Clients → Create → Client ID: `flask-app` → Client Protocol: `openid-connect`  
+   - **Settings**:  
+     - Client authentication: `on`
+     - Root URL: url to app (e.g. `http://127.0.0.1:9000`)
+     - Valid Redirect URIs: `/auth`  
+     - Web Origins: `*`  
+     - Valid Post Logout Redirect URIs: `/`
+
+3. **Get Client Secret**  
+   - Go to **Credentials** → copy the secret  
+
+4. **Create Test User**  
+   - Users → Add User → username/email → set password
+
+## Flask Setup
+1. **Install dependencies**
+- `pip install authlib requests`
+
+2. **Edit OAuthSSO registration**
+```py
+sso = OAuthSSO(
+    app,
+    client_name="keycloak",
+    client_id="flask-app", # Copy from Keycloak
+    client_secret="YOUR_SECRET_HERE", # Copy from Keycloak
+    server_metadata_url="{keycloak_path}/realms/dev/.well-known/openid-configuration" # e.g (https://localhost:8080//realms/dev/.well-known/openid-configuration)
+)
+```

--- a/web_app/README.md
+++ b/web_app/README.md
@@ -5,12 +5,17 @@ This is a Flask-based web interface for running OpenFold protein structure predi
 
 ## Running the Application
 
-1. Start the Flask development server:
+1. Change your directory to the web_app directory:
+   ```bash
+   cd web_app
+   ```
+
+2. Start the Flask development server:
    ```bash
    python app.py
    ```
 
-2. Open your web browser and navigate to:
+3. Open your web browser and navigate to:
    ```
    http://localhost:5000
    ```

--- a/web_app/README.md
+++ b/web_app/README.md
@@ -1,5 +1,9 @@
 # Protein Structure Prediction Web Interface
 
+# Demo
+
+https://github.com/user-attachments/assets/5570bf41-51c0-4e44-a91d-8909c7abd57b
+
 This is a Flask-based web interface for running OpenFold protein structure predictions and visualizing the results in 3D.
    ```
 

--- a/web_app/README.md
+++ b/web_app/README.md
@@ -1,0 +1,46 @@
+# Protein Structure Prediction Web Interface
+
+This is a Flask-based web interface for running OpenFold protein structure predictions and visualizing the results in 3D.
+   ```
+
+## Running the Application
+
+1. Start the Flask development server:
+   ```bash
+   python app.py
+   ```
+
+2. Open your web browser and navigate to:
+   ```
+   http://localhost:5000
+   ```
+
+## Usage
+
+1. Enter a protein ID (e.g., 6KWC)
+2. Enter a residue index to focus on (default: 18)
+3. Optionally, add a description
+4. Enter the protein sequence in single-letter amino acid code
+5. Click "Predict Structure" to run the prediction
+
+## Features
+
+- 3D visualization of predicted protein structures
+- Interactive controls for viewing different representations (cartoon, backbone, sidechains)
+- Color schemes for better visualization (by chain, by residue)
+- Responsive design that works on desktop and tablet devices
+
+## Output
+
+The application will create the following directories in the `web_tmp_dir` directory:
+
+- `fasta_<protein_id>/`: Contains the input FASTA file
+- `outputs/attention_files_<protein_id>_demo_tri_<residue_idx>/`: Contains attention map files
+- `outputs/my_outputs_align_<protein_id>_demo_tri_<residue_idx>/`: Contains output files including the predicted PDB
+- `outputs/attention_images_<protein_id>_demo_tri_<residue_idx>/`: Contains visualization images
+
+## Notes
+
+- The first run may take longer as it needs to download the required models
+- For large proteins, the prediction may take several minutes to complete
+- Ensure you have sufficient disk space for temporary files and outputs

--- a/web_app/app.py
+++ b/web_app/app.py
@@ -251,14 +251,16 @@ def process():
         '--bfd_database_path', f'{data_dir}/bfd/bfd_metaclust_clu_complete_id30_c90_final_seq.sorted_opt',
         '--save_outputs',
         '--cpus', '8',
-        '--use_precomputed_alignments', '/home/hice1/vsr9/scratch/attention-viz-demo/examples/monomer/alignments',
-        '--enable_chunking',
         '--model_device', 'cuda:0',
         '--attn_map_dir', attn_map_dir,
         '--num_recycles_save', '1',
         '--triangle_residue_idx', str(residue_idx),
         '--demo_attn'
     ]
+
+    if (os.path.exists(os.path.abspath(f'./examples/monomer/alignments/fasta_dir_{protein_id}'))):
+        cmd.append('--use_precomputed_alignments')
+        cmd.append(os.path.abspath('./examples/monomer/alignments'))
 
     # Store the process
     process = subprocess.Popen(

--- a/web_app/app.py
+++ b/web_app/app.py
@@ -1,0 +1,206 @@
+import os
+import subprocess
+import time
+import json
+from flask import Flask, render_template, request, jsonify, send_from_directory, Response
+
+app = Flask(__name__)
+app.config['UPLOAD_FOLDER'] = './web_tmp_dir'
+# Store running processes
+running_processes = {}
+app.config['MAX_CONTENT_LENGTH'] = 16 * 1024 * 1024  # 16MB max upload size
+DATA_DIR = "/ime/hdd/rhaas/SUP-5301/database"
+
+# Ensure upload directory exists
+os.makedirs(app.config['UPLOAD_FOLDER'], exist_ok=True)
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+def stream_output(process, pdb_file, protein_id, prediction_id):
+    """Stream output from subprocess to client."""
+    def generate():
+        # Stream stdout line-by-line in text mode
+        for line in iter(process.stdout.readline, ''):
+            line_str = line.rstrip('\n')
+            if line_str:
+                yield f"data: {json.dumps({'type': 'output', 'message': line_str})}\n\n"
+        
+        # Check for errors
+        process.wait()
+        
+        # Clean up the process from the running processes
+        if prediction_id in running_processes:
+            del running_processes[prediction_id]
+            
+        if process.returncode != 0:
+            try:
+                error = process.stderr.read()
+                yield f"data: {json.dumps({'type': 'error', 'message': error})}\n\n"
+            except Exception:
+                yield f"data: {json.dumps({'type': 'error', 'message': 'An error occurred while reading the error output'})}\n\n"
+        else:
+            # Send completion message with PDB file info
+            yield f"""data: {json.dumps({
+                'type': 'complete',
+                'pdb_file': pdb_file,
+                'protein_id': protein_id
+            })}\n\n"""
+    
+    return Response(
+        generate(),
+        mimetype='text/event-stream',
+        headers={
+            'Cache-Control': 'no-cache',
+            'X-Accel-Buffering': 'no',  # for nginx
+            'Connection': 'keep-alive'
+        }
+    )
+
+@app.route('/cancel_prediction', methods=['POST'])
+def cancel_prediction():
+    prediction_id = request.json.get('prediction_id')
+    if not prediction_id:
+        return jsonify({'status': 'error', 'message': 'No prediction ID provided'}), 400
+        
+    if prediction_id in running_processes:
+        process_info = running_processes[prediction_id]
+        try:
+            # Terminate the process group to ensure all child processes are killed
+            if process_info['process'].poll() is None:  # Check if process is still running
+                try:
+                    # Try to terminate gracefully first
+                    os.killpg(os.getpgid(process_info['process'].pid), 15)  # SIGTERM
+                    
+                    # Wait a bit for the process to terminate
+                    try:
+                        process_info['process'].wait(timeout=5)
+                    except subprocess.TimeoutExpired:
+                        # Force kill if it doesn't terminate
+                        os.killpg(os.getpgid(process_info['process'].pid), 9)  # SIGKILL
+                        
+                    return jsonify({
+                        'status': 'cancelled',
+                        'message': 'Prediction was successfully cancelled'
+                    })
+                except ProcessLookupError:
+                    # Process already terminated
+                    pass
+                except Exception as e:
+                    return jsonify({
+                        'status': 'error',
+                        'message': f'Error cancelling prediction: {str(e)}'
+                    }), 500
+            
+            # Clean up
+            del running_processes[prediction_id]
+            return jsonify({'status': 'already_done', 'message': 'Process was already terminated'})
+            
+        except Exception as e:
+            # Clean up even if there was an error
+            if prediction_id in running_processes:
+                del running_processes[prediction_id]
+            return jsonify({
+                'status': 'error',
+                'message': f'Error cancelling prediction: {str(e)}'
+            }), 500
+    
+    return jsonify({'status': 'not_found', 'message': 'No running prediction found with that ID'})
+
+@app.route('/process', methods=['GET', 'POST'])
+def process():
+    prediction_id = None
+    if request.method == 'GET':
+        # Handle SSE connection
+        sequence = request.args.get('sequence', '').strip()
+        description = request.args.get('description', '').strip()
+        residue_idx = int(request.args.get('residue_idx', 1))
+        protein_id = request.args.get('protein_id', 'demo').strip()
+        prediction_id = request.args.get('prediction_id', None)
+    else:
+        # Handle form submission
+        sequence = request.form.get('sequence', '').strip()
+        description = request.form.get('description', '').strip()
+        protein_id = request.form.get('protein_id', 'demo').strip()
+        prediction_id = request.form.get('prediction_id', None)
+        try:
+            residue_idx = int(request.form.get('residue_idx', 1))
+        except (ValueError, TypeError):
+            residue_idx = 1  # Default value if conversion fails
+    
+    if sequence == '':
+        return jsonify({'error': 'Protein sequence is required'}), 400
+    
+    # Format FASTA content
+    fasta_content = f">{protein_id} {description}\n{sequence}"
+    
+    # Run OpenFold in a subprocess with streaming output
+    fasta_dir = os.path.join(os.path.abspath(app.config['UPLOAD_FOLDER']), f'fasta_{protein_id}')
+    os.makedirs(fasta_dir, exist_ok=True)
+    
+    # Save FASTA file
+    fasta_path = os.path.join(fasta_dir, f"{protein_id}.fasta")
+    with open(fasta_path, 'w') as f:
+        f.write(fasta_content)
+    
+    # Define output directories
+    attn_map_dir = os.path.join(os.path.abspath(app.config['UPLOAD_FOLDER']), f'outputs/attention_files_{protein_id}_demo_tri_{residue_idx}')
+    output_dir = os.path.join(os.path.abspath(app.config['UPLOAD_FOLDER']), f'outputs/my_outputs_align_{protein_id}_demo_tri_{residue_idx}')
+    image_output_dir = os.path.join(os.path.abspath(app.config['UPLOAD_FOLDER']), f'outputs/attention_images_{protein_id}_demo_tri_{residue_idx}')
+    
+    data_dir = os.path.realpath(os.path.expanduser(DATA_DIR))
+    # Create output directories
+    os.makedirs(attn_map_dir, exist_ok=True)
+    os.makedirs(output_dir, exist_ok=True)
+    os.makedirs(image_output_dir, exist_ok=True)
+    
+    #Build the command
+    cmd = [
+        'python3', '-u', 'run_pretrained_openfold.py',
+        fasta_dir,
+        f'{data_dir}/pdb_mmcif/mmcif_files',
+        '--output_dir', output_dir,
+        '--config_preset', 'model_1_ptm',
+        '--uniref90_database_path', f'{data_dir}/uniref90/uniref90.fasta',
+        '--mgnify_database_path', f'{data_dir}/mgnify/mgy_clusters_2022_05.fa',
+        '--pdb70_database_path', f'{data_dir}/pdb70/pdb70',
+        '--uniclust30_database_path', f'{data_dir}/uniclust30/uniclust30_2018_08/uniclust30_2018_08',
+        '--bfd_database_path', f'{data_dir}/bfd/bfd_metaclust_clu_complete_id30_c90_final_seq.sorted_opt',
+        '--save_outputs',
+        '--model_device', 'cuda:0',
+        '--attn_map_dir', attn_map_dir,
+        '--num_recycles_save', '1',
+        '--triangle_residue_idx', str(residue_idx),
+        '--demo_attn'
+    ]
+
+    # Store the process
+    process = subprocess.Popen(
+        cmd,
+        cwd='..',
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,  # merge stderr into stdout to prevent blocking
+        text=True,
+        bufsize=1,  # line buffered
+        universal_newlines=True,
+        start_new_session=True  # Required for process group management
+    )
+    
+    # Store the process in the global dictionary
+    running_processes[prediction_id] = {
+        'process': process,
+        'start_time': time.time()
+    }
+    
+    # Path to the expected PDB file
+    pdb_file = f'outputs/my_outputs_align_{protein_id}_demo_tri_{residue_idx}/predictions/{protein_id}_model_1_ptm_relaxed.pdb'
+    # Return the streaming response
+    return stream_output(process, pdb_file, protein_id, prediction_id)
+
+@app.route('/pdb/<path:filename>')
+def serve_pdb(filename):
+    return send_from_directory(app.config['UPLOAD_FOLDER'], filename)
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000, debug=True)

--- a/web_app/auth.py
+++ b/web_app/auth.py
@@ -1,0 +1,52 @@
+from functools import wraps
+from flask import redirect, url_for, session
+from authlib.integrations.flask_client import OAuth
+
+
+class OAuthSSO:
+    def __init__(
+        self,
+        app,
+        client_name="keycloak",
+        client_id=None,
+        client_secret=None,
+        server_metadata_url=None,
+        scope="openid profile email",
+    ):
+        self.app = app
+        self.client_name = client_name
+        self.oauth = OAuth(app)
+        self.client = self.oauth.register(
+            name=client_name,
+            client_id=client_id,
+            client_secret=client_secret,
+            server_metadata_url=server_metadata_url,
+            client_kwargs={"scope": scope},
+        )
+
+    def login(self):
+        redirect_uri = url_for("auth_callback", _external=True)
+        return self.client.authorize_redirect(redirect_uri)
+
+    def callback(self):
+        token = self.client.authorize_access_token()
+        session["user"] = token.get("userinfo") or token.get("id_token_claims")
+        session["id_token"] = token.get("id_token")
+        return redirect(url_for("index"))
+
+    def logout(self):
+        id_token = session.pop("id_token", None)
+        session.pop("user", None)
+        session.pop("token", None)
+
+        end_session_url = self.client.server_metadata.get("end_session_endpoint")
+        if end_session_url and id_token:
+            redirect_uri = url_for("index", _external=True)
+            return redirect(
+                f"{end_session_url}?id_token_hint={id_token}&post_logout_redirect_uri={redirect_uri}"
+            )
+
+        return redirect(url_for("index"))
+
+    def logged_in(self):
+        return session.get("user") is not None

--- a/web_app/templates/index.html
+++ b/web_app/templates/index.html
@@ -239,6 +239,11 @@
     </div>
 </div>
 
+<form action="{{ url_for('logout') }}" method="post">
+    <button type="submit">Logout</button>
+</form>
+
+
 <!-- Bootstrap Icons -->
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.0/font/bootstrap-icons.css">
 

--- a/web_app/templates/index.html
+++ b/web_app/templates/index.html
@@ -172,6 +172,71 @@
             </div>
         </div>
     </div>
+
+    <!-- Attention Visualizations Section -->
+    <div class="card mb-4">
+        <div class="card-header d-flex justify-content-between align-items-center" data-bs-toggle="collapse"
+            href="#attnCollapse" role="button" aria-expanded="false" aria-controls="attnCollapse"
+            style="cursor: pointer;">
+            <h5 class="mb-0">Attention Visualizations</h5>
+            <i class="bi bi-chevron-down"></i>
+        </div>
+        <div class="collapse" id="attnCollapse">
+            <div class="card-body">
+                <div class="row align-items-center g-3 mb-3">
+                    <div class="col-md-4">
+                        <div class="dropdown">
+                            <button class="btn btn-outline-secondary dropdown-toggle w-100" type="button" id="attnDropdown" data-bs-toggle="dropdown" aria-expanded="false">
+                                Select visualization
+                            </button>
+                            <ul class="dropdown-menu" id="attn-dropdown-menu">
+                                <li><a class="dropdown-item" href="#" data-type="msa_row">MSA Row Attention</a></li>
+                                <li><a class="dropdown-item" href="#" data-type="triangle_start">Triangle Start Attention</a></li>
+                            </ul>
+                        </div>
+                    </div>
+                    <div class="col-md-8">
+                        <div class="d-flex align-items-center gap-3">
+                            <div class="flex-grow-1">
+                                <label for="layerRange" class="form-label mb-0">Layer: <span id="layerValue">-</span></label>
+                                <input type="range" class="form-range" id="layerRange" min="0" max="0" value="0" disabled>
+                            </div>
+                            <div class="form-check ms-2">
+                                <input class="form-check-input" type="checkbox" value="" id="noLayer3D">
+                                <label class="form-check-label" for="noLayer3D">No layer</label>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div id="attn-loading" class="text-center" style="display: none;">
+                    <div class="spinner-border text-primary" role="status">
+                        <span class="visually-hidden">Loading...</span>
+                    </div>
+                    <p class="mt-2">Preparing attention visualizations...</p>
+                </div>
+                <div class="row g-3 mb-2" id="attn-content" style="display: none;">
+                    <div class="col-12 d-flex align-items-center">
+                        <label class="me-2">Head:</label>
+                        <select id="headSelect" class="form-select form-select-sm" style="width:auto"></select>
+                    </div>
+                </div>
+                <div class="row g-3">
+                    <div class="col-md-6">
+                        <div class="border rounded p-2 h-100">
+                            <div class="fw-bold mb-2">Arc Diagram</div>
+                            <svg id="arcSvg" width="100%" height="480"></svg>
+                        </div>
+                    </div>
+                    <div class="col-md-6">
+                        <div class="border rounded p-2 h-100">
+                            <div class="fw-bold mb-2">Attention Heatmap</div>
+                            <canvas id="heatmapCanvas" width="800" height="480" style="width:100%; height:480px;"></canvas>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
 </div>
 
 <!-- Bootstrap Icons -->
@@ -267,6 +332,8 @@
         outputCollapse.show();
         let threeDCollapse = new bootstrap.Collapse(document.getElementById('threeDCollapse'), { toggle: false });
         threeDCollapse.hide();
+        let attnCollapse = new bootstrap.Collapse(document.getElementById('attnCollapse'), { toggle: false });
+        attnCollapse.hide();
 
         // Show loading indicator and hide viewer controls
         loading.style.display = 'block';
@@ -316,6 +383,12 @@
                 runButton.disabled = false;
                 cancelButton.style.display = 'none';
                 loadPDB(data.pdb_file);
+                // Initialize attention UI and start polling for this prediction
+                const protId = document.getElementById('protein-id').value;
+                const resIdx = parseInt(document.getElementById('residue-idx').value || '0');
+                currentProteinMeta = { protein_id: protId, residue_idx: resIdx };
+                initAttentionUI();
+                attnCollapse.show();
                 eventSource.close();
             }
         };
@@ -366,6 +439,12 @@
                                 outputElement.textContent += '\nError loading PDB: ' + error.message + '\n';
                             });
                         }
+                        // Also initialize attention UI
+                        const protId = document.getElementById('protein-id').value;
+                        const resIdx = parseInt(document.getElementById('residue-idx').value || '0');
+                        currentProteinMeta = { protein_id: protId, residue_idx: resIdx };
+                        initAttentionUI();
+                        attnCollapse.show();
                     }
                 } catch (e) {
                     console.error('Error processing message:', e);
@@ -506,6 +585,10 @@
     });
     // Store the current model
     let currentModel = null;
+    let currentProteinMeta = null; // {protein_id, residue_idx}
+    let attnData = null; // cached list from /viz/list
+    let attnType = 'msa_row';
+    let attnPollTimer = null;
 
     // Function to load proteins from /proteins endpoint
     async function loadProteins() {
@@ -563,8 +646,14 @@
         document.getElementById('sequence').value = protein.sequence;
         document.getElementById('residue-idx').value = protein.residue_idx;
         loadPDB(protein.pdb_file);
+        currentProteinMeta = { protein_id: protein.protein_id, residue_idx: protein.residue_idx };
+        initAttentionUI();
+        let outputCollapse = new bootstrap.Collapse(document.getElementById('outputCollapse'), { toggle: false });
+        outputCollapse.hide();
         let threeDCollapse = new bootstrap.Collapse(document.getElementById('threeDCollapse'), { toggle: false });
         threeDCollapse.show();
+        let attnCollapse = new bootstrap.Collapse(document.getElementById('attnCollapse'), { toggle: false });
+        attnCollapse.show();
         // Close dropdown
         const dropdown = bootstrap.Dropdown.getInstance(document.getElementById('proteinDropdown'));
         if (dropdown) {
@@ -581,8 +670,15 @@
         document.getElementById('residue-idx').value = '';
         window.viewer.clear();
         document.getElementById('viewer-controls').style.display = 'none';
+        currentProteinMeta = null;
+        attnData = null;
+        updateAttentionDisplay(null);
+        let outputCollapse = new bootstrap.Collapse(document.getElementById('outputCollapse'), { toggle: false });
+        outputCollapse.hide();
         let threeDCollapse = new bootstrap.Collapse(document.getElementById('threeDCollapse'), { toggle: false });
         threeDCollapse.hide();
+        let attnCollapse = new bootstrap.Collapse(document.getElementById('attnCollapse'), { toggle: false });
+        attnCollapse.hide();
         // Close dropdown
         const dropdown = bootstrap.Dropdown.getInstance(document.getElementById('proteinDropdown'));
         if (dropdown) {
@@ -611,6 +707,16 @@
             // Store the current model
             currentModel = pdbData;
 
+            // Compute residue coordinates (CA atoms) for 3D overlays
+            try {
+                const model = window.viewer.getModel();
+                const caAtoms = model ? model.selectedAtoms({ atom: 'CA' }) : [];
+                window.residueCoords = caAtoms.map(a => ({ x: a.x, y: a.y, z: a.z }));
+            } catch (e) {
+                console.warn('Failed to compute CA coordinates', e);
+                window.residueCoords = [];
+            }
+
             // Show viewer controls
             document.getElementById('viewer-controls').style.display = 'block';
 
@@ -620,6 +726,531 @@
         }
     }
 
+
+    // Attention visualization logic
+    // Pan/Zoom view states
+    let arcView = { xMin: 0, xMax: null }; // in index units [0, n]
+    let currentArcConnections = [];
+    let currentSequence = '';
+    let heatView = { x: 0, y: 0, w: null, h: null }; // in grid units
+    let lastHeatSource = null; // offscreen canvas with full heatmap image
+    let lastHeatSeqLen = 0;
+    function initAttentionUI() {
+        const menu = document.getElementById('attn-dropdown-menu');
+        if (!menu) return;
+        menu.querySelectorAll('a').forEach(a => {
+            a.onclick = (e) => {
+                e.preventDefault();
+                attnType = a.getAttribute('data-type');
+                document.getElementById('attnDropdown').textContent = a.textContent;
+                if (attnData) updateLayerControls();
+                updateAttentionDisplay(getCurrentAssets());
+            };
+        });
+
+        // default selection
+        attnType = 'msa_row';
+        const attnBtn = document.getElementById('attnDropdown');
+        if (attnBtn) attnBtn.textContent = 'MSA Row Attention';
+
+        const range = document.getElementById('layerRange');
+        if (range) {
+            range.oninput = () => {
+                document.getElementById('layerValue').textContent = range.value;
+                updateAttentionDisplay(getCurrentAssets());
+            };
+        }
+
+        // Trigger generation and start polling for availability
+        triggerVizGeneration();
+        pollVizUntilReady();
+
+        // Setup interactions
+        setupArcInteractions();
+        setupHeatmapInteractions();
+
+        const noLayerChk = document.getElementById('noLayer3D');
+        if (noLayerChk) {
+            noLayerChk.onchange = () => {
+                if (noLayerChk.checked) {
+                    clear3DOverlay();
+                } else {
+                    maybeUpdate3DOverlay();
+                }
+            };
+        }
+    }
+
+    function setAttnLoading(loading) {
+        const loadingEl = document.getElementById('attn-loading');
+        const contentEl = document.getElementById('attn-content');
+        if (!loadingEl || !contentEl) return;
+        loadingEl.style.display = loading ? 'block' : 'none';
+        contentEl.style.display = loading ? 'none' : 'flex';
+    }
+
+    function updateLayerControls() {
+        const range = document.getElementById('layerRange');
+        const layers = (attnType === 'msa_row') ? (attnData?.msa_row?.layers || []) : (attnData?.triangle_start?.layers || []);
+        if (!range) return;
+        if (layers.length === 0) {
+            range.disabled = true;
+            range.min = 0; range.max = 0; range.value = 0;
+            document.getElementById('layerValue').textContent = '-';
+            return;
+        }
+        layers.sort((a,b)=>a-b);
+        range.disabled = false;
+        range.min = layers[0];
+        range.max = layers[layers.length-1];
+        if (!layers.includes(parseInt(range.value))) {
+            range.value = layers[0];
+        }
+        document.getElementById('layerValue').textContent = range.value;
+    }
+
+    function getCurrentAssets() {
+        if (!attnData) return null;
+        const L = document.getElementById('layerRange').value;
+        const assets = (attnType === 'msa_row') ? attnData.msa_row.assets[String(L)] : attnData.triangle_start.assets[String(L)];
+        return assets || null;
+    }
+
+    function updateAttentionDisplay(assets) {
+        if (!assets) {
+            setAttnLoading(true);
+            clearArcAndHeatmap();
+            return;
+        }
+        setAttnLoading(false);
+        fetchAndRenderAttention(assets.attn_file_url);
+    }
+
+    function clearArcAndHeatmap() {
+        const svg = document.getElementById('arcSvg');
+        while (svg.firstChild) svg.removeChild(svg.firstChild);
+        const ctx = document.getElementById('heatmapCanvas').getContext('2d');
+        ctx.clearRect(0,0,ctx.canvas.width, ctx.canvas.height);
+    }
+
+    async function fetchAndRenderAttention(url) {
+        try {
+            const res = await fetch(url);
+            if (!res.ok) throw new Error('failed to fetch attention file');
+            const text = await res.text();
+            const parsed = parseAttentionFile(text);
+            populateHeadSelector(Object.keys(parsed).map(x=>parseInt(x,10)).sort((a,b)=>a-b));
+            const head = getSelectedHead();
+            const edges = preprocessConnections(parsed[head] || []);
+            currentArcConnections = edges;
+            currentSequence = getSequence();
+            // reset arc view to full range
+            arcView.xMin = 0; arcView.xMax = currentSequence.length;
+            renderArcDiagram(currentArcConnections, currentSequence);
+            renderHeatmap(parsed[head] || [], currentSequence.length);
+            // update 3D overlay if enabled
+            maybeUpdate3DOverlay();
+        } catch (e) {
+            console.warn('fetchAndRenderAttention error', e);
+            clearArcAndHeatmap();
+        }
+    }
+
+    function parseAttentionFile(text) {
+        const lines = text.split(/\r?\n/);
+        const heads = {};
+        let currentHead = null;
+        for (let raw of lines) {
+            const line = raw.trim();
+            if (!line) continue;
+            if (line.toLowerCase().startsWith('layer')) {
+                // e.g., "Layer 47, Head 0"
+                const parts = line.replace(',', '').split(/\s+/);
+                const headIdx = parseInt(parts[parts.length-1], 10);
+                currentHead = headIdx;
+                if (!(currentHead in heads)) heads[currentHead] = [];
+            } else {
+                const parts = line.split(/\s+/);
+                if (parts.length >= 3) {
+                    const r1 = parseInt(parts[0], 10);
+                    const r2 = parseInt(parts[1], 10);
+                    const w = parseFloat(parts[2]);
+                    if (!Number.isNaN(r1) && !Number.isNaN(r2) && !Number.isNaN(w)) {
+                        heads[currentHead].push([r1, r2, w]);
+                    }
+                }
+            }
+        }
+        return heads;
+    }
+
+    function populateHeadSelector(heads) {
+        const sel = document.getElementById('headSelect');
+        if (!sel) return;
+        const current = sel.value;
+        sel.innerHTML = '';
+        heads.forEach(h => {
+            const opt = document.createElement('option');
+            opt.value = String(h);
+            opt.textContent = `Head ${h}`;
+            sel.appendChild(opt);
+        });
+        if (heads.length > 0) {
+            sel.value = heads.includes(parseInt(current,10)) ? current : String(heads[0]);
+        }
+        sel.onchange = () => {
+            // Re-render with current layer/type
+            const assets = getCurrentAssets();
+            if (assets) fetchAndRenderAttention(assets.attn_file_url);
+        };
+    }
+
+    function getSelectedHead() {
+        const sel = document.getElementById('headSelect');
+        return sel && sel.value ? parseInt(sel.value, 10) : 0;
+    }
+
+    function getSequence() {
+        return (document.getElementById('sequence').value || '').trim();
+    }
+
+    function renderArcDiagram(connections, sequence) {
+        const svg = document.getElementById('arcSvg');
+        while (svg.firstChild) svg.removeChild(svg.firstChild);
+
+        const n = sequence.length;
+        const width = svg.clientWidth || svg.parentElement.clientWidth;
+        const height = svg.getAttribute('height') ? parseInt(svg.getAttribute('height'),10) : 480;
+        const padding = 20;
+        const baselineY = height - 40;
+        // Ensure view initialized
+        if (arcView.xMax === null) { arcView.xMin = 0; arcView.xMax = n; }
+        const viewSpan = Math.max(arcView.xMax - arcView.xMin, 1e-6);
+        const xScale = (width - 2*padding) / viewSpan;
+        const xCenter = (fIndex) => padding + xScale * (fIndex - arcView.xMin); // fIndex can be fractional (i+0.5)
+        const xTick = (i) => xCenter(i + 0.5);
+
+        // draw baseline residue labels (only those visible), snap to pixel to reduce flicker
+        const iStart = Math.max(0, Math.floor(arcView.xMin));
+        const iEnd = Math.min(n, Math.ceil(arcView.xMax));
+        for (let i=iStart;i<iEnd;i++) {
+            const tx = document.createElementNS('http://www.w3.org/2000/svg','text');
+            const xpix = Math.round(xTick(i));
+            tx.setAttribute('x', xpix);
+            tx.setAttribute('y', baselineY + 14);
+            tx.setAttribute('text-anchor','middle');
+            tx.setAttribute('font-size','10');
+            tx.textContent = sequence[i];
+            // Highlight specific residue for triangle_start, matching Python's behavior
+            if (attnType === 'triangle_start' && currentProteinMeta && typeof currentProteinMeta.residue_idx === 'number' && currentProteinMeta.residue_idx === i) {
+                tx.setAttribute('fill', 'blue');
+                tx.setAttribute('font-weight', 'bold');
+            }
+            svg.appendChild(tx);
+        }
+
+        if (!connections || connections.length === 0) return;
+        const weights = connections.map(c=>c[2]);
+        const wmin = Math.min(...weights), wmax = Math.max(...weights);
+        const norm = (w)=> (wmax!==wmin) ? (w - wmin)/(wmax-wmin) : 0.5;
+
+        // Determine scaling so tallest arc is 75% of drawable height
+        const drawableHeight = baselineY - padding; // from top padding to baseline
+        let maxAbsDist = 0;
+        for (const [r1, r2] of connections) {
+            const df = Math.abs((r2 + 0.5) - (r1 + 0.5));
+            if (df > maxAbsDist) maxAbsDist = df;
+        }
+        const rawMaxHeightPx = maxAbsDist * 0.5 * ((width - 2*padding) / n); // base scale uses full index scale to match parity across zoom
+        const targetMaxHeight = 0.75 * drawableHeight;
+        const heightScale = rawMaxHeightPx > 0 ? (targetMaxHeight / rawMaxHeightPx) : 1.0;
+
+        // Draw arcs as sampled semicircles to match matplotlib implementation
+        const SAMPLES = 60; // number of samples for the semicircle
+        connections.forEach(([r1, r2, w]) => {
+            // Apply +0.5 offset in index space
+            const f1 = r1 + 0.5;
+            const f2 = r2 + 0.5;
+            // Pixel x for endpoints
+            const px1 = xCenter(f1);
+            const px2 = xCenter(f2);
+            // Height in index units is |f2 - f1|/2; convert to pixels via BASE xScale (full index span) and global scaling
+            const baseXScale = (width - 2*padding) / n;
+            const heightPx = Math.abs(f2 - f1) * 0.5 * baseXScale * heightScale;
+            const path = document.createElementNS('http://www.w3.org/2000/svg','path');
+            let d = '';
+            for (let i=0; i<=SAMPLES; i++) {
+                const t = i / SAMPLES; // 0..1
+                const xpx = px1 + (px2 - px1) * t;
+                const ypx = baselineY - heightPx * Math.sin(Math.PI * t);
+                d += (i===0 ? `M ${xpx} ${ypx}` : ` L ${xpx} ${ypx}`);
+            }
+            const nw = norm(w);
+            const strokeWidth = (0.5 + 3* nw).toFixed(2);
+            const blue = Math.round((0.5 + 0.5 * nw) * 255);
+            path.setAttribute('d', d);
+            path.setAttribute('stroke', `rgb(0,0,${blue})`);
+            path.setAttribute('stroke-width', strokeWidth);
+            path.setAttribute('fill','none');
+            path.setAttribute('opacity','0.9');
+            svg.appendChild(path);
+        });
+    }
+
+    function clear3DOverlay() {
+        try { window.viewer.removeAllShapes(); window.viewer.render(); } catch (e) {}
+    }
+
+    function maybeUpdate3DOverlay() {
+        const noLayer = document.getElementById('noLayer3D');
+        if (noLayer && noLayer.checked) { clear3DOverlay(); return; }
+        if (!Array.isArray(window.residueCoords) || window.residueCoords.length === 0) return;
+        if (!currentArcConnections || currentArcConnections.length === 0) { clear3DOverlay(); return; }
+        try {
+            // Remove previous shapes
+            window.viewer.removeAllShapes();
+            const n = currentSequence ? currentSequence.length : window.residueCoords.length;
+            const weights = currentArcConnections.map(e=>e[2]);
+            const wmin = Math.min(...weights), wmax = Math.max(...weights);
+            const norm = (w)=> (wmax!==wmin) ? (w - wmin)/(wmax-wmin) : 0.5;
+            currentArcConnections.forEach(([i,j,w]) => {
+                if (i<0||j<0||i>=n||j>=n) return;
+                const a = window.residueCoords[i];
+                const b = window.residueCoords[j];
+                if (!a||!b) return;
+                const t = norm(w);
+                const radius = 0.1 + 0.4 * t; // scale radius by weight
+                const blue = Math.round((0.5 + 0.5*t) * 255);
+                window.viewer.addCylinder({
+                    start: a, end: b,
+                    radius: radius,
+                    fromCap: 1, toCap: 1,
+                    color: `rgb(0,0,${blue})`
+                });
+            });
+            window.viewer.render();
+        } catch (e) {
+            console.warn('Failed updating 3D overlay', e);
+        }
+    }
+
+    function preprocessConnections(connections) {
+        // Match Python generate_arc_diagrams behavior:
+        // - r1 != r2 (no self loops)
+        // - treat pairs as undirected (i<j), keep max weight per pair
+        // - apply top_k=50 by weight desc
+        const pairs = new Map();
+        for (const item of connections) {
+            const r1 = item[0]|0, r2 = item[1]|0; const w = Number(item[2]);
+            if (!Number.isFinite(w)) continue;
+            if (r1 === r2) continue;
+            const a = Math.min(r1, r2), b = Math.max(r1, r2);
+            const key = a + '-' + b;
+            const prev = pairs.get(key);
+            if (prev === undefined || w > prev) pairs.set(key, w);
+        }
+        const arr = Array.from(pairs.entries()).map(([key, w]) => {
+            const [a, b] = key.split('-').map(x=>parseInt(x,10));
+            return [a, b, w];
+        });
+        arr.sort((x,y)=> y[2]-x[2]);
+        const TOP_K = 50;
+        return arr.slice(0, TOP_K);
+    }
+
+    function renderHeatmap(connections, seqLen) {
+        const canvas = document.getElementById('heatmapCanvas');
+        const ctx = canvas.getContext('2d');
+        ctx.clearRect(0,0,canvas.width, canvas.height);
+        const W = canvas.width, H = canvas.height;
+        const grid = new Float32Array(seqLen*seqLen);
+        let wmin = Infinity, wmax = -Infinity;
+        for (const [r1,r2,w] of connections) {
+            const idx = r1*seqLen + r2;
+            grid[idx] = w;
+            if (w<wmin) wmin=w;
+            if (w>wmax) wmax=w;
+        }
+        if (!isFinite(wmin) || !isFinite(wmax)) { wmin=0; wmax=1; }
+        const norm = (v)=> (wmax!==wmin)? (v-wmin)/(wmax-wmin) : 0.5;
+        const img = ctx.createImageData(seqLen, seqLen);
+        for (let y=0;y<seqLen;y++){
+            for (let x=0;x<seqLen;x++){
+                const v = norm(grid[y*seqLen+x] || 0);
+                const i = (y*seqLen + x)*4;
+                const r = 230 - Math.floor(180*v);
+                const g = 240 - Math.floor(200*v);
+                const b = 255;
+                img.data[i]=r; img.data[i+1]=g; img.data[i+2]=b; img.data[i+3]=255;
+            }
+        }
+        // scale to canvas
+        const off = document.createElement('canvas');
+        off.width = seqLen; off.height = seqLen;
+        off.getContext('2d').putImageData(img,0,0);
+        // store for pan/zoom redraws
+        lastHeatSource = off;
+        lastHeatSeqLen = seqLen;
+        if (heatView.w === null || heatView.h === null) { heatView = { x: 0, y: 0, w: seqLen, h: seqLen }; }
+        redrawHeatmap();
+        // axes labels are omitted for simplicity
+    }
+
+    function redrawHeatmap() {
+        const canvas = document.getElementById('heatmapCanvas');
+        const ctx = canvas.getContext('2d');
+        ctx.clearRect(0,0,canvas.width, canvas.height);
+        if (!lastHeatSource) return;
+        const W = canvas.width, H = canvas.height;
+        const sx = Math.max(0, Math.min(lastHeatSeqLen-1, heatView.x));
+        const sy = Math.max(0, Math.min(lastHeatSeqLen-1, heatView.y));
+        const sw = Math.max(1, Math.min(lastHeatSeqLen - sx, heatView.w));
+        const sh = Math.max(1, Math.min(lastHeatSeqLen - sy, heatView.h));
+        ctx.imageSmoothingEnabled = false;
+        ctx.drawImage(lastHeatSource, sx, sy, sw, sh, 0, 0, W, H);
+    }
+
+    function setupArcInteractions() {
+        const svg = document.getElementById('arcSvg');
+        let isDown = false; let startX = 0; let startMin = 0;
+        svg.addEventListener('mousedown', (e) => {
+            e.preventDefault();
+            isDown = true;
+            startX = e.clientX;
+            startMin = arcView.xMin;
+            // prevent text selection during drag
+            document.body.style.userSelect = 'none';
+            svg.style.cursor = 'grabbing';
+        });
+        window.addEventListener('mouseup', ()=> isDown=false);
+        window.addEventListener('mousemove', (e)=>{
+            if (!isDown || !currentSequence) return;
+            e.preventDefault();
+            const width = svg.clientWidth || svg.parentElement.clientWidth;
+            const padding = 20;
+            const drawable = Math.max(1, width - 2*padding);
+            const span = Math.max(1e-6, arcView.xMax - arcView.xMin);
+            const dxPx = e.clientX - startX;
+            const dIndex = dxPx / drawable * span;
+            const n = currentSequence.length;
+            let newMin = startMin - dIndex;
+            newMin = Math.max(0, Math.min(n - span, newMin));
+            arcView.xMin = newMin; arcView.xMax = newMin + span;
+            renderArcDiagram(currentArcConnections, currentSequence);
+        });
+        window.addEventListener('mouseup', ()=>{
+            document.body.style.userSelect = '';
+            svg.style.cursor = '';
+        });
+        svg.addEventListener('wheel', (e)=>{
+            if (!currentSequence) return;
+            e.preventDefault();
+            const rect = svg.getBoundingClientRect();
+            const x = e.clientX - rect.left;
+            const width = svg.clientWidth || svg.parentElement.clientWidth;
+            const padding = 20;
+            const drawable = Math.max(1, width - 2*padding);
+            const n = currentSequence.length;
+            const span = Math.max(1e-6, arcView.xMax - arcView.xMin);
+            const mouseT = Math.max(0, Math.min(1, (x - padding) / drawable));
+            const mouseIndex = arcView.xMin + mouseT * span;
+            const factor = (e.deltaY < 0) ? 0.9 : 1.1; // zoom in/out
+            let newSpan = Math.max(5, Math.min(n, span * factor));
+            let newMin = mouseIndex - mouseT * newSpan;
+            newMin = Math.max(0, Math.min(n - newSpan, newMin));
+            arcView.xMin = newMin; arcView.xMax = newMin + newSpan;
+            renderArcDiagram(currentArcConnections, currentSequence);
+        }, { passive: false });
+    }
+
+    function setupHeatmapInteractions() {
+        const canvas = document.getElementById('heatmapCanvas');
+        let isDown = false; let startX=0, startY=0; let startView=null;
+        canvas.addEventListener('mousedown', (e)=>{
+            isDown = true;
+            startX = e.clientX; startY = e.clientY;
+            startView = { ...heatView };
+        });
+        window.addEventListener('mouseup', ()=> isDown=false);
+        window.addEventListener('mousemove', (e)=>{
+            if (!isDown || !lastHeatSource) return;
+            const W = canvas.clientWidth; const H = canvas.clientHeight;
+            const dxPx = e.clientX - startX; const dyPx = e.clientY - startY;
+            // translate in grid units proportionally to current view extents
+            const dX = dxPx / Math.max(1, W) * startView.w;
+            const dY = dyPx / Math.max(1, H) * startView.h;
+            const maxX = Math.max(0, lastHeatSeqLen - startView.w);
+            const maxY = Math.max(0, lastHeatSeqLen - startView.h);
+            heatView.x = Math.max(0, Math.min(maxX, startView.x - dX));
+            heatView.y = Math.max(0, Math.min(maxY, startView.y - dY));
+            redrawHeatmap();
+        });
+        canvas.addEventListener('wheel', (e)=>{
+            if (!lastHeatSource) return;
+            e.preventDefault();
+            const rect = canvas.getBoundingClientRect();
+            const mx = e.clientX - rect.left;
+            const my = e.clientY - rect.top;
+            const W = canvas.clientWidth; const H = canvas.clientHeight;
+            const tx = Math.max(0, Math.min(1, mx / Math.max(1, W)));
+            const ty = Math.max(0, Math.min(1, my / Math.max(1, H)));
+            const factor = (e.deltaY < 0) ? 0.9 : 1.1;
+            let newW = Math.max(10, Math.min(lastHeatSeqLen, heatView.w * factor));
+            let newH = Math.max(10, Math.min(lastHeatSeqLen, heatView.h * factor));
+            const cx = heatView.x + tx * heatView.w;
+            const cy = heatView.y + ty * heatView.h;
+            let newX = cx - tx * newW;
+            let newY = cy - ty * newH;
+            newX = Math.max(0, Math.min(lastHeatSeqLen - newW, newX));
+            newY = Math.max(0, Math.min(lastHeatSeqLen - newH, newY));
+            heatView = { x: newX, y: newY, w: newW, h: newH };
+            redrawHeatmap();
+        }, { passive: false });
+    }
+
+    async function triggerVizGeneration() {
+        if (!currentProteinMeta) return;
+        try {
+            await fetch('/viz/generate', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ protein_id: currentProteinMeta.protein_id })
+            });
+        } catch (e) {
+            console.warn('Failed to trigger viz generation:', e);
+        }
+    }
+
+    async function fetchVizList() {
+        if (!currentProteinMeta) return null;
+        const params = new URLSearchParams({
+            protein_id: currentProteinMeta.protein_id,
+            residue_idx: currentProteinMeta.residue_idx
+        });
+        const res = await fetch(`/viz/list?${params.toString()}`);
+        if (!res.ok) return null;
+        return await res.json();
+    }
+
+    async function pollVizUntilReady() {
+        if (attnPollTimer) clearInterval(attnPollTimer);
+        setAttnLoading(true);
+        const attempt = async () => {
+            try {
+                const data = await fetchVizList();
+                if (data && ((data.msa_row.layers && data.msa_row.layers.length>0) || (data.triangle_start.layers && data.triangle_start.layers.length>0))) {
+                    attnData = data;
+                    updateLayerControls();
+                    updateAttentionDisplay(getCurrentAssets());
+                    if (attnPollTimer) clearInterval(attnPollTimer);
+                }
+            } catch (e) {
+                console.warn('viz list fetch failed', e);
+            }
+        };
+        await attempt();
+        attnPollTimer = setInterval(attempt, 4000);
+    }
 
 </script>
 </body>

--- a/web_app/templates/index.html
+++ b/web_app/templates/index.html
@@ -86,10 +86,20 @@
                             placeholder="Enter amino acid sequence" required></textarea>
                         <div class="form-text">Enter protein sequence in single-letter amino acid code</div>
                     </div>
-                    <div class="d-flex justify-content-end">
-                        <button type="submit" class="btn btn-primary me-2" id="run-btn">Run Prediction</button>
-                        <button type="button" class="btn btn-danger" id="cancel-btn" style="display: none;"
-                            onclick="cancelPrediction()">Cancel</button>
+                    <div class="d-flex">
+                        <div class="me-auto">
+                            <button class="btn btn-secondary dropdown-toggle" type="button" id="proteinDropdown" data-bs-toggle="dropdown" aria-expanded="false">
+                                Select a protein
+                              </button>
+                              <ul class="dropdown-menu" id="protein-dropdown-menu">
+                                <li><a class="dropdown-item" href="#">Loading proteins...</a></li>
+                              </ul>
+                        </div>
+                        <div>
+                            <button type="submit" class="btn btn-primary me-2" id="run-btn">Run Prediction</button>
+                            <button type="button" class="btn btn-danger" id="cancel-btn" style="display: none;"
+                                onclick="cancelPrediction()">Cancel</button>
+                        </div>
                     </div>
             </form>
         </div>
@@ -360,6 +370,7 @@
                 } catch (e) {
                     console.error('Error processing message:', e);
                     outputElement.textContent += '\nError processing server response\n';
+                    outputElement.scrollTop = outputElement.scrollHeight;
                     loading.style.display = 'none';
                     runButton.disabled = false;
                     cancelButton.style.display = 'none';
@@ -371,6 +382,7 @@
             // Handle connection errors
             eventSource.onerror = function () {
                 outputElement.textContent += '\nConnection error occurred. Please try again.\n';
+                outputElement.scrollTop = outputElement.scrollHeight;
                 loading.style.display = 'none';
                 runButton.disabled = false;
                 cancelButton.style.display = 'none';
@@ -387,6 +399,7 @@
 
         } catch (error) {
             outputElement.textContent += '\nError: ' + error.message + '\n';
+            outputElement.scrollTop = outputElement.scrollHeight;
             console.error('Error:', error);
             loading.style.display = 'none';
         }
@@ -421,6 +434,8 @@
     document.addEventListener('DOMContentLoaded', function () {
         window.viewer = initViewer();
 
+        // Load proteins into dropdown
+        loadProteins();
 
         // Handle window resize
         function handleResize() {
@@ -492,7 +507,90 @@
     // Store the current model
     let currentModel = null;
 
-    // Function to load and display PDB file
+    // Function to load proteins from /proteins endpoint
+    async function loadProteins() {
+        try {
+            const response = await fetch('/proteins');
+            const proteins = await response.json();
+
+            const dropdownMenu = document.getElementById('protein-dropdown-menu');
+            const dropdownButton = document.getElementById('proteinDropdown');
+
+            // Clear existing items
+            dropdownMenu.innerHTML = '';
+
+            if (proteins.length === 0) {
+                dropdownMenu.innerHTML = '<li><a class="dropdown-item disabled" href="#">No proteins available</a></li>';
+                return;
+            }
+
+            // Add protein options
+            proteins.forEach(protein => {
+                const li = document.createElement('li');
+                const a = document.createElement('a');
+                a.className = 'dropdown-item';
+                a.href = '#';
+                a.textContent = `${protein.protein_id}`;
+                a.onclick = () => selectProtein(protein);
+                li.appendChild(a);
+                dropdownMenu.appendChild(li);
+            });
+
+            const li = document.createElement('li');
+            const a = document.createElement('a');
+            a.className = 'dropdown-item';
+            a.href = '#';
+            a.textContent = `Clear`;
+            a.onclick = () => clearProtein();
+            li.appendChild(a);
+            dropdownMenu.appendChild(li);
+
+        } catch (error) {
+            console.error('Error loading proteins:', error);
+            const dropdownMenu = document.getElementById('protein-dropdown-menu');
+            dropdownMenu.innerHTML = '<li><a class="dropdown-item disabled" href="#">Error loading proteins</a></li>';
+        }
+    }
+
+    // Function to handle protein selection
+    function selectProtein(protein) {
+        // Update dropdown button text
+        document.getElementById('proteinDropdown').textContent = `${protein.protein_id}`;
+
+        // Populate form fields
+        document.getElementById('protein-id').value = protein.protein_id;
+        document.getElementById('description').value = protein.description;
+        document.getElementById('sequence').value = protein.sequence;
+        document.getElementById('residue-idx').value = protein.residue_idx;
+        loadPDB(protein.pdb_file);
+        let threeDCollapse = new bootstrap.Collapse(document.getElementById('threeDCollapse'), { toggle: false });
+        threeDCollapse.show();
+        // Close dropdown
+        const dropdown = bootstrap.Dropdown.getInstance(document.getElementById('proteinDropdown'));
+        if (dropdown) {
+            dropdown.hide();
+        }
+
+    }
+
+    function clearProtein() {
+        document.getElementById('proteinDropdown').textContent = `Select a protein`;
+        document.getElementById('protein-id').value = '';
+        document.getElementById('description').value = '';
+        document.getElementById('sequence').value = '';
+        document.getElementById('residue-idx').value = '';
+        window.viewer.clear();
+        document.getElementById('viewer-controls').style.display = 'none';
+        let threeDCollapse = new bootstrap.Collapse(document.getElementById('threeDCollapse'), { toggle: false });
+        threeDCollapse.hide();
+        // Close dropdown
+        const dropdown = bootstrap.Dropdown.getInstance(document.getElementById('proteinDropdown'));
+        if (dropdown) {
+            dropdown.hide();
+        }
+    }
+
+        // Function to load and display PDB file
     async function loadPDB(pdbPath) {
         try {
             // Clear previous model

--- a/web_app/templates/index.html
+++ b/web_app/templates/index.html
@@ -1,0 +1,529 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Protein Structure Prediction</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/3Dmol/2.0.1/3Dmol-min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+
+    <style>
+        body {
+            padding: 20px;
+            background-color: #f8f9fa;
+        }
+
+        #viewer {
+            width: 100%;
+            height: 100%;
+            min-height: 500px;
+            position: relative;
+        }
+
+        #viewer canvas {
+            width: 100% !important;
+            height: 100% !important;
+            display: block;
+        }
+
+        #command-output {
+            height: 300px;
+            overflow-y: auto;
+            color: #1e1e1e;
+            padding: 15px;
+            border-radius: 4px;
+            font-family: monospace;
+            white-space: pre-wrap;
+            margin-bottom: 20px;
+        }
+
+        #loading {
+            display: none;
+            text-align: center;
+            margin: 20px 0;
+        }
+
+        .spinner-border {
+            width: 3rem;
+            height: 3rem;
+        }
+    </style>
+</head>
+<div class="container">
+    <h1 class="mb-4">Protein Structure Prediction</h1>
+
+    <div class="card mb-4">
+        <div class="card-header">
+            <h5 class="mb-0">Input Parameters</h5>
+        </div>
+        <div class="card-body">
+            <form id="protein-form" onsubmit="event.preventDefault(); submitForm(event); return false;">
+                <div class="row">
+                    <div class="col-md-6">
+                        <div class="form-group mb-3">
+                            <label for="protein-id" class="form-label">Protein ID</label>
+                            <input type="text" class="form-control" id="protein-id" name="protein_id"
+                                placeholder="Enter protein ID" required>
+                        </div>
+                    </div>
+                    <div class="col-md-6">
+                        <div class="form-group mb-3">
+                            <label for="residue-idx" class="form-label">Residue Index</label>
+                            <input type="number" class="form-control" id="residue-idx" name="residue_idx" value="18"
+                                min="1" required>
+                        </div>
+                    </div>
+                </div>
+                <div class="form-group">
+                    <label for="description" class="form-label">Description (Optional)</label>
+                    <input type="text" class="form-control" id="description" name="description"
+                        placeholder="Enter protein description">
+                    <div class="form-group">
+                        <label for="sequence" class="form-label">Amino Acid Sequence</label>
+                        <textarea class="form-control" id="sequence" name="sequence" rows="6"
+                            placeholder="Enter amino acid sequence" required></textarea>
+                        <div class="form-text">Enter protein sequence in single-letter amino acid code</div>
+                    </div>
+                    <div class="d-flex justify-content-end">
+                        <button type="submit" class="btn btn-primary me-2" id="run-btn">Run Prediction</button>
+                        <button type="button" class="btn btn-danger" id="cancel-btn" style="display: none;"
+                            onclick="cancelPrediction()">Cancel</button>
+                    </div>
+            </form>
+        </div>
+    </div>
+
+    <div class="loading" id="loading">
+        <div class="spinner-border text-primary" role="status">
+            <span class="visually-hidden">Loading...</span>
+        </div>
+        <p class="mt-2">Running OpenFold prediction. This may take several minutes...</p>
+    </div>
+
+    <!-- Collapsible Output Section -->
+    <div class="card mb-4">
+        <div class="card-header d-flex justify-content-between align-items-center" data-bs-toggle="collapse"
+            href="#outputCollapse" role="button" aria-expanded="false" aria-controls="outputCollapse"
+            style="cursor: pointer;">
+            <h5 class="mb-0">Command Output</h5>
+            <i class="bi bi-chevron-down"></i>
+        </div>
+        <div class="collapse" id="outputCollapse">
+            <div class="card-body">
+                <pre id="command-output"></pre>
+            </div>
+        </div>
+    </div>
+
+    <!-- Collapsible 3d Viewer Section -->
+    <div class="card mb-4">
+        <div class="card-header d-flex justify-content-between align-items-center" data-bs-toggle="collapse"
+            href="#threeDCollapse" role="button" aria-expanded="false" aria-controls="threeDCollapse"
+            style="cursor: pointer;">
+            <h5 class="mb-0">3d Structure Viewer</h5>
+            <i class="bi bi-chevron-down"></i>
+        </div>
+        <div class="collapse" id="threeDCollapse">
+            <div class="card-body p-0" style="height: 500px;">
+                <div id="viewer" style="width: 100%; height: 100%;"></div>
+            </div>
+            <div id="viewer-controls" class="card-footer bg-transparent border-top-0" style="display: none">
+                <div class="btn-toolbar" role="toolbar">
+                    <div class="btn-group me-2" role="group">
+                        <button type="button" class="btn btn-sm btn-outline-secondary" id="toggle-backbone">
+                            <i class="bi bi-diagram-2"></i> Backbone
+                        </button>
+                        <button type="button" class="btn btn-sm btn-outline-secondary" id="toggle-sidechains">
+                            <i class="bi bi-bounding-box"></i> Sidechains
+                        </button>
+                    </div>
+                    <div class="btn-group me-2" role="group">
+                        <button type="button" class="btn btn-sm btn-outline-primary" id="color-cartoon">
+                            <i class="bi bi-bezier2"></i> Cartoon
+                        </button>
+                        <button type="button" class="btn btn-sm btn-outline-primary" id="color-chain">
+                            <i class="bi bi-braces"></i> Chain
+                        </button>
+                        <button type="button" class="btn btn-sm btn-outline-primary" id="color-residue">
+                            <i class="bi bi-dot"></i> Residue
+                        </button>
+                    </div>
+                    <div class="btn-group ms-auto" role="group">
+                        <button type="button" class="btn btn-sm btn-outline-info" id="zoom-to-fit">
+                            <i class="bi bi-zoom-in"></i> Zoom to Fit
+                        </button>
+                        <button type="button" class="btn btn-sm btn-outline-info" id="reset-view">
+                            <i class="bi bi-arrow-counterclockwise"></i> Reset View
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Bootstrap Icons -->
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.0/font/bootstrap-icons.css">
+
+<script>
+    // Function to handle form submission
+    let currentPredictionId = null;
+    let eventSource = null;
+
+    function cancelPrediction() {
+        if (!currentPredictionId) {
+            console.log('No prediction to cancel');
+            return;
+        }
+
+        const cancelButton = document.getElementById('cancel-btn');
+        const runButton = document.getElementById('run-btn');
+        const outputElement = document.getElementById('command-output');
+
+        // Disable cancel button to prevent multiple clicks
+        cancelButton.disabled = true;
+
+        fetch('/cancel_prediction', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ prediction_id: currentPredictionId })
+        })
+            .then(response => {
+                if (!response.ok) {
+                    throw new Error('Network response was not ok');
+                }
+                return response.json();
+            })
+            .then(data => {
+                console.log('Cancel response:', data);
+
+                if (data.status === 'cancelled' || data.status === 'already_done') {
+                    outputElement.textContent += '\n' + (data.message || 'Prediction was cancelled.') + '\n';
+
+                    // Close the event source if it exists
+                    if (eventSource) {
+                        eventSource.close();
+                        eventSource = null;
+                    }
+
+                    // Update UI
+                    document.getElementById('loading').style.display = 'none';
+                    runButton.disabled = false;
+                    cancelButton.style.display = 'none';
+                    cancelButton.disabled = false;
+
+                    // Reset prediction ID
+                    currentPredictionId = null;
+                } else {
+                    outputElement.textContent += '\nError: ' + (data.message || 'Failed to cancel prediction') + '\n';
+                    cancelButton.disabled = false;
+                }
+            })
+            .catch(error => {
+                console.error('Error cancelling prediction:', error);
+                outputElement.textContent += '\nError cancelling prediction: ' + error.message + '\n';
+                cancelButton.disabled = false;
+
+                // Still try to clean up
+                if (eventSource) {
+                    eventSource.close();
+                    eventSource = null;
+                }
+
+                document.getElementById('loading').style.display = 'none';
+                runButton.disabled = false;
+                cancelButton.style.display = 'none';
+                currentPredictionId = null;
+            });
+    }
+
+    function submitForm(event) {
+        event.preventDefault();
+
+        const form = document.getElementById('protein-form');
+        const loading = document.getElementById('loading');
+        const outputElement = document.getElementById('command-output');
+        const viewerControls = document.getElementById('viewer-controls');
+        const runButton = document.getElementById('run-btn');
+        const cancelButton = document.getElementById('cancel-btn');
+
+        // Reset and show output
+        outputElement.textContent = 'Starting prediction...\n';
+        let outputCollapse = new bootstrap.Collapse(document.getElementById('outputCollapse'), { toggle: false });
+        outputCollapse.show();
+        let threeDCollapse = new bootstrap.Collapse(document.getElementById('threeDCollapse'), { toggle: false });
+        threeDCollapse.hide();
+
+        // Show loading indicator and hide viewer controls
+        loading.style.display = 'block';
+        viewerControls.style.display = 'none';
+        runButton.disabled = true;
+        cancelButton.style.display = 'inline-block';
+
+        // Generate a new prediction ID
+        currentPredictionId = Date.now().toString();
+
+        // Store the form data
+        const formData = new FormData(form);
+
+        // Close any existing event source
+        if (eventSource) {
+            eventSource.close();
+        }
+
+        // Add prediction ID to form data
+        formData.append('prediction_id', currentPredictionId);
+
+        // Create a URL with query parameters
+        const params = new URLSearchParams();
+        for (const [key, value] of formData.entries()) {
+            params.append(key, value);
+        }
+
+        // Set up event source for server-sent events
+        eventSource = new EventSource(`/process?${params.toString()}`);
+
+        eventSource.onmessage = function (event) {
+            const data = JSON.parse(event.data);
+
+            if (data.type === 'output') {
+                outputElement.textContent += data.message + '\n';
+                outputElement.scrollTop = outputElement.scrollHeight;
+            } else if (data.type === 'error') {
+                outputElement.textContent += '\nError: ' + data.message + '\n';
+                loading.style.display = 'none';
+                runButton.disabled = false;
+                cancelButton.style.display = 'none';
+                eventSource.close();
+            } else if (data.type === 'complete') {
+                outputElement.textContent += '\nPrediction complete! Loading structure...\n';
+                loading.style.display = 'none';
+                viewerControls.style.display = 'block';
+                runButton.disabled = false;
+                cancelButton.style.display = 'none';
+                loadPDB(data.pdb_file);
+                eventSource.close();
+            }
+        };
+
+        eventSource.onerror = function () {
+            outputElement.textContent += '\nConnection to server was closed.\n';
+            loading.style.display = 'none';
+            runButton.disabled = false;
+            cancelButton.style.display = 'none';
+            eventSource.close();
+        };
+
+        try {
+
+            // Handle incoming messages
+            eventSource.onmessage = function (event) {
+                try {
+                    const data = JSON.parse(event.data);
+
+                    if (data.type === 'output') {
+                        // Append new output
+                        outputElement.textContent += data.message + '\n';
+                        // Auto-scroll to bottom
+                        outputElement.scrollTop = outputElement.scrollHeight;
+                    }
+                    else if (data.type === 'error') {
+                        outputElement.textContent += '\nERROR: ' + data.message + '\n';
+                        outputElement.scrollTop = outputElement.scrollHeight;
+                        loading.style.display = 'none';
+                        runButton.disabled = false;
+                        cancelButton.style.display = 'none';
+                        currentPredictionId = null;
+                        eventSource.close();
+                    }
+                    else if (data.type === 'complete') {
+                        // Close the event source when done
+                        eventSource.close();
+                        loading.style.display = 'none';
+                        runButton.disabled = false;
+                        cancelButton.style.display = 'none';
+                        currentPredictionId = null;
+                        outputCollapse.hide();
+                        threeDCollapse.show();
+                        // Load and display the PDB file if available
+                        if (data.pdb_file) {
+                            loadPDB(data.pdb_file).catch(error => {
+                                console.error('Error loading PDB:', error);
+                                outputElement.textContent += '\nError loading PDB: ' + error.message + '\n';
+                            });
+                        }
+                    }
+                } catch (e) {
+                    console.error('Error processing message:', e);
+                    outputElement.textContent += '\nError processing server response\n';
+                    loading.style.display = 'none';
+                    runButton.disabled = false;
+                    cancelButton.style.display = 'none';
+                    currentPredictionId = null;
+                    eventSource.close();
+                }
+            };
+
+            // Handle connection errors
+            eventSource.onerror = function () {
+                outputElement.textContent += '\nConnection error occurred. Please try again.\n';
+                loading.style.display = 'none';
+                runButton.disabled = false;
+                cancelButton.style.display = 'none';
+                currentPredictionId = null;
+                eventSource.close();
+            };
+
+            // Close the connection when leaving the page
+            window.addEventListener('beforeunload', function () {
+                if (eventSource) {
+                    eventSource.close();
+                }
+            });
+
+        } catch (error) {
+            outputElement.textContent += '\nError: ' + error.message + '\n';
+            console.error('Error:', error);
+            loading.style.display = 'none';
+        }
+
+        return false;
+    }
+
+    // Initialize 3DMol viewer
+    function initViewer() {
+        try {
+            // Create viewer with explicit dimensions
+            const viewer = $3Dmol.createViewer('viewer', {
+                defaultcolors: $3Dmol.rasmolElementColors,
+                backgroundColor: 0xffffff,
+                width: '100%',
+                height: '100%'
+            });
+
+            // Set a default style
+            viewer.setStyle({}, { cartoon: {} });
+            viewer.zoomTo();
+            viewer.render();
+
+            return viewer;
+        } catch (error) {
+            console.error('Error initializing 3DMol viewer:', error);
+            return null;
+        }
+    }
+
+    // Initialize viewer when the page loads
+    document.addEventListener('DOMContentLoaded', function () {
+        window.viewer = initViewer();
+
+
+        // Handle window resize
+        function handleResize() {
+            if (window.viewer) {
+                const container = document.getElementById('viewer');
+                if (container) {
+                    // Force canvas dimensions to match container
+                    const canvas = container.querySelector('canvas');
+                    if (canvas) {
+                        canvas.style.width = '100%';
+                        canvas.style.height = '100%';
+                    }
+                    window.viewer.resize();
+                    window.viewer.render();
+                }
+            }
+        }
+
+        // Initial render
+        handleResize();
+
+        // Debounce resize events
+        let resizeTimer;
+        window.addEventListener('resize', function () {
+            clearTimeout(resizeTimer);
+            resizeTimer = setTimeout(handleResize, 100);
+        });
+
+        const controls = {
+            'toggle-backbone': () => {
+                window.viewer.setStyle({}, { line: {} });
+                window.viewer.render();
+            },
+            'toggle-sidechains': () => {
+                window.viewer.setStyle({}, { stick: {} });
+                window.viewer.render();
+            },
+            'color-cartoon': () => {
+                window.viewer.setStyle({}, { cartoon: {} });
+                window.viewer.render();
+            },
+            'color-chain': () => {
+                window.viewer.setStyle({}, { cartoon: { colorscheme: 'chainHetatm' } });
+                window.viewer.render();
+            },
+            'color-residue': () => {
+                window.viewer.setStyle({}, { cartoon: { colorscheme: 'shapely' } });
+                window.viewer.render();
+            },
+            'zoom-to-fit': () => {
+                window.viewer.zoomTo();
+                window.viewer.render();
+            },
+            'reset-view': () => {
+                window.viewer.zoomTo();
+                window.viewer.setStyle({}, { cartoon: {} });
+                window.viewer.render();
+            }
+        };
+
+        // Attach event listeners
+        Object.entries(controls).forEach(([id, handler]) => {
+            const element = document.getElementById(id);
+            if (element) {
+                element.addEventListener('click', handler);
+            }
+        });
+    });
+    // Store the current model
+    let currentModel = null;
+
+    // Function to load and display PDB file
+    async function loadPDB(pdbPath) {
+        try {
+            // Clear previous model
+            window.viewer.clear();
+
+            // Load PDB file
+            const response = await fetch(`/pdb/${pdbPath}`);
+            const pdbData = await response.text();
+
+            // Add model to viewer
+            window.viewer.addModel(pdbData, 'pdb');
+
+            // Set style and zoom
+            window.viewer.setStyle({}, { cartoon: {} });
+            window.viewer.zoomTo();
+            window.viewer.render();
+
+            // Store the current model
+            currentModel = pdbData;
+
+            // Show viewer controls
+            document.getElementById('viewer-controls').style.display = 'block';
+
+        } catch (error) {
+            console.error('Error loading PDB:', error);
+            throw new Error('Failed to load protein structure');
+        }
+    }
+
+
+</script>
+</body>
+
+</html>


### PR DESCRIPTION
This PR builds off the web interface implemented in #12. The initial goal was to add SSO via GT login (http://iamweb1.iam.gatech.edu/docs/Home), however, that requires you to submit details for the necessary permissions, so I decided to implement it locally for now. The local system utilizes Keycloak for SSO. Information on how to set it up is in `README-auth.md`. I added a simple logout button so the feature can be tested, but in reality the auth session would eventually expire and force a refresh when needed.  In the future, this system can be replaced with GT SSO when the necessary permissions are approved.