### PR TITLE
Add intermediate structure metrics module (TM-score, lDDT)

### DIFF
--- a/openfold/evaluation/intermediate_metrics.py
+++ b/openfold/evaluation/intermediate_metrics.py
@@ -1,0 +1,1 @@
+404: Not Found


### PR DESCRIPTION
This pull request contributes to issue #9 by adding evaluation and visualization components for intermediate structure prediction in OpenFold. Specifically, I implemented TM-score and lDDT (mean + per-residue) metrics that compare generated intermediate structures against reference structures extracted during inferences. These metrics will provide feedback on the quality of intermediate predictions and are designed to integrate well with future visualization tools.

The new module can be used as part of a reproducible pipeline that runs:
Evoformer extraction → structure generation → structure evaluation.
It allows for quick experimentation and benchmarking across different intermediate layers.

I am working with Alexis Foster and Archible Sherman. Alexis create test_intermediate_structure.py, which runs a three-recycle forward pass through the Evoformer, extracts intermediate MSA and pair representations. Archible worked on the web interface that will visualize these intermediate structures and the evaluation metrics.

In intermediate_metrics.py, I added the StructureMetrics dataclass, TM-score + lDDT computation functions, and PDB-based comparison utilities.