### PR TITLE
Intermediate representation visualization utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,11 @@ cutlass/
 *.sto
 *.a3m
 *.hhr
+
+# Local OS junk
+.DS_Store
+
+# Local experiment outputs
+outputs/
+*.pt
+*.npy

--- a/openfold/viz/__init__.py
+++ b/openfold/viz/__init__.py
@@ -1,0 +1,5 @@
+"""
+Utilities for visualizing intermediate representations in OpenFold.
+
+This package is completely optional and does not modify core OpenFold code.
+"""

--- a/openfold/viz/intermediate_hooks.py
+++ b/openfold/viz/intermediate_hooks.py
@@ -1,0 +1,200 @@
+"""
+Utilities for recording intermediate representations from Evoformer layers
+without modifying core OpenFold code.
+
+You can import `IntermediateRecorder` and `attach_evoformer_hooks` in your own
+scripts or notebooks.
+"""
+
+from typing import List, Dict, Any
+
+import os
+import numpy as np
+import torch
+from torch import nn
+
+
+class IntermediateRecorder:
+    """
+    Records intermediate representations from Evoformer layers.
+
+    For each layer (hook call) we store:
+      - 'msa'   : [*, N_seq, N_res, C_m]
+      - 'pair'  : [*, N_res, N_res, C_z]
+      - 'single': [*, N_res, C_s] (if available)
+    """
+
+    def __init__(self) -> None:
+        self.storage: List[Dict[str, torch.Tensor]] = []
+
+    def hook_fn(self, module: nn.Module,
+                inputs: Any,
+                output: Any) -> None:
+        """
+        Forward hook attached to each Evoformer block.
+
+        We expect output to be a tuple (m, z, s) OR (m, z).
+        If 's' is not present per layer, we just skip it.
+        """
+        if isinstance(output, (tuple, list)):
+            if len(output) == 3:
+                m, z, s = output
+            elif len(output) == 2:
+                m, z = output
+                s = None
+            else:
+                # Unexpected shape; don't record
+                return
+        else:
+            # Unexpected output type
+            return
+
+        record: Dict[str, torch.Tensor] = {
+            "msa": m.detach().cpu(),
+            "pair": z.detach().cpu(),
+        }
+        if s is not None:
+            record["single"] = s.detach().cpu()
+
+        self.storage.append(record)
+
+    def clear(self) -> None:
+        self.storage = []
+
+    def save(self, out_dir: str, protein_id: str) -> None:
+        """
+        Save all recorded tensors as .npy files.
+
+        Files look like:
+          {protein_id}_msa_layer{L}.npy
+          {protein_id}_pair_layer{L}.npy
+          {protein_id}_single_layer{L}.npy
+        """
+        os.makedirs(out_dir, exist_ok=True)
+
+        for layer_idx, reps in enumerate(self.storage):
+            for name, tensor in reps.items():
+                path = os.path.join(
+                    out_dir,
+                    f"{protein_id}_{name}_layer{layer_idx}.npy"
+                )
+                np.save(path, tensor.numpy())
+                print(f"[saved] {path}")
+
+
+def attach_evoformer_hooks(model: nn.Module,
+                           recorder: IntermediateRecorder) -> List[torch.utils.hooks.RemovableHandle]:
+    """
+    Attach hooks to each Evoformer block in the model.
+
+    DOES NOT modify the model code itself. You call this from your
+    own script or notebook after creating the model.
+
+    Returns:
+        list of hook handles. You MUST call .remove() on each when done.
+    """
+    handles: List[torch.utils.hooks.RemovableHandle] = []
+
+    evo = getattr(model, "evoformer", None)
+    if evo is None:
+        print("[warning] Model has no `.evoformer` attribute; no hooks attached.")
+        return handles
+
+    blocks = getattr(evo, "blocks", None)
+    if blocks is None:
+        print("[warning] evoformer has no `.blocks` attribute; no hooks attached.")
+        return handles
+
+    for idx, block in enumerate(blocks):
+        h = block.register_forward_hook(recorder.hook_fn)
+        handles.append(h)
+        print(f"[hook] registered on evoformer.blocks[{idx}]")
+
+    if not handles:
+        print("[warning] No Evoformer blocks found; check model.evoformer.blocks")
+
+    return handles
+
+"""
+Lightweight helpers for working with intermediate representations
+(msa / pair / single) from OpenFold.
+
+These utilities do NOT modify any core OpenFold modules. They are meant
+to be called after a normal OpenFold inference run, using the `outputs`
+dictionary returned by `AlphaFold.forward`.
+"""
+
+from typing import Dict, Any, Optional
+import os
+
+import torch
+
+from visualize_intermediate_utils import (
+    plot_single_norm,
+    plot_pair_heatmap,
+    plot_msa_norms,
+    save_intermediate_summaries,
+)
+
+
+def visualize_from_outputs(
+    outputs: Dict[str, Any],
+    out_dir: str,
+    protein_name: Optional[str] = None,
+    show: bool = False,
+) -> None:
+    """
+    High-level helper: given an OpenFold `outputs` dict, generate
+    summary numpy arrays and plots for msa / pair / single
+    representations.
+
+    Args:
+        outputs: dict produced by AlphaFold.forward
+        out_dir: directory where plots and .npy files will be written
+        protein_name: optional label (used in filenames / plot titles)
+        show: if True, show plots interactively in addition to saving
+    """
+    os.makedirs(out_dir, exist_ok=True)
+
+
+    save_intermediate_summaries(outputs, out_dir, protein_name=protein_name)
+
+
+    msa = outputs.get("msa", None)
+    pair = outputs.get("pair", None)
+    single = outputs.get("single", None)
+
+    if msa is not None and not isinstance(msa, torch.Tensor):
+        msa = torch.as_tensor(msa)
+    if pair is not None and not isinstance(pair, torch.Tensor):
+        pair = torch.as_tensor(pair)
+    if single is not None and not isinstance(single, torch.Tensor):
+        single = torch.as_tensor(single)
+
+   
+    if single is not None:
+        plot_single_norm(
+            single,
+            out_path=os.path.join(out_dir, f"{protein_name or 'sample'}_single_norm.png"),
+            protein_name=protein_name,
+            show=show,
+        )
+
+    if pair is not None:
+        plot_pair_heatmap(
+            pair,
+            out_path=os.path.join(out_dir, f"{protein_name or 'sample'}_pair_norm_heatmap.png"),
+            protein_name=protein_name,
+            show=show,
+        )
+
+
+    if msa is not None:
+        plot_msa_norms(
+            msa,
+            out_line_path=os.path.join(out_dir, f"{protein_name or 'sample'}_msa_per_res.png"),
+            out_seq_hist_path=os.path.join(out_dir, f"{protein_name or 'sample'}_msa_seqwise_hist.png"),
+            protein_name=protein_name,
+            mode="first",
+            show=show,
+        )

