### PR TITLE
Initial CLI for Aligning Data to FASTA Script

### DIFF
--- a/scripts/alignment_data_to_fasta_CLI.py
+++ b/scripts/alignment_data_to_fasta_CLI.py
@@ -1,0 +1,64 @@
+"""
+CLI for alignment_data_to_fasta.py
+
+This CLI delegates all core logic to the underlying fasta_generator module,
+providing a clean, stable interface for VizFold workflows and HPC batch jobs.
+"""
+
+from argparse import ArgumentParser
+from pathlib import Path
+
+from fasta_generator import main as generate_fasta
+
+
+def build_cli():
+    parser = ArgumentParser(
+        prog="vizfold fasta",
+        description="Generate a FASTA file from alignment directories or alignment DB indices."
+    )
+
+    parser.add_argument(
+        "--output",
+        required=True,
+        type=Path,
+        help="Path to write the output FASTA file."
+    )
+
+    source = parser.add_mutually_exclusive_group(required=True)
+
+    source.add_argument(
+        "--alignment-dir",
+        type=Path,
+        help="Directory containing chain subdirectories with alignment files."
+    )
+
+    source.add_argument(
+        "--alignment-db-index",
+        type=Path,
+        help="Path to alignment DB index JSON file."
+    )
+
+    parser.add_argument(
+        "--threads",
+        type=int,
+        default=None,
+        help="Number of worker threads (default: number of CPU cores)."
+    )
+
+    return parser
+
+
+def cli():
+    parser = build_cli()
+    args = parser.parse_args()
+
+    # Delegates to existing script
+    generate_fasta(
+        output_path=args.output,
+        alignment_db_index=args.alignment_db_index,
+        alignment_dir=args.alignment_dir,
+    )
+
+
+if __name__ == "__main__":
+    cli()

--- a/scripts/fasta_to_clusterfile_CLI.py
+++ b/scripts/fasta_to_clusterfile_CLI.py
@@ -1,0 +1,71 @@
+"""
+CLI wrapper for clustering FASTA sequences using mmseqs2 with PDB-style settings.
+
+This provides a standardized, reproducible interface for VizFold workflows,
+HPC batch jobs, and Airavata pipelines.
+"""
+
+from argparse import ArgumentParser
+from pathlib import Path
+
+# Import your existing logic
+from cluster_fasta import main as run_cluster
+
+
+def build_cli():
+    parser = ArgumentParser(
+        prog="vizfold cluster",
+        description=(
+            "Cluster protein sequences from a FASTA file using mmseqs2 with "
+            "PDB-style parameters. Produces a reformatted cluster file where "
+            "each line lists all {PDB_ID}_{CHAIN_ID} entries in a cluster."
+        )
+    )
+
+    parser.add_argument(
+        "--input-fasta",
+        required=True,
+        type=Path,
+        help="Input FASTA file. Headers must be >{PDB_ID}_{CHAIN_ID}."
+    )
+
+    parser.add_argument(
+        "--output-file",
+        required=True,
+        type=Path,
+        help="Output text file containing clusters (one cluster per line)."
+    )
+
+    parser.add_argument(
+        "--mmseqs-binary",
+        required=True,
+        type=str,
+        help="Path to the mmseqs2 binary."
+    )
+
+    parser.add_argument(
+        "--seq-id",
+        type=float,
+        default=0.4,
+        help="Sequence identity threshold (default: 0.4)."
+    )
+
+    return parser
+
+
+def cli():
+    parser = build_cli()
+    args = parser.parse_args()
+
+    # Convert to the argument names expected by your original script
+    class WrappedArgs:
+        input_fasta = args.input_fasta
+        output_file = args.output_file
+        mmseqs_binary_path = args.mmseqs_binary
+        seq_id = args.seq_id
+
+    run_cluster(WrappedArgs())
+
+
+if __name__ == "__main__":
+    cli()

