### PR TITLE
added visualization adapter for offline trace integration

### DIFF
--- a/webui/app.py
+++ b/webui/app.py
@@ -1,0 +1,330 @@
+"""
+VizFold — Streamlit UI for offline protein model internals exploration.
+
+Run:
+    streamlit run webui/app.py
+"""
+
+import hashlib
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+import streamlit as st
+
+from trace_reader import TraceReader, ZarrTraceReader
+from components.structure_viewer import render_structure
+from components.attention_heatmap import render_heatmap
+from components.arc_diagram import render_arc_diagram
+
+# ── Page config ───────────────────────────────────────────────────────────────
+
+st.set_page_config(
+    page_title="VizFold",
+    page_icon="🔬",
+    layout="wide",
+    initial_sidebar_state="expanded",
+)
+
+st.markdown(
+    """
+    <style>
+    [data-testid="stSidebar"] { background-color: #111827; }
+    [data-testid="stSidebar"] .stMarkdown p { color: #9ca3af; }
+    .block-container { padding-top: 1.5rem; }
+    </style>
+    """,
+    unsafe_allow_html=True,
+)
+
+# ── Zarr session-state cache ──────────────────────────────────────────────────
+
+def _get_zarr_reader(uploaded_file) -> ZarrTraceReader:
+    """Cache ZarrTraceReader in session state, keyed by file hash."""
+    file_bytes = uploaded_file.read()
+    file_hash = hashlib.md5(file_bytes).hexdigest()
+    if st.session_state.get("_zarr_hash") != file_hash:
+        st.session_state["_zarr_hash"] = file_hash
+        st.session_state["_zarr_reader"] = ZarrTraceReader(file_bytes)
+    return st.session_state["_zarr_reader"]
+
+# ── Sidebar ───────────────────────────────────────────────────────────────────
+
+# Shared rendering outputs — populated by whichever source branch runs
+connections: list = []
+fasta_seq: str = ""
+n_residues: int = 0
+pdb_path: str | None = None
+pdb_string: str | None = None
+protein: str = ""
+head_label: str = ""
+attn_badge: str = ""
+residue_idx: int | None = None
+
+with st.sidebar:
+    st.markdown("## 🔬 VizFold")
+    st.caption("Protein model internals explorer")
+    st.divider()
+
+    source = st.radio(
+        "Data source",
+        ["Trace directory", "Zarr archive"],
+        help="Load from a local trace folder, or upload a Zarr ZipStore (.zip).",
+    )
+    st.divider()
+
+    # ── Branch A: Trace directory ─────────────────────────────────────────────
+    if source == "Trace directory":
+        default_trace = os.path.join(os.path.dirname(__file__), "sample_trace")
+        trace_dir = st.text_input(
+            "Trace directory",
+            value=default_trace,
+            help="Root folder containing per-protein trace subdirectories.",
+        )
+
+        reader = TraceReader(trace_dir)
+        proteins = reader.list_proteins()
+
+        if not proteins:
+            st.error(
+                "No proteins found. Check the path, or run "
+                "`python webui/make_sample_trace.py` first."
+            )
+            st.stop()
+
+        protein = st.selectbox("Protein", proteins)
+        fasta_seq = reader.get_fasta_sequence(protein)
+        n_residues = len(fasta_seq)
+        if n_residues:
+            st.caption(f"{n_residues} residues")
+
+        st.divider()
+        st.markdown("**Attention**")
+
+        attn_type = st.radio(
+            "Type",
+            ["msa_row", "triangle_start"],
+            format_func=lambda x: "MSA Row" if x == "msa_row" else "Triangle Start",
+        )
+
+        layers = reader.list_layers(protein, attn_type)
+        if not layers:
+            st.warning(f"No `{attn_type}` attention files found for **{protein}**.")
+            st.stop()
+
+        layer_idx = st.select_slider("Layer", options=layers, value=layers[-1])
+
+        if attn_type == "triangle_start":
+            available_res = reader.list_triangle_residues(protein, layer_idx)
+            if not available_res:
+                st.warning("No triangle attention files found for this layer.")
+                st.stop()
+            residue_idx = st.select_slider(
+                "Source residue", options=available_res, value=available_res[0]
+            )
+
+        top_k = st.slider("Top-K connections", 10, 200, 50, step=10)
+
+        if attn_type == "triangle_start" and residue_idx is not None:
+            attn_data = reader.load_triangle_attention(protein, layer_idx, residue_idx, top_k)
+        else:
+            attn_data = reader.load_attention(protein, attn_type, layer_idx, top_k)
+
+        n_heads = len(attn_data)
+        head_sel = st.selectbox(
+            "Head",
+            ["Average"] + list(range(n_heads)),
+            format_func=lambda x: "All heads averaged" if x == "Average" else f"Head {x}",
+        )
+
+        if head_sel == "Average":
+            connections = [c for cs in attn_data.values() for c in cs]
+            head_label = "All heads averaged"
+        else:
+            connections = attn_data.get(int(head_sel), [])
+            head_label = f"Head {head_sel}"
+
+        pdb_path = reader.get_pdb_path(protein)
+        attn_badge = (
+            "MSA Row" if attn_type == "msa_row"
+            else f"Triangle Start (res {residue_idx})"
+        )
+
+    # ── Branch B: Zarr archive ────────────────────────────────────────────────
+    else:
+        uploaded = st.file_uploader(
+            "Upload Zarr archive",
+            type=["zip"],
+            help=(
+                "Upload a Zarr ZipStore containing attention arrays. "
+                "Expected array shape: [n_layers, n_heads, N, N]. "
+                "Optional keys: `sequence` (amino acid string), `structure_pdb` (PDB text)."
+            ),
+        )
+
+        if not uploaded:
+            st.info("Upload a `.zip` Zarr archive to continue.")
+            st.stop()
+
+        with st.spinner("Opening Zarr store…"):
+            zarr_reader = _get_zarr_reader(uploaded)
+
+        all_arrays = zarr_reader.list_all_arrays()
+        attn_arrays = zarr_reader.list_attention_arrays()
+
+        with st.expander("Zarr contents", expanded=not attn_arrays):
+            if all_arrays:
+                for name, shape in all_arrays.items():
+                    marker = " ✓" if name in attn_arrays else ""
+                    st.code(f"{name}: {shape}{marker}", language=None)
+            else:
+                st.warning("No arrays found in this Zarr store.")
+
+        if not attn_arrays:
+            st.warning(
+                "No N×N attention arrays detected (shape [..., N, N]). "
+                "Select any array below — it will be treated as attention."
+            )
+            candidate_arrays = all_arrays
+        else:
+            candidate_arrays = attn_arrays
+
+        if not candidate_arrays:
+            st.error("No arrays to display.")
+            st.stop()
+
+        array_name = st.selectbox(
+            "Attention array",
+            list(candidate_arrays.keys()),
+        )
+
+        _n_layers = zarr_reader.n_layers(array_name)
+        _n_heads = zarr_reader.n_heads(array_name)
+        n_residues = zarr_reader.n_residues(array_name)
+        protein = uploaded.name.rsplit(".", 1)[0]
+
+        fasta_seq = zarr_reader.get_sequence()
+        if fasta_seq and len(fasta_seq) != n_residues:
+            st.caption(
+                f"Note: sequence length ({len(fasta_seq)}) ≠ array dim ({n_residues}). "
+                "Using placeholder residue labels."
+            )
+            fasta_seq = ""
+        if not fasta_seq:
+            fasta_seq = "X" * n_residues
+
+        st.caption(f"{n_residues} residues · {_n_layers} layers · {_n_heads} heads")
+
+        layer_idx = st.slider("Layer", 0, max(0, _n_layers - 1), min(_n_layers - 1, 47))
+
+        head_sel_zarr = st.selectbox(
+            "Head",
+            ["Average"] + list(range(_n_heads)),
+            format_func=lambda x: "All heads averaged" if x == "Average" else f"Head {x}",
+        )
+
+        top_k = st.slider("Top-K connections", 10, 200, 50, step=10)
+
+        _head_idx = None if head_sel_zarr == "Average" else int(head_sel_zarr)
+        connections = zarr_reader.load_attention(array_name, layer_idx, _head_idx, top_k)
+        head_label = "All heads averaged" if head_sel_zarr == "Average" else f"Head {head_sel_zarr}"
+
+        pdb_string = zarr_reader.get_pdb_string()
+        attn_badge = f"{array_name}"
+
+    # ── Shared display toggles ────────────────────────────────────────────────
+    st.divider()
+    st.markdown("**Display**")
+    show_structure = st.toggle("3D Structure", value=True)
+    show_heatmap = st.toggle("Attention Heatmap", value=True)
+    show_arc = st.toggle("Arc Diagram", value=True)
+
+# ── Header ────────────────────────────────────────────────────────────────────
+
+st.markdown(f"# {protein}")
+
+c1, c2, c3, c4 = st.columns(4)
+c1.metric("Residues", n_residues)
+c2.metric("Layer", layer_idx)
+c3.metric("Head", head_label)
+c4.metric("Connections", len(connections))
+st.caption(f"Attention: **{attn_badge}** · top-{top_k} per head")
+
+if not connections:
+    st.warning("No connections loaded — check that the trace files exist.")
+
+st.divider()
+
+# ── Main layout ───────────────────────────────────────────────────────────────
+
+left_col, right_col = st.columns([1, 1], gap="large")
+
+with left_col:
+    if show_structure:
+        with st.container(border=True):
+            st.markdown("#### 3D Structure")
+            has_structure = (pdb_path and os.path.exists(pdb_path)) or pdb_string
+            if has_structure:
+                render_structure(
+                    pdb_path=pdb_path,
+                    connections=connections,
+                    n_residues=n_residues,
+                    pdb_string=pdb_string,
+                )
+            else:
+                st.info(
+                    "No structure file found. For Zarr archives, include a "
+                    "`structure_pdb` array with PDB text content."
+                )
+
+    if show_arc:
+        with st.container(border=True):
+            st.markdown("#### Arc Diagram")
+            render_arc_diagram(connections, fasta_seq, highlight_residue=residue_idx)
+
+with right_col:
+    if show_heatmap:
+        with st.container(border=True):
+            st.markdown("#### Attention Heatmap")
+            render_heatmap(connections, fasta_seq, head_label)
+
+    with st.container(border=True):
+        st.markdown("#### Residue Scores")
+        if connections and fasta_seq:
+            import numpy as np
+            import plotly.graph_objects as go
+
+            scores = np.zeros(n_residues)
+            for r1, r2, w in connections:
+                if r1 < n_residues:
+                    scores[r1] += w
+                if r2 < n_residues:
+                    scores[r2] += w
+
+            tick_step = max(1, n_residues // 20)
+            fig = go.Figure(
+                go.Bar(
+                    x=list(range(n_residues)),
+                    y=scores,
+                    marker=dict(color=scores, colorscale="Reds", showscale=False),
+                    hovertemplate=(
+                        "Residue %{x} (%{customdata})<br>"
+                        "Score: %{y:.4f}<extra></extra>"
+                    ),
+                    customdata=list(fasta_seq),
+                )
+            )
+            fig.update_layout(
+                xaxis=dict(
+                    title="Residue index",
+                    tickvals=list(range(0, n_residues, tick_step)),
+                    ticktext=[fasta_seq[i] for i in range(0, n_residues, tick_step)],
+                ),
+                yaxis_title="Aggregated attention",
+                margin=dict(l=40, r=10, t=10, b=50),
+                height=240,
+            )
+            st.plotly_chart(fig, use_container_width=True)
+        else:
+            st.info("Load attention data to see per-residue scores.")

--- a/webui/app.py
+++ b/webui/app.py
@@ -13,10 +13,15 @@ sys.path.insert(0, os.path.dirname(__file__))
 
 import streamlit as st
 
-from trace_reader import TraceReader, ZarrTraceReader
 from components.structure_viewer import render_structure
 from components.attention_heatmap import render_heatmap
 from components.arc_diagram import render_arc_diagram
+
+from trace_reader import TraceReader, ZarrTraceReader
+from visualization_adapter import (
+    flatten_attention_heads,
+    build_visualization_payload,
+)
 
 # ── Page config ───────────────────────────────────────────────────────────────
 
@@ -139,7 +144,7 @@ with st.sidebar:
         )
 
         if head_sel == "Average":