--- a/scripts/make_dummy_outputs.py
+++ b/scripts/make_dummy_outputs.py
@@ -1,0 +1,27 @@
+import os
+import torch
+
+# Make sure the outputs directory exists
+os.makedirs("outputs", exist_ok=True)
+
+# Toy sizes – small but realistic-ish
+L = 80   # number of residues
+S = 16   # number of MSA sequences
+C_m = 64 # MSA / single embedding dim
+C_z = 32 # pair embedding dim
+
+msa = torch.randn(1, S, L, C_m)      # [*, N_seq, N_res, C_m]
+pair = torch.randn(1, L, L, C_z)     # [*, N_res, N_res, C_z]
+single = torch.randn(1, L, C_m)      # [*, N_res, C_s]
+
+outputs = {
+    "msa": msa,
+    "pair": pair,
+    "single": single,
+}
+
+out_path = "outputs/6KWC_outputs.pt"
+torch.save(outputs, out_path)
+print(f"Saved dummy outputs to {out_path}")
+
+

--- a/scripts/plot_intermediate_example.py
+++ b/scripts/plot_intermediate_example.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+
+"""
+Small helper script to build a single multi-panel figure from the
+saved numpy summaries (single_norm, pair_norm, msa_per_res).
+
+You can use this to generate a nice example figure for your README.
+"""
+
+import argparse
+import os
+import numpy as np
+import matplotlib.pyplot as plt
+
+
+def parse_args():
+    p = argparse.ArgumentParser(
+        description="Create a demo figure from saved intermediate summaries."
+    )
+    p.add_argument(
+        "--summary-dir",
+        type=str,
+        required=True,
+        help="Directory containing *_single_norm.npy, *_pair_norm.npy, *_msa_per_res.npy.",
+    )
+    p.add_argument(
+        "--basename",
+        type=str,
+        default="sample",
+        help="Base name used in the npy files (e.g., '6KWC').",
+    )
+    p.add_argument(
+        "--out-path",
+        type=str,
+        default="outputs/intermediate_reps/example_panel.png",
+        help="Where to save the combined panel figure.",
+    )
+    return p.parse_args()
+
+
+def main():
+    args = parse_args()
+    os.makedirs(os.path.dirname(args.out_path) or ".", exist_ok=True)
+
+    single_path = os.path.join(args.summary_dir, f"{args.basename}_single_norm.npy")
+    pair_path = os.path.join(args.summary_dir, f"{args.basename}_pair_norm.npy")
+    msa_res_path = os.path.join(args.summary_dir, f"{args.basename}_msa_per_res.npy")
+
+    single = np.load(single_path)
+    pair = np.load(pair_path)
+    msa_res = np.load(msa_res_path)
+
+    fig, axes = plt.subplots(1, 3, figsize=(15, 4))
+
+    # Single
+    x = np.arange(1, len(single) + 1)
+    axes[0].plot(x, single, linewidth=1.2)
+    axes[0].set_title("Single Rep Norm per Residue")
+    axes[0].set_xlabel("Residue index")
+    axes[0].set_ylabel("L2 norm")
+
+    # Pair
+    im = axes[1].imshow(pair, origin="lower", aspect="auto")
+    axes[1].set_title("Pair Rep Frobenius Norm")
+    axes[1].set_xlabel("Residue index")
+    axes[1].set_ylabel("Residue index")
+    fig.colorbar(im, ax=axes[1], fraction=0.046, pad=0.04)
+
+    # MSA per-residue
+    x2 = np.arange(1, len(msa_res) + 1)
+    axes[2].plot(x2, msa_res, linewidth=1.2)
+    axes[2].set_title("MSA Rep Norm per Residue (first seq)")
+    axes[2].set_xlabel("Residue index")
+    axes[2].set_ylabel("L2 norm")
+
+    fig.suptitle(f"Intermediate Representations — {args.basename}", fontsize=14)
+    fig.tight_layout()
+    plt.savefig(args.out_path, dpi=300, bbox_inches="tight")
+    plt.close()
+    print(f"[Saved] example panel → {args.out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_with_intermediate_reps.py
+++ b/scripts/run_with_intermediate_reps.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+
+"""
+Run intermediate representation visualization on a saved OpenFold outputs file.
+
+Usage example:
+
+    python scripts/run_with_intermediate_reps.py \
+        --outputs-path outputs/my_protein_outputs.pt \
+        --outdir outputs/intermediate_reps/my_protein \
+        --protein-name 6KWC
+
+This script does NOT run OpenFold itself. It assumes you have already
+run inference (e.g., via existing scripts / notebooks) and saved the
+`outputs` dict using:
+
+    torch.save(outputs, "outputs/my_protein_outputs.pt")
+"""
+
+import argparse
+import os
+import torch
+
+from visualize_intermediate_utils import visualize_from_outputs
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Visualize msa / pair / single reps from a saved OpenFold outputs dict."
+    )
+    parser.add_argument(
+        "--outputs-path",
+        type=str,
+        required=True,
+        help="Path to a torch-saved outputs dict (e.g. .pt or .pth).",
+    )
+    parser.add_argument(
+        "--outdir",
+        type=str,
+        required=True,
+        help="Directory where plots and summary .npy files will be written.",
+    )
+    parser.add_argument(
+        "--protein-name",
+        type=str,
+        default=None,
+        help="Optional protein name/ID for labeling plots and filenames.",
+    )
+    parser.add_argument(
+        "--show",
+        action="store_true",
+        help="If set, show plots interactively in addition to saving PNGs.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    os.makedirs(args.outdir, exist_ok=True)
+
+    print(f"[Info] Loading outputs from: {args.outputs_path}")
+    outputs = torch.load(args.outputs_path, map_location="cpu")
+
+    if not isinstance(outputs, dict):
+        raise ValueError(
+            f"Expected a dict-like object from {args.outputs_path}, "
+            f"but got type {type(outputs)}"
+        )
+
+    visualize_from_outputs(
+        outputs,
+        out_dir=args.outdir,
+        protein_name=args.protein_name,
+        show=args.show,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/visualize_intermediate_utils.py
+++ b/visualize_intermediate_utils.py
@@ -1,0 +1,292 @@
+"""
+Utilities for summarizing and visualizing intermediate OpenFold
+representations (msa / pair / single).
+
+This file is self-contained and does NOT import `openfold`. It expects
+to work with the `outputs` dict returned by `AlphaFold.forward`.
+"""
+
+from typing import Dict, Any, Optional, Tuple
+import os
+
+import numpy as np
+import torch
+import matplotlib.pyplot as plt
+
+
+# ----------------------------------------------------------------------
+# Helper: safe conversion to numpy
+# ----------------------------------------------------------------------
+
+def _to_numpy(x: Any) -> np.ndarray:
+    if isinstance(x, torch.Tensor):
+        return x.detach().cpu().numpy()
+    return np.asarray(x)
+
+
+# ----------------------------------------------------------------------
+# Numeric summaries (saved as .npy)
+# ----------------------------------------------------------------------
+
+def save_intermediate_summaries(
+    outputs: Dict[str, Any],
+    out_dir: str,
+    protein_name: Optional[str] = None,
+) -> None:
+    """
+    Save simple norm-based summaries of msa / pair / single reps as .npy.
+
+    - msa_per_res_norm: [N_res] (averaged over seqs and channels)
+    - single_norm:      [N_res]
+    - pair_norm:        [N_res, N_res]
+    """
+    os.makedirs(out_dir, exist_ok=True)
+    tag = protein_name or "sample"
+
+    # ----- MSA -----
+    if "msa" in outputs and outputs["msa"] is not None:
+        msa = outputs["msa"]
+        if not isinstance(msa, torch.Tensor):
+            msa = torch.as_tensor(msa)
+
+        # msa: [..., N_seq, N_res, C_m]
+        # Compute per-residue norm, averaged over sequences
+        # shape -> [..., N_seq, N_res, C_m]
+        msa_norm = msa.norm(dim=-1)          # [..., N_seq, N_res]
+        msa_per_res = msa_norm.mean(dim=-2)  # [..., N_res]
+
+        msa_np = _to_numpy(msa_per_res.squeeze(0))
+        path = os.path.join(out_dir, f"{tag}_msa_per_res_norm.npy")
+        np.save(path, msa_np)
+        print(f"[saved] {path}")
+
+    # ----- SINGLE -----
+    if "single" in outputs and outputs["single"] is not None:
+        single = outputs["single"]
+        if not isinstance(single, torch.Tensor):
+            single = torch.as_tensor(single)
+
+        # single: [..., N_res, C_s]
+        single_norm = single.norm(dim=-1)  # [..., N_res]
+        single_np = _to_numpy(single_norm.squeeze(0))
+        path = os.path.join(out_dir, f"{tag}_single_norm.npy")
+        np.save(path, single_np)
+        print(f"[saved] {path}")
+
+    # ----- PAIR -----
+    if "pair" in outputs and outputs["pair"] is not None:
+        pair = outputs["pair"]
+        if not isinstance(pair, torch.Tensor):
+            pair = torch.as_tensor(pair)
+
+        # pair: [..., N_res, N_res, C_z]
+        pair_norm = pair.norm(dim=-1)  # [..., N_res, N_res]
+        pair_np = _to_numpy(pair_norm.squeeze(0))
+        path = os.path.join(out_dir, f"{tag}_pair_norm.npy")
+        np.save(path, pair_np)
+        print(f"[saved] {path}")
+
+
+# ----------------------------------------------------------------------
+# Plotting helpers
+# ----------------------------------------------------------------------
+
+def plot_single_norm(
+    single: torch.Tensor,
+    out_path: str,
+    protein_name: Optional[str] = None,
+    show: bool = False,
+) -> None:
+    """
+    Line plot of ||single[i]|| across residues.
+    """
+    if not isinstance(single, torch.Tensor):
+        single = torch.as_tensor(single)
+
+    single_norm = single.norm(dim=-1)  # [..., N_res]
+    single_norm = single_norm.squeeze(0).cpu().numpy()
+
+    plt.figure(figsize=(8, 4))
+    plt.plot(single_norm)
+    plt.xlabel("Residue index")
+    plt.ylabel("||single|| (L2 norm)")
+    title = f"Single representation norm per residue"
+    if protein_name:
+        title += f" — {protein_name}"
+    plt.title(title)
+    plt.tight_layout()
+
+    os.makedirs(os.path.dirname(out_path), exist_ok=True)
+    plt.savefig(out_path, dpi=300, bbox_inches="tight")
+    if show:
+        plt.show()
+    else:
+        plt.close()
+    print(f"[saved] {out_path}")
+
+
+def plot_pair_heatmap(
+    pair: torch.Tensor,
+    out_path: str,
+    protein_name: Optional[str] = None,
+    show: bool = False,
+) -> None:
+    """
+    Heatmap of ||pair[i,j]|| across residue pairs (i,j).
+    """
+    if not isinstance(pair, torch.Tensor):
+        pair = torch.as_tensor(pair)
+
+    pair_norm = pair.norm(dim=-1).squeeze(0).cpu().numpy()  # [N_res, N_res]
+
+    plt.figure(figsize=(6, 5))
+    im = plt.imshow(pair_norm, cmap="viridis", origin="lower")
+    plt.colorbar(im, label="||pair|| (L2)")
+    plt.xlabel("Residue j")
+    plt.ylabel("Residue i")
+    title = "Pair representation norm heatmap"
+    if protein_name:
+        title += f" — {protein_name}"
+    plt.title(title)
+    plt.tight_layout()
+
+    os.makedirs(os.path.dirname(out_path), exist_ok=True)
+    plt.savefig(out_path, dpi=300, bbox_inches="tight")
+    if show:
+        plt.show()
+    else:
+        plt.close()
+    print(f"[saved] {out_path}")
+
+
+def plot_msa_norms(
+    msa: torch.Tensor,
+    out_line_path: str,
+    out_seq_hist_path: str,
+    protein_name: Optional[str] = None,
+    mode: str = "first",
+    show: bool = False,
+) -> None:
+    """
+    Two plots:
+
+    1) Per-residue norm (average over sequences) as a line plot
+    2) Histogram of per-sequence average norms
+
+    mode:
+      - "first": use only the first example in batch
+    """
+    if not isinstance(msa, torch.Tensor):
+        msa = torch.as_tensor(msa)
+
+    # msa: [..., N_seq, N_res, C_m]
+    msa = msa.squeeze(0)  # [N_seq, N_res, C_m]
+    msa_norm = msa.norm(dim=-1)            # [N_seq, N_res]
+    per_res = msa_norm.mean(dim=0).cpu().numpy()  # [N_res]
+    per_seq = msa_norm.mean(dim=1).cpu().numpy()  # [N_seq]
+
+    # Line plot per residue
+    plt.figure(figsize=(8, 4))
+    plt.plot(per_res)
+    plt.xlabel("Residue index")
+    plt.ylabel("Mean ||msa|| over sequences")
+    title = "MSA representation per-residue norm"
+    if protein_name:
+        title += f" — {protein_name}"
+    plt.title(title)
+    plt.tight_layout()
+    os.makedirs(os.path.dirname(out_line_path), exist_ok=True)
+    plt.savefig(out_line_path, dpi=300, bbox_inches="tight")
+    if show:
+        plt.show()
+    else:
+        plt.close()
+    print(f"[saved] {out_line_path}")
+
+    # Histogram over sequences
+    plt.figure(figsize=(6, 4))
+    plt.hist(per_seq, bins=30)
+    plt.xlabel("Mean ||msa|| over residues")
+    plt.ylabel("Count (sequences)")
+    title = "MSA sequence-wise mean norm"
+    if protein_name:
+        title += f" — {protein_name}"
+    plt.title(title)
+    plt.tight_layout()
+    os.makedirs(os.path.dirname(out_seq_hist_path), exist_ok=True)
+    plt.savefig(out_seq_hist_path, dpi=300, bbox_inches="tight")
+    if show:
+        plt.show()
+    else:
+        plt.close()
+    print(f"[saved] {out_seq_hist_path}")
+
+
+# ----------------------------------------------------------------------
+# High-level helper used by your script
+# ----------------------------------------------------------------------
+
+def visualize_from_outputs(
+    outputs: Dict[str, Any],
+    out_dir: str,
+    protein_name: Optional[str] = None,
+    show: bool = False,
+) -> None:
+    """
+    High-level helper: given an OpenFold `outputs` dict, generate
+    summary numpy arrays and plots for msa / pair / single
+    representations.
+
+    Args:
+        outputs: dict produced by AlphaFold.forward
+        out_dir: directory where plots and .npy files will be written
+        protein_name: optional label (used in filenames / plot titles)
+        show: if True, show plots interactively in addition to saving
+    """
+    os.makedirs(out_dir, exist_ok=True)
+
+    # Save numeric summaries
+    save_intermediate_summaries(outputs, out_dir, protein_name=protein_name)
+
+    # Convert to tensors if needed
+    msa = outputs.get("msa", None)
+    pair = outputs.get("pair", None)
+    single = outputs.get("single", None)
+
+    if msa is not None and not isinstance(msa, torch.Tensor):
+        msa = torch.as_tensor(msa)
+    if pair is not None and not isinstance(pair, torch.Tensor):
+        pair = torch.as_tensor(pair)
+    if single is not None and not isinstance(single, torch.Tensor):
+        single = torch.as_tensor(single)
+
+    tag = protein_name or "sample"
+
+    # Single rep line plot
+    if single is not None:
+        plot_single_norm(
+            single,
+            out_path=os.path.join(out_dir, f"{tag}_single_norm.png"),
+            protein_name=protein_name,
+            show=show,
+        )
+
+    # Pair rep heatmap
+    if pair is not None:
+        plot_pair_heatmap(
+            pair,
+            out_path=os.path.join(out_dir, f"{tag}_pair_norm_heatmap.png"),
+            protein_name=protein_name,
+            show=show,
+        )
+
+    # MSA plots
+    if msa is not None:
+        plot_msa_norms(
+            msa,
+            out_line_path=os.path.join(out_dir, f"{tag}_msa_per_res.png"),
+            out_seq_hist_path=os.path.join(out_dir, f"{tag}_msa_seqwise_hist.png"),
+            protein_name=protein_name,
+            mode="first",
+            show=show,
+        )


### PR DESCRIPTION
<h2 data-start="860" data-end="938">Intermediate representation visualization (Issue #8 – student contribution)</h2>
<p data-start="940" data-end="1111">This contribution adds a small set of utilities for visualizing OpenFold’s intermediate representations (<code data-start="1045" data-end="1050">msa</code>, <code data-start="1052" data-end="1058">pair</code>, and <code data-start="1064" data-end="1072">single</code>) <strong data-start="1074" data-end="1110">without modifying the core model</strong>.</p>
<hr data-start="1113" data-end="1116">
<h3 data-start="1118" data-end="1140">New files included</h3>
<ul data-start="1142" data-end="1766">
<li data-start="1142" data-end="1258">
<p data-start="1144" data-end="1258"><code data-start="1144" data-end="1180">openfold/viz/intermediate_hooks.py</code><br data-start="1180" data-end="1183">
Helper functions to read stored outputs and dispatch visualization logic.</p>
</li>
<li data-start="1260" data-end="1377">
<p data-start="1262" data-end="1377"><code data-start="1262" data-end="1295">visualize_intermediate_utils.py</code><br data-start="1295" data-end="1298">
Utility functions for computing norms, producing plots, and saving summaries.</p>
</li>
<li data-start="1379" data-end="1537">
<p data-start="1381" data-end="1537"><code data-start="1381" data-end="1412">scripts/make_dummy_outputs.py</code><br data-start="1412" data-end="1415">
Generates a dummy output file (<code data-start="1448" data-end="1473">outputs/6KWC_outputs.pt</code>) shaped like real OpenFold intermediate representation outputs.</p>
</li>
<li data-start="1539" data-end="1652">
<p data-start="1541" data-end="1652"><code data-start="1541" data-end="1580">scripts/run_with_intermediate_reps.py</code><br data-start="1580" data-end="1583">
Loads an outputs file and writes <code data-start="1618" data-end="1624">.npy</code> summaries + visualizations.</p>
</li>
<li data-start="1654" data-end="1766">
<p data-start="1656" data-end="1766"><code data-start="1656" data-end="1694">scripts/plot_intermediate_example.py</code><br data-start="1694" data-end="1697">
Builds a combined summary figure from generated image output files.</p>
</li>
</ul>
<hr data-start="1768" data-end="1771">
<h3 data-start="1773" data-end="1815">How to test and run the visualizations</h3>
<p data-start="1817" data-end="1930">All commands assume you are in the repo root and have Python with<br data-start="1882" data-end="1885">
<code data-start="1885" data-end="1892">torch</code>, <code data-start="1894" data-end="1901">numpy</code>, and <code data-start="1907" data-end="1919">matplotlib</code> installed.</p>
<hr data-start="1932" data-end="1935">
<h4 data-start="1937" data-end="1986">1. Create dummy OpenFold outputs for testing</h4>
<pre class="overflow-visible!" data-start="1988" data-end="2049"><div class="contain-inline-size rounded-2xl corner-superellipse/1.1 relative bg-token-sidebar-surface-primary"><div class="sticky top-9"><div class="absolute end-0 bottom-0 flex h-9 items-center pe-2"><div class="bg-token-bg-elevated-secondary text-token-text-secondary flex items-center gap-4 rounded-sm px-2 font-sans text-xs"></div></div></div><div class="overflow-y-auto p-4" dir="ltr"><code class="whitespace-pre! language-bash"><span><span>PYTHONPATH=. python scripts/make_dummy_outputs.py
</span></span></code></div></div></pre>
<p data-start="2051" data-end="2070">This will generate:</p>
<pre class="overflow-visible!" data-start="2072" data-end="2103"><div class="contain-inline-size rounded-2xl corner-superellipse/1.1 relative bg-token-sidebar-surface-primary"><div class="sticky top-9"><div class="absolute end-0 bottom-0 flex h-9 items-center pe-2"><div class="bg-token-bg-elevated-secondary text-token-text-secondary flex items-center gap-4 rounded-sm px-2 font-sans text-xs"></div></div></div><div class="overflow-y-auto p-4" dir="ltr"><code class="whitespace-pre!"><span><span>outputs/6KWC_outputs.pt
</span></span></code></div></div></pre>
<hr data-start="2105" data-end="2108">
<h4 data-start="2110" data-end="2169">2. Generate intermediate-representation visualizations</h4>
<pre class="overflow-visible!" data-start="2171" data-end="2357"><div class="contain-inline-size rounded-2xl corner-superellipse/1.1 relative bg-token-sidebar-surface-primary"><div class="sticky top-9"><div class="absolute end-0 bottom-0 flex h-9 items-center pe-2"><div class="bg-token-bg-elevated-secondary text-token-text-secondary flex items-center gap-4 rounded-sm px-2 font-sans text-xs"></div></div></div><div class="overflow-y-auto p-4" dir="ltr"><code class="whitespace-pre! language-bash"><span><span>PYTHONPATH=. python scripts/run_with_intermediate_reps.py \
    --outputs-path outputs/6KWC_outputs.pt \
    --outdir outputs/intermediate_reps/6KWC \
    --protein-name 6KWC
</span></span></code></div></div></pre>
<p data-start="2359" data-end="2384">This produces files like:</p>
<pre class="overflow-visible!" data-start="2386" data-end="2554"><div class="contain-inline-size rounded-2xl corner-superellipse/1.1 relative bg-token-sidebar-surface-primary"><div class="sticky top-9"><div class="absolute end-0 bottom-0 flex h-9 items-center pe-2"><div class="bg-token-bg-elevated-secondary text-token-text-secondary flex items-center gap-4 rounded-sm px-2 font-sans text-xs"></div></div></div><div class="overflow-y-auto p-4" dir="ltr"><code class="whitespace-pre!"><span><span>6KWC_single_norm.npy
6KWC_single_norm.png
6KWC_pair_norm.npy
6KWC_pair_norm_heatmap.png
6KWC_msa_per_res_norm.npy
6KWC_msa_per_res.png
6KWC_msa_seqwise_hist.png
</span></span></code></div></div></pre>
<p data-start="2556" data-end="2569">Stored under:</p>
<pre class="overflow-visible!" data-start="2571" data-end="2610"><div class="contain-inline-size rounded-2xl corner-superellipse/1.1 relative bg-token-sidebar-surface-primary"><div class="sticky top-9"><div class="absolute end-0 bottom-0 flex h-9 items-center pe-2"><div class="bg-token-bg-elevated-secondary text-token-text-secondary flex items-center gap-4 rounded-sm px-2 font-sans text-xs"></div></div></div><div class="overflow-y-auto p-4" dir="ltr"><code class="whitespace-pre!"><span><span>outputs/intermediate_reps/6KWC/
</span></span></code></div></div></pre>
<hr data-start="2612" data-end="2615">
<h4 data-start="2617" data-end="2670">3. (Optional) Generate a combined summary figure</h4>
<pre class="overflow-visible!" data-start="2672" data-end="2863"><div class="contain-inline-size rounded-2xl corner-superellipse/1.1 relative bg-token-sidebar-surface-primary"><div class="sticky top-9"><div class="absolute end-0 bottom-0 flex h-9 items-center pe-2"><div class="bg-token-bg-elevated-secondary text-token-text-secondary flex items-center gap-4 rounded-sm px-2 font-sans text-xs"></div></div></div><div class="overflow-y-auto p-4" dir="ltr"><code class="whitespace-pre! language-bash"><span><span>PYTHONPATH=. python scripts/plot_intermediate_example.py \
    --imgdir outputs/intermediate_reps/6KWC \
    --outpath outputs/intermediate_reps/6KWC/6KWC_intermediate_summary.png
</span></span></code></div></div></pre>
<hr data-start="2865" data-end="2868">


### What each visualization represents

| File pattern               | Interpretation                                            |
|---------------------------|-----------------------------------------------------------|
| `*_single_norm.png`       | Magnitude of single representation per residue           |
| `*_pair_norm_heatmap.png` | Pair-wise magnitude heatmap (contact-like structure)     |
| `*_msa_per_res.png`       | Mean MSA embedding magnitude per residue index           |
| `*_msa_seqwise_hist.png`  | Distribution of MSA embedding norms across MSA sequences |



</div></div>
<hr data-start="3255" data-end="3258">
<h3 data-start="3260" data-end="3282">Why this is useful</h3>
<p data-start="3284" data-end="3411">This makes it possible to inspect internal activations of OpenFold <strong data-start="3351" data-end="3387">without modifying the model code</strong>.<br data-start="3388" data-end="3391">
It enables users to:</p>
<ul data-start="3413" data-end="3552">
<li data-start="3413" data-end="3437">
<p data-start="3415" data-end="3437">debug model behavior</p>
</li>
<li data-start="3438" data-end="3477">
<p data-start="3440" data-end="3477">visually compare different proteins</p>
</li>
<li data-start="3478" data-end="3513">
<p data-start="3480" data-end="3513">generate interpretable examples</p>
</li>
<li data-start="3514" data-end="3552">
<p data-start="3516" data-end="3552">support research &amp; educational use</p></li></ul>