--- a/viz_attention_demo_base.ipynb
+++ b/viz_attention_demo_base.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "1400375b",
    "metadata": {},
    "outputs": [],
@@ -16,56 +16,120 @@
     "TRI_RESIDUE_IDX = 18\n",
     "\n",
     "# Define all relevant directories\n",
-    "BASE_DATA_DIR = \"/ime/hdd/rhaas/SUP-5301/database\" # path to AlphaFold database\n",
+    "BASE_DATA_DIR = \"/storage/ice1/shared/d-pace_community/alphafold/alphafold_2.3.2_data\"\n",
+    "ROOT_DIR = os.path.expanduser(\"~/scratch\")\n",
     "\n",
     "# Local paths for saving results (these probably can remain unchanged)\n",
-    "ATTN_MAP_DIR = f\"./outputs/attention_files_{PROT}_demo_tri_{TRI_RESIDUE_IDX}\" # directory for saving text files with top-k attention scores\n",
-    "ALIGNMENT_DIR = \"./examples/monomer/alignments\" # directory containing pre-computed alignment files (and MSAs)\n",
-    "OUTPUT_DIR = f\"./outputs/my_outputs_align_{PROT}_demo_tri_{TRI_RESIDUE_IDX}\" # directory to save outputs\n",
-    "IMAGE_OUTPUT_DIR = f\"./outputs/attention_images_{PROT}_demo_tri_{TRI_RESIDUE_IDX}\"\n",
-    "FASTA_DIR = f\"./examples/monomer/fasta_dir_{PROT}\"\n",
+    "ATTN_MAP_DIR = f\"{ROOT_DIR}/vizfold-foundation/outputs/attention_files_{PROT}_demo_tri_{TRI_RESIDUE_IDX}\"\n",
+    "ALIGNMENT_DIR = f\"{ROOT_DIR}/vizfold-foundation/examples/monomer/alignments\"\n",
+    "OUTPUT_DIR = f\"{ROOT_DIR}/vizfold-foundation/outputs/my_outputs_align_{PROT}_demo_tri_{TRI_RESIDUE_IDX}\"\n",
+    "IMAGE_OUTPUT_DIR = f\"{ROOT_DIR}/vizfold-foundation/outputs/attention_images_{PROT}_demo_tri_{TRI_RESIDUE_IDX}\"\n",
+    "FASTA_DIR = f\"{ROOT_DIR}/vizfold-foundation/examples/monomer/fasta_dir_{PROT}\"\n",
+    "\n",
+    "os.makedirs(FASTA_DIR, exist_ok=True)\n",
+    "os.makedirs(f\"{ROOT_DIR}/vizfold-foundation/outputs\", exist_ok=True)\n",
     "\n",
     "# Note: If this is a new protein, the ALIGNMENT_DIR does not need to be specified here or in the next cell\n",