-            connections = [c for cs in attn_data.values() for c in cs]
+            connections = flatten_attention_heads(attn_data)
             head_label = "All heads averaged"
         else:
             connections = attn_data.get(int(head_sel), [])
@@ -249,6 +254,38 @@ c1.metric("Residues", n_residues)
 c2.metric("Layer", layer_idx)
 c3.metric("Head", head_label)
 c4.metric("Connections", len(connections))
+
+viz_payload = build_visualization_payload(
+    fasta_seq=fasta_seq,
+    pdb_path=pdb_path,
+    connections=connections,
+    layer_idx=layer_idx,
+    head_label=head_label,
+)
+
+with st.expander("Visualization Integration Output", expanded=False):
+    st.write("Stored trace data has been converted into visualization-ready format.")
+    st.write("Format: `(source_residue, target_residue, attention_weight)`")
+
+    st.write("Layer:", viz_payload["layer_idx"])
+    st.write("Head:", viz_payload["head_label"])
+    st.write("Residues:", viz_payload["n_residues"])
+    st.write("Connections:", len(viz_payload["connections"]))
+
+    if viz_payload["connections"]:
+        st.dataframe(
+            [
+                {
+                    "source_residue": r1,
+                    "target_residue": r2,
+                    "attention_weight": weight,
+                }
+                for r1, r2, weight in viz_payload["connections"][:10]
+            ],
+            use_container_width=True,
+        )
+
+
 st.caption(f"Attention: **{attn_badge}** · top-{top_k} per head")
 
 if not connections:

--- a/webui/components/arc_diagram.py
+++ b/webui/components/arc_diagram.py
@@ -1,0 +1,76 @@
+"""
+Arc diagram — residue-to-residue attention arcs drawn with Matplotlib.
+Adapted from visualize_attention_arc_diagram_demo_utils.py but returns
+a Figure instead of saving to disk, for use inside Streamlit.
+"""
+
+from __future__ import annotations
+from typing import List, Optional, Tuple
+
+import numpy as np
+import matplotlib.pyplot as plt
+import streamlit as st
+
+
+def render_arc_diagram(
+    connections: List[Tuple[int, int, float]],
+    fasta_seq: str,
+    highlight_residue: Optional[int] = None,
+) -> None:
+    if not connections or not fasta_seq:
+        st.info("No arc data to display.")
+        return
+    fig = _build_figure(connections, fasta_seq, highlight_residue)
+    st.pyplot(fig, use_container_width=True)
+    plt.close(fig)
+
+
+# ── Internal ──────────────────────────────────────────────────────────────────
+
+def _build_figure(
+    connections: List[Tuple[int, int, float]],
+    fasta_seq: str,
+    highlight_residue: Optional[int],
+) -> plt.Figure:
+    n = len(fasta_seq)
+    weights = [w for _, _, w in connections]
+    w_min, w_max = min(weights), max(weights)
+    w_range = (w_max - w_min) or 1.0
+
+    fig_w = max(14, n // 7)
+    fig, ax = plt.subplots(figsize=(fig_w, 4))
+    fig.patch.set_facecolor("#0e1117")
+    ax.set_facecolor("#0e1117")
+
+    for r1, r2, w in connections:
+        x1, x2 = r1 + 0.5, r2 + 0.5
+        height = abs(x2 - x1) / 2
+        norm_w = (w - w_min) / w_range
+        lw = 0.3 + norm_w * 2.0
+        intensity = 0.35 + 0.65 * norm_w
+        color = (0.15, 0.45 * (1 - norm_w * 0.5), intensity)
+
+        xs = np.linspace(x1, x2, 80)
+        ys = height * np.sin(np.linspace(0, np.pi, 80))
+        ax.plot(xs, ys, color=color, linewidth=lw, alpha=0.85, solid_capstyle="round")
+
+    ax.set_xlim(0, n)
+    ax.set_ylim(0, None)
+    ax.set_xticks(np.arange(n) + 0.5)
+    labels = ax.set_xticklabels(
+        list(fasta_seq), fontsize=max(5, min(8, 120 // n)),
+        color="#aaaaaa", ha="center",
+    )
+
+    if highlight_residue is not None and 0 <= highlight_residue < len(labels):
+        labels[highlight_residue].set_color("#ff4b4b")
+        labels[highlight_residue].set_fontweight("bold")
+
+    ax.tick_params(axis="x", length=0)
+    ax.set_yticks([])
+    ax.spines[:].set_visible(False)
+    ax.set_ylabel("Attention strength", color="#aaaaaa", fontsize=9)
+    ax.yaxis.label.set_color("#aaaaaa")
+
+    plt.tight_layout(pad=0.5)
+    return fig

--- a/webui/components/attention_heatmap.py
+++ b/webui/components/attention_heatmap.py
@@ -1,0 +1,69 @@
+"""
+Interactive N×N attention heatmap rendered with Plotly.
+Builds a dense matrix from sparse (res1, res2, weight) connections.
+"""
+
+from __future__ import annotations
+from typing import List, Tuple
+
+import numpy as np
+import plotly.graph_objects as go
+import streamlit as st
+
+
+def render_heatmap(
+    connections: List[Tuple[int, int, float]],
+    fasta_seq: str,
+    head_label: str,
+) -> None:
+    n = len(fasta_seq)
+    if n == 0 or not connections:
+        st.info("No attention data to display.")
+        return
+
+    matrix = _build_matrix(connections, n)
+
+    tick_step = max(1, n // 20)
+    tick_vals = list(range(0, n, tick_step))
+    tick_text = [fasta_seq[i] for i in tick_vals]
+
+    fig = go.Figure(
+        data=go.Heatmap(
+            z=matrix,
+            colorscale="Blues",
+            colorbar=dict(title="Attention", thickness=14),
+            hovertemplate="Source %{y} → Target %{x}<br>Score: %{z:.5f}<extra></extra>",
+        )
+    )
+    fig.update_layout(
+        title=dict(text=f"Attention Map — {head_label}", font=dict(size=14)),
+        xaxis=dict(
+            title="Target residue",
+            tickvals=tick_vals,
+            ticktext=tick_text,
+            tickfont=dict(size=10),
+        ),
+        yaxis=dict(
+            title="Source residue",
+            tickvals=tick_vals,
+            ticktext=tick_text,
+            tickfont=dict(size=10),
+            autorange="reversed",
+        ),
+        margin=dict(l=60, r=20, t=50, b=60),
+        height=440,
+    )
+    st.plotly_chart(fig, use_container_width=True)
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _build_matrix(
+    connections: List[Tuple[int, int, float]], n: int
+) -> np.ndarray:
+    matrix = np.zeros((n, n))
+    for r1, r2, w in connections:
+        if r1 < n and r2 < n:
+            matrix[r1, r2] += w
+            matrix[r2, r1] += w
+    return matrix

--- a/webui/components/structure_viewer.py
+++ b/webui/components/structure_viewer.py
@@ -1,0 +1,86 @@
+"""
+3D protein structure viewer powered by py3Dmol.
+Residues are colored by aggregated attention score (white → red gradient).
+"""
+
+from __future__ import annotations
+from typing import List, Tuple
+
+import os
+
+import numpy as np
+import py3Dmol
+import streamlit as st
+import streamlit.components.v1 as components
+
+
+def render_structure(
+    pdb_path: str | None,
+    connections: List[Tuple[int, int, float]],
+    n_residues: int,
+    height: int = 480,
+    pdb_string: str | None = None,
+) -> None:
+    if pdb_string is not None:
+        pdb_str = pdb_string
+    elif pdb_path and os.path.exists(pdb_path):
+        with open(pdb_path) as f:
+            pdb_str = f.read()
+    else:
+        st.info("No structure file available.")
+        return
+
+    scores = _residue_scores(connections, n_residues)
+
+    view = py3Dmol.view(width="100%", height=height)
+    view.addModel(pdb_str, "pdb")
+    view.setStyle({"cartoon": {"color": "#cccccc"}})
+    view.setBackgroundColor("#0e1117")
+
+    if scores.max() > 0:
+        normed = scores / scores.max()
+        for resi_0, t in enumerate(normed):
+            if t > 0.02:
+                color = _score_to_hex(float(t))
+                view.addStyle(
+                    {"resi": resi_0 + 1},
+                    {"cartoon": {"color": color}},
+                )
+
+    view.zoomTo()
+
+    # stmol is optional; fall back to raw HTML embed
+    try:
+        from stmol import showmol  # type: ignore
+        showmol(view, height=height + 20)
+    except ImportError:
+        components.html(view._make_html(), height=height + 20, scrolling=False)
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _residue_scores(
+    connections: List[Tuple[int, int, float]], n_residues: int
+) -> np.ndarray:
+    scores = np.zeros(n_residues)
+    for r1, r2, w in connections:
+        if r1 < n_residues:
+            scores[r1] += w
+        if r2 < n_residues:
+            scores[r2] += w
+    return scores
+
+
+def _score_to_hex(t: float) -> str:
+    """Map t ∈ [0, 1] to a white→orange→red gradient."""
+    if t < 0.5:
+        s = t * 2
+        r = int(255)
+        g = int(255 * (1 - s * 0.5))
+        b = int(255 * (1 - s))
+    else:
+        s = (t - 0.5) * 2
+        r = int(255)
+        g = int(255 * 0.5 * (1 - s))
+        b = 0
+    return f"#{r:02x}{g:02x}{b:02x}"

--- a/webui/make_sample_trace.py
+++ b/webui/make_sample_trace.py
@@ -1,0 +1,135 @@
+"""
+make_sample_trace.py — one-time setup script for the VizFold sample trace.
+
+Run from the repo root:
+    python webui/make_sample_trace.py
+
+Copies the 6KWC PDB and FASTA from the examples/ directory into
+webui/sample_trace/6KWC/ and writes synthetic attention files so the
+Streamlit app can run immediately without a real inference trace.
+"""
+
+import os
+import shutil
+import random
+import math
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+WEBUI_DIR = os.path.dirname(os.path.abspath(__file__))
+OUT_DIR = os.path.join(WEBUI_DIR, "sample_trace", "6KWC")
+
+PDB_SRC = os.path.join(REPO_ROOT, "examples", "monomer", "sample_predictions",
+                        "6KWC_1_model_1_ptm_relaxed.pdb")
+FASTA_SRC = os.path.join(REPO_ROOT, "examples", "monomer", "fasta_dir", "6kwc.fasta")
+
+LAYERS = [0, 10, 20, 30, 40, 47]
+N_HEADS = 8
+N_RESIDUES = 190
+TOP_K = 100
+TRIANGLE_RESIDUES = [18, 39, 51, 79, 138, 159]
+
+random.seed(42)
+
+
+def softmax_weights(n: int, bias_center: int | None = None) -> list[float]:
+    """Generate plausible attention-like weights (peaked distribution)."""
+    logits = [random.gauss(0, 1) for _ in range(n)]
+    if bias_center is not None:
+        for i in range(n):
+            dist = abs(i - bias_center)
+            logits[i] += max(0, 3.0 - dist * 0.15)
+    max_l = max(logits)
+    exps = [math.exp(l - max_l) for l in logits]
+    total = sum(exps)
+    return [e / total for e in exps]
+
+
+def generate_connections(
+    n_residues: int,
+    n_connections: int,
+    bias_residue: int | None = None,
+) -> list[tuple[int, int, float]]:
+    row_weights = softmax_weights(n_residues, bias_residue)
+    connections: list[tuple[int, int, float]] = []
+    seen: set[tuple[int, int]] = set()
+
+    while len(connections) < n_connections:
+        r1 = random.choices(range(n_residues), weights=row_weights)[0]
+        col_weights = softmax_weights(n_residues, r1)
+        r2 = random.choices(range(n_residues), weights=col_weights)[0]
+        if r1 == r2:
+            continue
+        key = (min(r1, r2), max(r1, r2))
+        if key in seen:
+            continue
+        seen.add(key)
+        weight = random.uniform(0.001, 0.05) + random.random() * 0.02
+        connections.append((r1, r2, weight))
+
+    connections.sort(key=lambda x: x[2], reverse=True)
+    return connections
+
+
+def write_heads_file(path: str, layer_idx: int, n_heads: int,
+                     n_residues: int, top_k: int,
+                     bias_residue: int | None = None) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as f:
+        for head in range(n_heads):
+            conns = generate_connections(n_residues, top_k, bias_residue)
+            f.write(f"Layer {layer_idx}, Head {head}\n")
+            for r1, r2, w in conns:
+                f.write(f"{r1} {r2} {w:.6f}\n")
+    print(f"  Written: {os.path.relpath(path, REPO_ROOT)}")
+
+
+def main() -> None:
+    print("VizFold — setting up sample trace for 6KWC\n")
+
+    attn_dir = os.path.join(OUT_DIR, "attention")
+    os.makedirs(attn_dir, exist_ok=True)
+
+    # --- PDB ---
+    pdb_dst = os.path.join(OUT_DIR, "6KWC.pdb")
+    if os.path.exists(PDB_SRC):
+        shutil.copy2(PDB_SRC, pdb_dst)
+        print(f"  Copied: {os.path.relpath(pdb_dst, REPO_ROOT)}")
+    else:
+        print(f"  [WARN] PDB source not found: {PDB_SRC}")
+
+    # --- FASTA ---
+    fasta_dst = os.path.join(OUT_DIR, "6KWC.fasta")
+    if os.path.exists(FASTA_SRC):
+        shutil.copy2(FASTA_SRC, fasta_dst)
+        print(f"  Copied: {os.path.relpath(fasta_dst, REPO_ROOT)}")
+    else:
+        print(f"  [WARN] FASTA source not found: {FASTA_SRC}")
+
+    print()
+
+    # --- MSA row attention ---
+    print("Generating MSA row attention files...")
+    for layer in LAYERS:
+        path = os.path.join(attn_dir, f"msa_row_attn_layer{layer}.txt")
+        write_heads_file(path, layer, N_HEADS, N_RESIDUES, TOP_K)
+
+    print()
+
+    # --- Triangle start attention ---
+    print("Generating triangle start attention files...")
+    for layer in [47]:
+        for res_idx in TRIANGLE_RESIDUES:
+            path = os.path.join(
+                attn_dir,
+                f"triangle_start_attn_layer{layer}_residue_idx_{res_idx}.txt",
+            )
+            write_heads_file(path, layer, N_HEADS, N_RESIDUES, TOP_K,
+                             bias_residue=res_idx)
+
+    print()
+    print("Done. Start the app with:")
+    print("  streamlit run webui/app.py")
+
+
+if __name__ == "__main__":
+    main()

--- a/webui/trace_reader.py
+++ b/webui/trace_reader.py
@@ -275,3 +275,20 @@ def _dense_to_topk_connections(matrix: np.ndarray, top_k: int) -> Connections:
     weights = (matrix[rows, cols] + matrix[cols, rows]) / 2.0
     idx = np.argsort(weights)[::-1][:top_k]
     return [(int(rows[i]), int(cols[i]), float(weights[i])) for i in idx]
+
+
+def flatten_attention_heads(attn_data):
+    """
+    Converts attention data from:
+        {head: [(res1, res2, weight), ...]}
+
+    into
+        [(res1, res2, weight), ...]
+
+    """
+    connections = []
+
+    for head_connections in attn_data.values():
+        connections.extend(head_connections)
+
+    return sorted(connections, key=lambda x: x[2], reverse=True)

--- a/webui/trace_reader.py
+++ b/webui/trace_reader.py
@@ -1,0 +1,277 @@
+"""
+TraceReader — loads offline VizFold inference traces from disk.
+
+Expected directory layout:
+
+    {trace_root}/
+    └── {PROTEIN_ID}/
+        ├── *.pdb
+        ├── *.fasta
+        └── attention/
+            ├── msa_row_attn_layer{N}.txt
+            └── triangle_start_attn_layer{N}_residue_idx_{R}.txt
+
+Attention files follow the format used by the existing OpenFold viz pipeline:
+    Layer {N}, Head {H}
+    res1 res2 weight
+    ...
+"""
+
+import os
+import glob
+import re
+import tempfile
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+
+
+AttentionMap = Dict[int, List[Tuple[int, int, float]]]
+
+
+class TraceReader:
+    def __init__(self, trace_root: str):
+        self.root = os.path.expanduser(trace_root)
+
+    # ── Discovery ────────────────────────────────────────────────────────────
+
+    def list_proteins(self) -> List[str]:
+        if not os.path.isdir(self.root):
+            return []
+        return sorted(
+            d for d in os.listdir(self.root)
+            if os.path.isdir(os.path.join(self.root, d))
+        )
+
+    def get_pdb_path(self, protein: str) -> Optional[str]:
+        hits = glob.glob(os.path.join(self.root, protein, "*.pdb"))
+        return hits[0] if hits else None
+
+    def get_fasta_sequence(self, protein: str) -> str:
+        hits = glob.glob(os.path.join(self.root, protein, "*.fasta"))
+        if not hits:
+            return ""
+        with open(hits[0]) as f:
+            lines = f.readlines()
+        return "".join(l.strip() for l in lines if not l.startswith(">"))
+
+    def list_layers(self, protein: str, attention_type: str) -> List[int]:
+        attn_dir = os.path.join(self.root, protein, "attention")
+        if not os.path.isdir(attn_dir):
+            return []
+        if attention_type == "msa_row":
+            pat = re.compile(r"msa_row_attn_layer(\d+)\.txt$")
+        else:
+            pat = re.compile(r"triangle_start_attn_layer(\d+)_residue_idx_\d+\.txt$")
+        layers: set = set()
+        for fname in os.listdir(attn_dir):
+            m = pat.match(fname)
+            if m:
+                layers.add(int(m.group(1)))
+        return sorted(layers)
+
+    def list_triangle_residues(self, protein: str, layer_idx: int) -> List[int]:
+        attn_dir = os.path.join(self.root, protein, "attention")
+        if not os.path.isdir(attn_dir):
+            return []
+        pat = re.compile(
+            rf"triangle_start_attn_layer{layer_idx}_residue_idx_(\d+)\.txt$"
+        )
+        residues: set = set()
+        for fname in os.listdir(attn_dir):
+            m = pat.match(fname)
+            if m:
+                residues.add(int(m.group(1)))
+        return sorted(residues)
+
+    # ── Loading ───────────────────────────────────────────────────────────────
+
+    def load_attention(
+        self,
+        protein: str,
+        attention_type: str,
+        layer_idx: int,
+        top_k: Optional[int] = None,
+    ) -> AttentionMap:
+        if attention_type != "msa_row":
+            return {}
+        path = os.path.join(
+            self.root, protein, "attention",
+            f"msa_row_attn_layer{layer_idx}.txt",
+        )
+        return self._parse_heads_file(path, top_k) if os.path.exists(path) else {}
+
+    def load_triangle_attention(
+        self,
+        protein: str,
+        layer_idx: int,
+        residue_idx: int,
+        top_k: Optional[int] = None,
+    ) -> AttentionMap:
+        path = os.path.join(
+            self.root, protein, "attention",
+            f"triangle_start_attn_layer{layer_idx}_residue_idx_{residue_idx}.txt",
+        )
+        return self._parse_heads_file(path, top_k) if os.path.exists(path) else {}
+
+    # ── Internal ──────────────────────────────────────────────────────────────
+
+    @staticmethod
+    def _parse_heads_file(path: str, top_k: Optional[int]) -> AttentionMap:
+        heads: AttentionMap = {}
+        current: Optional[int] = None
+        with open(path) as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                if line.lower().startswith("layer"):
+                    parts = line.replace(",", "").split()
+                    current = int(parts[-1])
+                    heads[current] = []
+                elif current is not None:
+                    r1, r2, w = map(float, line.split())
+                    heads[current].append((int(r1), int(r2), w))
+        for h in heads:
+            heads[h].sort(key=lambda x: x[2], reverse=True)
+            if top_k is not None:
+                heads[h] = heads[h][:top_k]
+        return heads
+
+
+# ── Zarr reader ───────────────────────────────────────────────────────────────
+
+Connections = List[Tuple[int, int, float]]
+
+
+class ZarrTraceReader:
+    """
+    Reads attention data from a Zarr ZipStore archive (.zip).
+
+    Auto-detects attention arrays by shape: any array with ndim >= 2
+    whose last two dimensions are equal (i.e. N×N residue–residue matrices).
+
+    Supported shapes:
+        4D [n_layers, n_heads, N, N]  — standard; layer + head indexable
+        3D [n_heads, N, N]            — single-layer store
+        2D [N, N]                     — single head + single layer
+
+    Optional metadata arrays (auto-detected by name):
+        sequence / seq / fasta        — amino acid string (bytes or str array)
+        structure_pdb / pdb           — PDB file content (bytes or str array)
+    """
+
+    def __init__(self, file_bytes: bytes) -> None:
+        import zarr
+        import zarr.storage
+
+        self._tmp_path = tempfile.mktemp(suffix=".zip")
+        with open(self._tmp_path, "wb") as f:
+            f.write(file_bytes)
+
+        self._store = zarr.storage.ZipStore(self._tmp_path, mode="r")
+        self._root = zarr.open_group(self._store, mode="r")
+        self._arrays: Dict[str, object] = {}
+        self._collect_arrays()
+
+    def _collect_arrays(self) -> None:
+        import zarr
+        for name, item in self._root.members(max_depth=None):
+            if isinstance(item, zarr.Array):
+                self._arrays[name] = item
+
+    # ── Discovery ─────────────────────────────────────────────────────────────
+
+    def list_all_arrays(self) -> Dict[str, tuple]:
+        return {name: arr.shape for name, arr in self._arrays.items()}  # type: ignore[union-attr]
+
+    def list_attention_arrays(self) -> Dict[str, tuple]:
+        """Arrays whose last two dims are equal and ≥ 10 (likely N×N attention)."""
+        out = {}
+        for name, arr in self._arrays.items():
+            shape = arr.shape  # type: ignore[union-attr]
+            if len(shape) >= 2 and shape[-1] == shape[-2] and shape[-1] >= 10:
+                out[name] = shape
+        return out
+
+    def n_layers(self, array_name: str) -> int:
+        shape = self._arrays[array_name].shape  # type: ignore[union-attr]
+        return shape[0] if len(shape) >= 4 else 1
+
+    def n_heads(self, array_name: str) -> int:
+        shape = self._arrays[array_name].shape  # type: ignore[union-attr]
+        if len(shape) >= 4:
+            return shape[1]
+        if len(shape) == 3:
+            return shape[0]
+        return 1
+
+    def n_residues(self, array_name: str) -> int:
+        return self._arrays[array_name].shape[-1]  # type: ignore[union-attr]
+
+    # ── Loading ───────────────────────────────────────────────────────────────
+
+    def load_attention(
+        self,
+        array_name: str,
+        layer_idx: int,
+        head_idx: Optional[int],
+        top_k: int = 50,
+    ) -> Connections:
+        arr = self._arrays[array_name]
+        shape = arr.shape  # type: ignore[union-attr]
+
+        if len(shape) == 4:
+            # [n_layers, n_heads, N, N]
+            layer_data = np.array(arr[layer_idx])  # type: ignore[index]
+            matrix = layer_data.mean(axis=0) if head_idx is None else layer_data[head_idx]
+        elif len(shape) == 3:
+            # [n_heads, N, N]
+            data = np.array(arr[:])  # type: ignore[index]
+            matrix = data.mean(axis=0) if head_idx is None else data[head_idx]
+        else:
+            # [N, N]
+            matrix = np.array(arr[:])  # type: ignore[index]
+
+        return _dense_to_topk_connections(matrix.astype(float), top_k)
+
+    def get_sequence(self) -> str:
+        for key in ("sequence", "seq", "fasta", "metadata/sequence"):
+            if key in self._arrays:
+                raw = np.array(self._arrays[key][()])
+                if raw.dtype.kind in ("S", "U", "O"):
+                    val = raw.flat[0]
+                    return val.decode() if isinstance(val, bytes) else str(val)
+        return ""
+
+    def get_pdb_string(self) -> Optional[str]:
+        for key in ("structure_pdb", "pdb", "structure", "structure/pdb"):
+            if key in self._arrays:
+                raw = np.array(self._arrays[key][()])
+                if raw.dtype.kind in ("S", "U", "O"):
+                    val = raw.flat[0]
+                    text = val.decode() if isinstance(val, bytes) else str(val)
+                    if "ATOM" in text or "HETATM" in text:
+                        return text
+        return None
+
+    def __del__(self) -> None:
+        try:
+            self._store.close()  # type: ignore[attr-defined]
+        except Exception:
+            pass
+        try:
+            os.unlink(self._tmp_path)
+        except Exception:
+            pass
+
+
+# ── Shared helper ─────────────────────────────────────────────────────────────
+
+def _dense_to_topk_connections(matrix: np.ndarray, top_k: int) -> Connections:
+    """Convert a dense N×N attention matrix to a sorted top-k connections list."""
+    n = matrix.shape[0]
+    rows, cols = np.triu_indices(n, k=1)
+    weights = (matrix[rows, cols] + matrix[cols, rows]) / 2.0
+    idx = np.argsort(weights)[::-1][:top_k]
+    return [(int(rows[i]), int(cols[i]), float(weights[i])) for i in idx]

--- a/webui/visualization_adapter.py
+++ b/webui/visualization_adapter.py
@@ -1,0 +1,108 @@
+"""
+visualization_adapter.py
+
+Middle-layer adapter for Issue #41.
+
+This file converts stored offline trace data from the archive/reader layer
+into visualization-ready formats for the Streamlit UI.
+"""
+
+from typing import Dict, List, Tuple, Optional
+import numpy as np
+
+Connection = Tuple[int, int, float]
+AttentionMap = Dict[int, List[Connection]]
+
+
+def flatten_attention_heads(attn_data: AttentionMap) -> List[Connection]:
+    """
+    Converts:
+        {head: [(res1, res2, weight), ...]}
+
+    into:
+        [(res1, res2, weight), ...]
+
+    This is the standardized format expected by Dev's visualization components.
+    """
+    connections: List[Connection] = []
+
+    for head_connections in attn_data.values():
+        connections.extend(head_connections)
+
+    return sorted(connections, key=lambda x: x[2], reverse=True)
+
+
+def dense_attention_to_connections(
+    matrix: np.ndarray,
+    top_k: int = 50,
+    symmetric: bool = True,
+) -> List[Connection]:
+    """
+    Converts a dense N x N attention matrix into top-k residue connections.
+
+    This supports archive outputs that store full tensors instead of sparse files.
+    """
+    if matrix.ndim != 2:
+        raise ValueError("Expected a 2D attention matrix.")
+
+    if matrix.shape[0] != matrix.shape[1]:
+        raise ValueError("Attention matrix must be square.")
+
+    n = matrix.shape[0]
+
+    if symmetric:
+        rows, cols = np.triu_indices(n, k=1)
+        weights = (matrix[rows, cols] + matrix[cols, rows]) / 2.0
+    else:
+        rows, cols = np.where(~np.eye(n, dtype=bool))
+        weights = matrix[rows, cols]
+
+    top_indices = np.argsort(weights)[::-1][:top_k]
+
+    return [
+        (int(rows[i]), int(cols[i]), float(weights[i]))
+        for i in top_indices
+    ]
+
+
+def residue_attention_scores(
+    connections: List[Connection],
+    n_residues: int,
+) -> np.ndarray:
+    """
+    Aggregates connection weights into one score per residue.
+
+    Used for coloring protein structure or plotting residue-level importance.
+    """
+    scores = np.zeros(n_residues)
+
+    for r1, r2, weight in connections:
+        if 0 <= r1 < n_residues:
+            scores[r1] += weight
+        if 0 <= r2 < n_residues:
+            scores[r2] += weight
+
+    return scores
+
+
+def build_visualization_payload(
+    fasta_seq: str,
+    pdb_path: Optional[str],
+    connections: List[Connection],
+    layer_idx: int,
+    head_label: str,
+) -> dict:
+    """
+    Creates one clean payload Dev's UI can consume.
+    """
+    n_residues = len(fasta_seq)
+
+    return {
+        "fasta_seq": fasta_seq,
+        "pdb_path": pdb_path,
+        "connections": connections,
+        "n_residues": n_residues,
+        "layer_idx": layer_idx,
+        "head_label": head_label,
+        "residue_scores": residue_attention_scores(connections, n_residues),
+    }


### PR DESCRIPTION
This PR adds a visualization adapter layer for Issue #41.

It converts offline trace outputs into standardized visualization-ready data structures for the Streamlit UI. This includes flattening attention heads into residue-level connections and building a unified payload for visualization components.

This is intended to serve as the integration bridge between the reader/archive layer and the visualization UI.