-    "# In this case, the code will compute MSAs and alignments, which can take several hours\n"
+    "# In this case, the code will compute MSAs and alignments, which can take several hours"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "3fd757f9",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "EnvironmentNameNotFound: Could not find conda environment: openfold_env\n",
+      "You can list all discoverable environments with `conda info --envs`.\n",
+      "\n",
+      "\n",
+      "Traceback (most recent call last):\n",
+      "  File \"/storage/ice1/7/1/tkohli7/vizfold-foundation/run_pretrained_openfold.py\", line 16, in <module>\n",
+      "    import torch\n",
+      "ModuleNotFoundError: No module named 'torch'\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Inference complete. Outputs saved to /home/hice1/tkohli7/scratch/vizfold-foundation/outputs/my_outputs_align_6KWC_demo_tri_18 and attention maps saved to /home/hice1/tkohli7/scratch/vizfold-foundation/outputs/attention_files_6KWC_demo_tri_18.\n"
+     ]
+    }
+   ],
    "source": [
-    "# Run OpenFold inference and save top attention scores to text files \n",
-    "inference_cmd = f\"\"\"\n",
+    "%%bash\n",
+    "# Activate conda environment with OpenFold installed\n",
+    "source \"$(conda info --base)/etc/profile.d/conda.sh\"\n",
+    "export CONDA_ENVS_PATH=$CONDA_INSTALL_DIR/.conda/envs\n",
+    "export CONDA_PKGS_DIRS=$CONDA_INSTALL_DIR/.conda/pkgs\n",
+    "conda activate openfold_env\n",
+    "\n",
+    "export MPLBACKEND=Agg\n",
+    "export PYTHONNOUSERSITE=1\n",
+    "cd ~/scratch/vizfold-foundation\n",
+    "\n",
+    "# Define variables for the script\n",
+    "PROT=\"6KWC\"\n",
+    "TRI_RESIDUE_IDX=18\n",
+    "BASE_DATA_DIR=\"/storage/ice1/shared/d-pace_community/alphafold/alphafold_2.3.2_data\"\n",
+    "FASTA_DIR=\"$HOME/scratch/vizfold-foundation/examples/monomer/fasta_dir_${PROT}\"\n",
+    "ALIGNMENT_DIR=\"$HOME/scratch/vizfold-foundation/examples/monomer/alignments\"\n",
+    "OUTPUT_DIR=\"$HOME/scratch/vizfold-foundation/outputs/my_outputs_align_${PROT}_demo_tri_${TRI_RESIDUE_IDX}\"\n",
+    "ATTN_MAP_DIR=\"$HOME/scratch/vizfold-foundation/outputs/attention_files_${PROT}_demo_tri_${TRI_RESIDUE_IDX}\"\n",
+    "\n",
+    "# Run OpenFold inference\n",
     "python3 run_pretrained_openfold.py \\\n",
-    "    {FASTA_DIR} \\\n",
-    "    {BASE_DATA_DIR}/pdb_mmcif/mmcif_files \\\n",
-    "    --use_precomputed_alignments {ALIGNMENT_DIR} \\\n",
-    "    --output_dir {OUTPUT_DIR} \\\n",
+    "    ${FASTA_DIR} \\\n",
+    "    ${BASE_DATA_DIR}/pdb_mmcif/mmcif_files \\\n",
+    "    --use_precomputed_alignments ${ALIGNMENT_DIR} \\\n",
+    "    --output_dir ${OUTPUT_DIR} \\\n",
     "    --config_preset model_1_ptm \\\n",
-    "    --uniref90_database_path {BASE_DATA_DIR}/uniref90/uniref90.fasta \\\n",
-    "    --mgnify_database_path {BASE_DATA_DIR}/mgnify/mgy_clusters_2022_05.fa \\\n",
-    "    --pdb70_database_path {BASE_DATA_DIR}/pdb70/pdb70 \\\n",
-    "    --uniclust30_database_path {BASE_DATA_DIR}/uniclust30/uniclust30_2018_08 \\\n",
-    "    --bfd_database_path {BASE_DATA_DIR}/bfd/bfd_metaclust_clu_complete_id30_c90_final_seq.sorted_opt \\\n",
+    "    --uniref90_database_path ${BASE_DATA_DIR}/uniref90/uniref90.fasta \\\n",
+    "    --mgnify_database_path ${BASE_DATA_DIR}/mgnify/mgy_clusters_2022_05.fa \\\n",
+    "    --pdb70_database_path ${BASE_DATA_DIR}/pdb70/pdb70 \\\n",
+    "    --uniclust30_database_path ${BASE_DATA_DIR}/uniclust30/uniclust30_2018_08 \\\n",
+    "    --bfd_database_path ${BASE_DATA_DIR}/bfd/bfd_metaclust_clu_complete_id30_c90_final_seq.sorted_opt \\\n",
     "    --save_outputs \\\n",
     "    --model_device \"cuda:0\" \\\n",
-    "    --attn_map_dir {ATTN_MAP_DIR} \\\n",
+    "    --attn_map_dir ${ATTN_MAP_DIR} \\\n",
     "    --num_recycles_save 1 \\\n",
-    "    --triangle_residue_idx {TRI_RESIDUE_IDX} \\\n",
+    "    --triangle_residue_idx ${TRI_RESIDUE_IDX} \\\n",
     "    --demo_attn\n",
-    "\"\"\"\n",
     "\n",
-    "subprocess.run(inference_cmd, shell=True, check=True)\n"
+    "echo \"Inference complete. Outputs saved to ${OUTPUT_DIR} and attention maps saved to ${ATTN_MAP_DIR}.\""
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "66a306cc",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "CmdException",
+     "evalue": " Error: failed to open file \"/home/hice1/tkohli7/scratch/vizfold-foundation/outputs/my_outputs_align_6KWC_demo_tri_18/predictions/6KWC_1_model_1_ptm_relaxed.pdb\"",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mFileNotFoundError\u001b[0m                         Traceback (most recent call last)",
+      "File \u001b[0;32m~/scratch/.conda/envs/openfold_env/lib/python3.10/site-packages/pymol/internal.py:293\u001b[0m, in \u001b[0;36mfile_read\u001b[0;34m(finfo, _self)\u001b[0m\n\u001b[1;32m    292\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[0;32m--> 293\u001b[0m     handle \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mopen\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43mfinfo\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mrb\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m)\u001b[49m\n\u001b[1;32m    294\u001b[0m contents \u001b[38;5;241m=\u001b[39m handle\u001b[38;5;241m.\u001b[39mread()\n",
+      "\u001b[0;31mFileNotFoundError\u001b[0m: [Errno 2] No such file or directory: '/home/hice1/tkohli7/scratch/vizfold-foundation/outputs/my_outputs_align_6KWC_demo_tri_18/predictions/6KWC_1_model_1_ptm_relaxed.pdb'",
+      "\nDuring handling of the above exception, another exception occurred:\n",
+      "\u001b[0;31mCmdException\u001b[0m                              Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[3], line 7\u001b[0m\n\u001b[1;32m      4\u001b[0m PDB_FILE \u001b[38;5;241m=\u001b[39m os\u001b[38;5;241m.\u001b[39mpath\u001b[38;5;241m.\u001b[39mjoin(OUTPUT_DIR, \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mpredictions/\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mPROT\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m_1_model_1_ptm_relaxed.pdb\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m      5\u001b[0m FNAME \u001b[38;5;241m=\u001b[39m \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mpredicted_structure_\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mPROT\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m_tri_\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mTRI_RESIDUE_IDX\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m.png\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[0;32m----> 7\u001b[0m \u001b[43mrender_pdb_to_image\u001b[49m\u001b[43m(\u001b[49m\u001b[43mPDB_FILE\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mIMAGE_OUTPUT_DIR\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mFNAME\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m/storage/ice1/7/1/tkohli7/vizfold-foundation/visualize_attention_general_utils.py:24\u001b[0m, in \u001b[0;36mrender_pdb_to_image\u001b[0;34m(pdb_file, output_image_path, fname)\u001b[0m\n\u001b[1;32m     21\u001b[0m output_image_path \u001b[38;5;241m=\u001b[39m os\u001b[38;5;241m.\u001b[39mpath\u001b[38;5;241m.\u001b[39mjoin(output_image_path, fname)\n\u001b[1;32m     23\u001b[0m cmd\u001b[38;5;241m.\u001b[39mreinitialize()\n\u001b[0;32m---> 24\u001b[0m \u001b[43mcmd\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mload\u001b[49m\u001b[43m(\u001b[49m\u001b[43mpdb_file\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mprotein\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m)\u001b[49m\n\u001b[1;32m     26\u001b[0m cmd\u001b[38;5;241m.\u001b[39mbg_color(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mwhite\u001b[39m\u001b[38;5;124m'\u001b[39m)\n\u001b[1;32m     27\u001b[0m cmd\u001b[38;5;241m.\u001b[39mshow(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mcartoon\u001b[39m\u001b[38;5;124m'\u001b[39m, \u001b[38;5;124m'\u001b[39m\u001b[38;5;124mprotein\u001b[39m\u001b[38;5;124m'\u001b[39m)\n",
+      "File \u001b[0;32m~/scratch/.conda/envs/openfold_env/lib/python3.10/site-packages/pymol/importing.py:827\u001b[0m, in \u001b[0;36mload\u001b[0;34m(filename, object, state, format, finish, discrete, quiet, multiplex, zoom, partial, mimic, object_props, atom_props, _self)\u001b[0m\n\u001b[1;32m    824\u001b[0m         kw[n] \u001b[38;5;241m=\u001b[39m kw_all[n]\n\u001b[1;32m    826\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;124m'\u001b[39m\u001b[38;5;124mcontents\u001b[39m\u001b[38;5;124m'\u001b[39m \u001b[38;5;129;01min\u001b[39;00m sig\u001b[38;5;241m.\u001b[39mparameters:\n\u001b[0;32m--> 827\u001b[0m     kw[\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mcontents\u001b[39m\u001b[38;5;124m'\u001b[39m] \u001b[38;5;241m=\u001b[39m \u001b[43m_self\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mfile_read\u001b[49m\u001b[43m(\u001b[49m\u001b[43mfilename\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    829\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m func(\u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkw)\n",
+      "File \u001b[0;32m~/scratch/.conda/envs/openfold_env/lib/python3.10/site-packages/pymol/internal.py:297\u001b[0m, in \u001b[0;36mfile_read\u001b[0;34m(finfo, _self)\u001b[0m\n\u001b[1;32m    295\u001b[0m     handle\u001b[38;5;241m.\u001b[39mclose()\n\u001b[1;32m    296\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mIOError\u001b[39;00m:\n\u001b[0;32m--> 297\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m pymol\u001b[38;5;241m.\u001b[39mCmdException(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mfailed to open file \u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;132;01m%s\u001b[39;00m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m'\u001b[39m \u001b[38;5;241m%\u001b[39m finfo)\n\u001b[1;32m    299\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m contents[:\u001b[38;5;241m2\u001b[39m] \u001b[38;5;241m==\u001b[39m \u001b[38;5;124mb\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;130;01m\\x1f\u001b[39;00m\u001b[38;5;130;01m\\x8b\u001b[39;00m\u001b[38;5;124m'\u001b[39m: \u001b[38;5;66;03m# gzip magic number\u001b[39;00m\n\u001b[1;32m    300\u001b[0m     \u001b[38;5;28;01mimport\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;21;01mio\u001b[39;00m\u001b[38;5;241m,\u001b[39m\u001b[38;5;250m \u001b[39m\u001b[38;5;21;01mgzip\u001b[39;00m\n",
+      "\u001b[0;31mCmdException\u001b[0m:  Error: failed to open file \"/home/hice1/tkohli7/scratch/vizfold-foundation/outputs/my_outputs_align_6KWC_demo_tri_18/predictions/6KWC_1_model_1_ptm_relaxed.pdb\""
+     ]
+    }
+   ],
    "source": [
     "# Render predicted 3D structure and save as PNG image\n",
     "from visualize_attention_general_utils import render_pdb_to_image\n",
@@ -73,7 +137,7 @@
     "PDB_FILE = os.path.join(OUTPUT_DIR, f\"predictions/{PROT}_1_model_1_ptm_relaxed.pdb\")\n",
     "FNAME = f\"predicted_structure_{PROT}_tri_{TRI_RESIDUE_IDX}.png\"\n",
     "\n",
-    "render_pdb_to_image(PDB_FILE, IMAGE_OUTPUT_DIR, FNAME)\n"
+    "render_pdb_to_image(PDB_FILE, IMAGE_OUTPUT_DIR, FNAME)"
    ]
   },
   {
@@ -88,11 +152,23 @@
     "from visualize_attention_arc_diagram_demo_utils import generate_arc_diagrams, parse_fasta_sequence\n",
     "\n",
     "# Setup visualization output directories\n",
-    "output_dir_msa = os.path.join(IMAGE_OUTPUT_DIR, 'msa_row_attention_plots') # directory for saving msa attention 3D visuals\n",
-    "output_dir_tri = os.path.join(IMAGE_OUTPUT_DIR, 'tri_start_attention_plots') # directory for saving triangle attention 3D visuals\n",
-    "FASTA_PATH = f\"/u/thayes/vizfold/examples/monomer/fasta_dir_{PROT}/{PROT}.fasta\"\n",
+    "PROT = \"6KWC\"\n",
+    "TRI_RESIDUE_IDX = 18\n",
     "LAYER_IDX = 47 # selected layer for attention evaluation\n",
     "TOP_K = 50 # show top-k attention links (limit to 500)\n",
+    "\n",
+    "BASE_DIR = os.path.expanduser(\"~/scratch/vizfold-foundation\")\n",
+    "OUTPUT_DIR = os.path.join(BASE_DIR, f\"outputs/my_outputs_align_{PROT}_demo_tri_{TRI_RESIDUE_IDX}\")\n",
+    "ATTN_MAP_DIR = os.path.join(BASE_DIR, f\"outputs/attention_files_{PROT}_demo_tri_{TRI_RESIDUE_IDX}\")\n",
+    "IMAGE_OUTPUT_DIR = os.path.join(OUTPUT_DIR, \"images\")\n",
+    "PDB_FILE = os.path.join(OUTPUT_DIR, f\"predictions/{PROT}_1_model_1_ptm_relaxed.pdb\")\n",
+    "FASTA_PATH = os.path.join(BASE_DIR, f\"examples/monomer/fasta_dir_{PROT}/{PROT}.fasta\")\n",
+    "\n",
+    "# Setup output sub-directories and create if they don't exist\n",
+    "output_dir_msa = os.path.join(IMAGE_OUTPUT_DIR, 'msa_row_attention_plots')\n",
+    "output_dir_tri = os.path.join(IMAGE_OUTPUT_DIR, 'tri_start_attention_plots')\n",
+    "os.makedirs(output_dir_msa, exist_ok=True)\n",
+    "os.makedirs(output_dir_tri, exist_ok=True)\n",
     "\n",
     "# Generate 3D attention plots for MSA row attention\n",
     "plot_pymol_attention_heads(\n",
@@ -141,7 +217,7 @@
     "    residue_indices=[TRI_RESIDUE_IDX],\n",
     "    top_k=TOP_K,\n",
     "    layer_idx=LAYER_IDX\n",
-    ")\n"
+    ")"
    ]
   },
   {
@@ -173,15 +249,15 @@
     "    output_dir_arc=output_dir_tri,\n",
     "    combined_output_dir=IMAGE_OUTPUT_DIR,\n",
     "    residue_indices=[TRI_RESIDUE_IDX]\n",
-    ")\n"
+    ")"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "openfold_env3",
+   "display_name": "openfold_env",
    "language": "python",
-   "name": "python3"
+   "name": "openfold_env"
   },
   "language_info": {
    "codemirror_mode": {
@@ -193,7 +269,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.17"
+   "version": "3.10.19"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Adds a standalone CLI for generating FASTA files from alignment directories or alignment‑DB indices.

- Adds vizfold_fasta_cli.py as a CLI that wraps the existing FASTA generation logic.
- Standardizes argument parsing and validation for alignment directory vs. alignment‑DB index inputs.
- Adds documentation to support onboarding

Example Usage
python vizfold_fasta_cli.py \
    --alignment-dir /path/to/alignment_dir \
    --output /path/to/output.fasta

Related to Issue #38