### PR TITLE
vizfold: rename `init` to `install`, add `uninstall`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Vizfold is a platform for running protein-structure models and inspecting what t
 2. Visualization & analysis: Explore, visualize, and analyze the extracted activations and attention maps.
 
 The `vizfold` CLI is the platform; a model backend plugs in underneath it. **OpenFold** is
-today's default (and only) backend, installed by `vizfold init`; the same `install/` scripts
+today's default (and only) backend, installed by `vizfold install`; the same `install/` scripts
 are built to host others (openfold3, boltz, esmfold) as they land.
 
 ---
@@ -28,18 +28,31 @@ release and installs it to `~/.local/bin` (set `VIZFOLD_VERSION=vX.Y.Z` to pin a
 install the OpenFold backend:
 
 ```bash
-vizfold init
+vizfold install
 ```
 
-`vizfold init` clones the matching checkout to `$HOME/vizfold-src` on first run (the binary
+`vizfold install` clones the matching checkout to `$HOME/vizfold-src` on first run (the binary
 ships only itself; the `install/` scripts and dashboard come from there), works out where it is
 running, picks the site, submits the OpenFold install to the scheduler, and prints the exact
 command to fold a test sequence. Cold: ~8 min on NCSA Delta, ~25 min where the AlphaFold
 databases have to be downloaded.
 
+### Uninstall
+
+```bash
+vizfold uninstall
+```
+
+Lists everything the install generated — the conda environment and the rest of the install
+prefix, the package caches beside it, the symlinks and build droppings it left in the checkout,
+the run database, the checkout it cloned into `$HOME/vizfold-src`, and
+`~/.config/vizfold/vizfold.json` — then removes it once you confirm (`--yes` skips the prompt).
+Fold outputs under the prefix, a checkout you pointed it at yourself, and the `vizfold` binary
+are left alone; drop the binary with `rm ~/.local/bin/vizfold`.
+
 ### Supported clusters
 
-Dispatch is on the SLURM `ClusterName`, so on these machines `vizfold init` needs no
+Dispatch is on the SLURM `ClusterName`, so on these machines `vizfold install` needs no
 arguments. Accounts and the install prefix are worked out live (your project space, the
 accounts you can charge); the values below are what a fresh install settles on.
 
@@ -54,7 +67,7 @@ accounts you can charge); the values below are what a fresh install settles on.
 | `ice-slurm` (GT PACE ICE) | ⚙️ profile | x86-64 | mirror¹ | `ice-cpu` → `ice-gpu` (A100) | `<scratch>/vizfold` (`/storage/ice1/…`) |
 | `phoenix-slurm` (GT PACE Phoenix) | ⚙️ profile | x86-64 | mirror¹ | `cpu-small` → `gpu-a100` (A100) | `<scratch>/vizfold` (`/storage/scratch1/…`) |
 
-Legend — ✅ install + fold verified end-to-end from `vizfold init` (fold → 2839-atom relaxed
+Legend — ✅ install + fold verified end-to-end from `vizfold install` (fold → 2839-atom relaxed
 structure); ◐ install run on the cluster with its site-specific fixes, final fold not re-confirmed
 in this pass⁵; ⚙️ site profile written and its paths probed live, full install not yet run.
 
@@ -83,7 +96,7 @@ exactly what you care about and nothing else:
 
 | | | |
 | --- | --- | --- |
-| 1 | inline environment | `OPENFOLD_PREFIX=/scratch/me/vizfold vizfold init` |
+| 1 | inline environment | `OPENFOLD_PREFIX=/scratch/me/vizfold vizfold install` |
 | 2 | `~/.config/vizfold/vizfold.json` | written by the install; edit to make a choice stick |
 | 3 | `install/sites/<site>.json` | the site's defaults, in the repo — edit to change them for everyone |
 
@@ -127,7 +140,7 @@ memory:
 To override for one run, put the variable inline — it wins over both files:
 
 ```bash
-OPENFOLD_EXAMPLE=1UBQ_1 OPENFOLD_PARTITION=cpuA100x4 vizfold init
+OPENFOLD_EXAMPLE=1UBQ_1 OPENFOLD_PARTITION=cpuA100x4 vizfold install
 ```
 
 Only the login-specific atom is discovered at run time (the allocation, account, or install

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Bootstrap the vizfold platform CLI: download the release binary into ~/.local/bin, then `vizfold init` installs a model backend (OpenFold today; the same install/ scripts would host openfold3/boltz/esmfold).
+# Bootstrap the vizfold platform CLI: download the release binary into ~/.local/bin, then `vizfold install` installs a model backend (OpenFold today; the same install/ scripts would host openfold3/boltz/esmfold).
 set -euo pipefail
 
 die() { echo "FATAL: $*" >&2; exit 1; }
@@ -54,6 +54,6 @@ main() {
     bootstrap::asset
     bootstrap::download
     bootstrap::path
-    echo "vizfold installed at $BIN/vizfold. Run \`vizfold init\` to install a model backend (OpenFold)."
+    echo "vizfold installed at $BIN/vizfold. Run \`vizfold install\` to install a model backend (OpenFold)."
 }
 main

--- a/install/init.sh
+++ b/install/init.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Install a model backend (OpenFold today) on this cluster; dispatch on SLURM ClusterName, add a cluster as install/sites/<ClusterName>.sh. Invoked by `vizfold init`.
+# Install a model backend (OpenFold today) on this cluster; dispatch on SLURM ClusterName, add a cluster as install/sites/<ClusterName>.sh. Invoked by `vizfold install`.
 set -euo pipefail
 
 REPO=${OPENFOLD_HOME:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}   # already cloned by the bootstrap

--- a/science-gateway/apps/executor/Cargo.lock
+++ b/science-gateway/apps/executor/Cargo.lock
@@ -629,7 +629,7 @@ dependencies = [
 
 [[package]]
 name = "executor"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-trait",
  "axum",

--- a/science-gateway/apps/executor/Cargo.toml
+++ b/science-gateway/apps/executor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "executor"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 
 [dependencies]

--- a/science-gateway/apps/executor/src/adapters/cli.rs
+++ b/science-gateway/apps/executor/src/adapters/cli.rs
@@ -26,7 +26,9 @@ pub struct Cli {
 #[derive(Debug, Subcommand)]
 enum Command {
     /// Install a model backend (OpenFold) on this machine.
-    Init,
+    Install,
+    /// Remove everything the install generated.
+    Uninstall(UninstallArgs),
     /// Start the workbench dashboard.
     Serve(ServeArgs),
     /// Seed the default executor records.
@@ -41,6 +43,13 @@ enum Command {
     ExecuteRun { run_id: i32 },
     /// Register known artifacts for a completed run.
     RegisterArtifacts { run_id: i32 },
+}
+
+#[derive(Debug, Args)]
+struct UninstallArgs {
+    /// Remove without the confirmation prompt.
+    #[arg(long, short = 'y')]
+    yes: bool,
 }
 
 #[derive(Debug, Args)]
@@ -132,15 +141,18 @@ struct OpenfoldQueueArgs {
 pub async fn run() -> Result<(), DbErr> {
     let cli = Cli::parse();
 
-    // `init` is the bootstrap; everything else requires an initialized config.
-    if !matches!(cli.command, Command::Init) && !config::is_initialized() {
-        eprintln!("run `vizfold init` first");
+    // `install` is the bootstrap and `uninstall` cleans up after a partial one; everything
+    // else requires an initialized config.
+    if !matches!(cli.command, Command::Install | Command::Uninstall(_)) && !config::is_initialized()
+    {
+        eprintln!("run `vizfold install` first");
         std::process::exit(1);
     }
 
-    // init and serve are subprocess launchers; they need no database connection.
+    // These three touch the filesystem only; they need no database connection.
     match cli.command {
-        Command::Init => return run_init(),
+        Command::Install => return run_install(),
+        Command::Uninstall(args) => return run_uninstall(args),
         Command::Serve(args) => return run_serve(args),
         _ => {}
     }
@@ -165,7 +177,9 @@ pub async fn run() -> Result<(), DbErr> {
         },
         Command::ExecuteRun { run_id } => execute_run(&database, run_id).await?,
         Command::RegisterArtifacts { run_id } => register_artifacts(&database, run_id).await?,
-        Command::Init | Command::Serve(_) => unreachable!("handled before DB connect"),
+        Command::Install | Command::Uninstall(_) | Command::Serve(_) => {
+            unreachable!("handled before DB connect")
+        }
     }
 
     Ok(())
@@ -173,8 +187,8 @@ pub async fn run() -> Result<(), DbErr> {
 
 /// Install a model backend (OpenFold) by running the checkout's `install/init.sh` with
 /// inherited stdio. The release binary ships only itself, so the checkout is cloned on
-/// first init. Idempotent: its steps are sentinel-guarded, so re-running is safe.
-fn run_init() -> Result<(), DbErr> {
+/// first install. Idempotent: its steps are sentinel-guarded, so re-running is safe.
+fn run_install() -> Result<(), DbErr> {
     let src = config::vizfold_src();
     let installer = src.join("install/init.sh");
     if !installer.is_file() {
@@ -198,7 +212,7 @@ fn run_init() -> Result<(), DbErr> {
         .ok_or_else(|| DbErr::Custom(format!("model install exited with status {status}")))
 }
 
-/// Clone the vizfold checkout `vizfold init` runs its scripts (and serves the dashboard)
+/// Clone the vizfold checkout `vizfold install` runs its scripts (and serves the dashboard)
 /// from -- the release binary ships only itself. Pins the binary's own version tag
 /// (`VIZFOLD_REF` overrides), falling back to the repo default branch.
 fn clone_checkout(src: &std::path::Path) -> Result<(), DbErr> {
@@ -224,6 +238,136 @@ fn clone_checkout(src: &std::path::Path) -> Result<(), DbErr> {
             "failed to clone {url} into {dest}; set VIZFOLD_SRC to an existing checkout"
         ))),
     }
+}
+
+/// Undo `vizfold install`: the install prefix's generated trees, the caches beside it, what it
+/// planted in the checkout, the run database and the install config. Resolved here rather than
+/// in an `install/uninstall.sh` because the checkout holding that script is itself one of the
+/// things being removed. Kept: fold outputs, a checkout the user pointed at, and this binary.
+fn run_uninstall(args: UninstallArgs) -> Result<(), DbErr> {
+    let prefix = config::prefix();
+    let mut targets = install_paths(&prefix, &config::openfold_home());
+    // Only the clone the install made itself: a checkout the user pointed at is theirs, and one
+    // holding the prefix holds the fold outputs too.
+    let src = config::vizfold_src();
+    if src == config::default_src() && !prefix.starts_with(&src) {
+        targets.push(src);
+    }
+    if let Some(database) = config::database_path() {
+        let sidecar = |suffix| PathBuf::from(format!("{}{suffix}", database.display()));
+        targets.extend([sidecar("-wal"), sidecar("-shm"), database]);
+    }
+    targets.push(config::config_file());
+
+    // Relative paths mean an empty config value resolved into one; never delete off the cwd.
+    targets.retain(|path| path.is_absolute() && std::fs::symlink_metadata(path).is_ok());
+    targets.sort();
+    targets.dedup();
+    // Drop what an outer target already covers (the clone contains the checkout paths), so the
+    // plan is what it removes. ponytail: O(n^2) over ~25 paths.
+    let outer = targets.clone();
+    targets.retain(|path| {
+        !outer
+            .iter()
+            .any(|other| other != path && path.starts_with(other))
+    });
+    if targets.is_empty() {
+        println!("Nothing to remove.");
+        return Ok(());
+    }
+
+    println!("This removes:");
+    for target in &targets {
+        println!("  {}", target.display());
+    }
+    if !args.yes && !confirmed()? {
+        println!("Aborted.");
+        return Ok(());
+    }
+    for target in &targets {
+        match remove_path(target) {
+            Ok(()) => println!("removed {}", target.display()),
+            Err(error) => eprintln!("warning: could not remove {}: {error}", target.display()),
+        }
+    }
+    if let Some(dir) = config::config_file().parent() {
+        let _ = std::fs::remove_dir(dir); // ours, but only if the uninstall emptied it
+    }
+    println!("\nKept: fold outputs, the vizfold checkout, and the vizfold binary itself.");
+    Ok(())
+}
+
+/// What an install writes under the prefix and into the checkout (`install/setup.sh`), minus
+/// `<prefix>/outputs` -- those are run results, not install state.
+fn install_paths(prefix: &Path, home: &Path) -> Vec<PathBuf> {
+    let mut paths: Vec<PathBuf> = [
+        "bin/micromamba",
+        "mamba",
+        "cutlass",
+        "tmp",
+        "data",
+        ".done",
+        "params",
+        "workbench",
+        "vizfold.db",
+    ]
+    .iter()
+    .map(|entry| prefix.join(entry))
+    .collect();
+    // One nvrtc-<driver-cuda> side prefix per driver version the install has pinned for.
+    paths.extend(
+        std::fs::read_dir(prefix)
+            .into_iter()
+            .flatten()
+            .flatten()
+            .map(|entry| entry.path())
+            .filter(|path| file_name(path).starts_with("nvrtc-")),
+    );
+    // Package caches, deliberately parked beside the prefix rather than in it.
+    paths.extend(
+        prefix
+            .parent()
+            .into_iter()
+            .flat_map(|dir| [dir.join(".openfold-pkgs"), dir.join(".openfold-pip")]),
+    );
+    paths.extend(
+        [
+            "openfold/resources/params",
+            "openfold/resources/stereo_chemical_props.txt",
+            "tests/test_data/alphafold/common/stereo_chemical_props.txt",
+            "openfold.egg-info", // both left by the editable install of the checkout
+            "build",
+        ]
+        .map(|entry| home.join(entry)),
+    );
+    paths
+}
+
+fn file_name(path: &Path) -> &str {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("")
+}
+
+/// Delete a file, directory tree, or symlink. `symlink_metadata` keeps a symlink to a directory
+/// (the AF2 mirror links under `<prefix>/data`) from being followed into the directory it points at.
+fn remove_path(path: &Path) -> std::io::Result<()> {
+    if std::fs::symlink_metadata(path)?.is_dir() {
+        std::fs::remove_dir_all(path)
+    } else {
+        std::fs::remove_file(path)
+    }
+}
+
+fn confirmed() -> Result<bool, DbErr> {
+    use std::io::Write;
+    print!("Remove these? [y/N] ");
+    std::io::stdout().flush().ok();
+    let mut answer = String::new();
+    std::io::stdin()
+        .read_line(&mut answer)
+        .map_err(|error| DbErr::Custom(format!("could not read confirmation: {error}")))?;
+    Ok(matches!(answer.trim(), "y" | "Y" | "yes" | "YES"))
 }
 
 /// Start the workbench dashboard, streaming its output to this shell.
@@ -857,9 +1001,68 @@ mod tests {
     }
 
     #[test]
-    fn parses_init() {
-        let cli = Cli::try_parse_from(["vizfold", "init"]).expect("init command should parse");
-        assert!(matches!(cli.command, Command::Init));
+    fn parses_install() {
+        let cli =
+            Cli::try_parse_from(["vizfold", "install"]).expect("install command should parse");
+        assert!(matches!(cli.command, Command::Install));
+    }
+
+    #[test]
+    fn parses_uninstall() {
+        assert!(matches!(
+            Cli::try_parse_from(["vizfold", "uninstall"])
+                .expect("uninstall command should parse")
+                .command,
+            Command::Uninstall(UninstallArgs { yes: false })
+        ));
+        assert!(matches!(
+            Cli::try_parse_from(["vizfold", "uninstall", "--yes"])
+                .expect("uninstall --yes should parse")
+                .command,
+            Command::Uninstall(UninstallArgs { yes: true })
+        ));
+    }
+
+    #[test]
+    fn install_paths_cover_generated_trees_but_not_run_outputs() {
+        let base = std::env::temp_dir().join(format!("vizfold-uninstall-{}", std::process::id()));
+        let (prefix, home) = (base.join("prefix"), base.join("checkout"));
+        let _ = std::fs::remove_dir_all(&base);
+        std::fs::create_dir_all(prefix.join("nvrtc-12.2")).unwrap();
+        std::fs::create_dir_all(prefix.join("outputs")).unwrap();
+
+        let paths = super::install_paths(&prefix, &home);
+
+        for expected in [
+            prefix.join("mamba"),
+            prefix.join("data"),
+            prefix.join(".done"),
+            prefix.join("nvrtc-12.2"),
+            base.join(".openfold-pkgs"),
+            home.join("openfold/resources/params"),
+        ] {
+            assert!(paths.contains(&expected), "missing {}", expected.display());
+        }
+        assert!(!paths.contains(&prefix.join("outputs")), "run outputs kept");
+        std::fs::remove_dir_all(&base).ok();
+    }
+
+    #[test]
+    fn remove_path_unlinks_a_symlink_without_touching_its_target() {
+        let base = std::env::temp_dir().join(format!("vizfold-rm-{}", std::process::id()));
+        let (mirror, link) = (base.join("mirror"), base.join("params"));
+        let _ = std::fs::remove_dir_all(&base);
+        std::fs::create_dir_all(&mirror).unwrap();
+        std::fs::write(mirror.join("params.npz"), "keep").unwrap();
+        std::os::unix::fs::symlink(&mirror, &link).unwrap();
+
+        super::remove_path(&link).unwrap();
+
+        assert!(link.symlink_metadata().is_err(), "symlink should be gone");
+        assert!(mirror.join("params.npz").is_file(), "target must survive");
+        super::remove_path(&mirror).unwrap();
+        assert!(!mirror.exists(), "a real directory is removed whole");
+        std::fs::remove_dir_all(&base).ok();
     }
 
     #[test]

--- a/science-gateway/apps/executor/src/core/config.rs
+++ b/science-gateway/apps/executor/src/core/config.rs
@@ -57,7 +57,7 @@ pub fn openfold_home() -> PathBuf {
         .unwrap_or_else(repository_root)
 }
 
-/// Repo checkout holding `install/init.sh` (what `vizfold init` runs, cloning it if absent).
+/// Repo checkout holding `install/init.sh` (what `vizfold install` runs, cloning it if absent).
 /// `VIZFOLD_SRC` env > vizfold.json `OPENFOLD_HOME` > the default clone location (`$HOME/vizfold-src`).
 pub fn vizfold_src() -> PathBuf {
     if let Ok(v) = std::env::var("VIZFOLD_SRC")
@@ -67,7 +67,13 @@ pub fn vizfold_src() -> PathBuf {
     }
     resolved("OPENFOLD_HOME")
         .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from(format!("{}/vizfold-src", home_dir())))
+        .unwrap_or_else(default_src)
+}
+
+/// Where `vizfold install` clones the checkout when nothing points at an existing one --
+/// the only checkout `vizfold uninstall` may delete.
+pub fn default_src() -> PathBuf {
+    PathBuf::from(format!("{}/vizfold-src", home_dir()))
 }
 
 pub fn data_dir() -> PathBuf {
@@ -111,6 +117,13 @@ pub fn database_url() -> String {
         .filter(|v| !v.is_empty())
         .unwrap_or_else(|| format!("{}/.local/share", home_dir()));
     format!("sqlite://{dh}/vizfold/vizfold.db?mode=rwc")
+}
+
+/// File behind `database_url()`, when it is a file-backed sqlite URL.
+pub fn database_path() -> Option<PathBuf> {
+    let url = database_url();
+    let path = url.strip_prefix("sqlite://")?.split('?').next()?;
+    (!path.is_empty() && path != ":memory:").then(|| PathBuf::from(path))
 }
 
 /// Repository root for the local development layout. DEV FALLBACK ONLY: relies on

--- a/science-gateway/apps/executor/src/core/db.rs
+++ b/science-gateway/apps/executor/src/core/db.rs
@@ -5,11 +5,11 @@ use sea_orm::{ConnectOptions, ConnectionTrait, Database, DatabaseConnection, DbE
 use crate::core::{config, migrations::MigratorTrait};
 
 pub async fn connect_and_migrate() -> Result<DatabaseConnection, DbErr> {
-    let database_url = config::database_url();
+    if let Some(parent) = config::database_path().as_deref().and_then(Path::parent) {
+        std::fs::create_dir_all(parent).map_err(|error| DbErr::Custom(error.to_string()))?;
+    }
 
-    ensure_sqlite_parent_dir(&database_url)?;
-
-    let mut options = ConnectOptions::new(database_url);
+    let mut options = ConnectOptions::new(config::database_url());
     options.sqlx_logging(false);
 
     let db = Database::connect(options).await?;
@@ -28,28 +28,4 @@ pub async fn connect_and_migrate() -> Result<DatabaseConnection, DbErr> {
 
 pub async fn migrate_database(db: &DatabaseConnection) -> Result<(), DbErr> {
     crate::core::migrations::Migrator::up(db, None).await
-}
-
-fn ensure_sqlite_parent_dir(database_url: &str) -> Result<(), DbErr> {
-    if !database_url.starts_with("sqlite://") {
-        return Ok(());
-    }
-
-    let path_part = database_url
-        .trim_start_matches("sqlite://")
-        .split('?')
-        .next()
-        .unwrap_or_default();
-
-    if path_part == ":memory:" || path_part.is_empty() {
-        return Ok(());
-    }
-
-    let path = Path::new(path_part);
-
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent).map_err(|error| DbErr::Custom(error.to_string()))?;
-    }
-
-    Ok(())
 }


### PR DESCRIPTION
`vizfold init` becomes `vizfold install` (unchanged behaviour — it still dispatches to the checkout's `install/init.sh`), and a new `vizfold uninstall` undoes it.

## `vizfold uninstall`

Prints the removal plan, then removes it once you confirm (`--yes` skips the prompt):

- **install prefix** — `bin/micromamba`, `mamba/`, `cutlass/`, `nvrtc-<ver>/`, `tmp/`, `data/`, `.done/`, `params/`, `workbench/`, `vizfold.db`
- **beside the prefix** — `.openfold-pkgs`, `.openfold-pip` (the caches `setup.sh` parks there)
- **in the checkout** — the `params` / `stereo_chemical_props.txt` symlinks, `openfold.egg-info`, `build/`
- **the auto-cloned checkout** at `$HOME/vizfold-src`
- **state** — the run database (+ `-wal`/`-shm`) and `~/.config/vizfold/vizfold.json` (and its dir, if the uninstall empties it)

Kept: fold outputs under the prefix, a checkout you pointed it at yourself (`VIZFOLD_SRC` / `OPENFOLD_HOME`), and the `vizfold` binary.

Design notes:

- **Rust, not `install/uninstall.sh`** — the checkout holding such a script is itself one of the things removed, and `config.rs` already resolves every path.
- **`symlink_metadata`, not `is_dir()`** — `<prefix>/data` and `openfold/resources/params` are symlinks into a read-only AF2 mirror; the symlink is unlinked, never followed.
- Targets are filtered to absolute + existing, deduped, and paths already covered by an outer target are folded in, so the printed plan is exactly what gets removed.
- The clone is spared when the prefix lives inside it (its `outputs/` would go with it).
- `db.rs`'s sqlite-URL parse moved to `config::database_path()`, shared with the target list (net deletion).

## Test plan

- `cargo test` — 103 pass, including new `parses_install`, `parses_uninstall`, `install_paths_cover_generated_trees_but_not_run_outputs`, and `remove_path_unlinks_a_symlink_without_touching_its_target`; `cargo clippy --all-targets` clean.
- Manual, against fake install trees: full uninstall removed every generated path, left `outputs/`, the checkout and the AF2 mirror behind the symlink intact; the config dir was cleaned; a rerun printed `Nothing to remove.`; `vizfold list runs` then correctly said ``run `vizfold install` first``.
- Auto-clone case (`HOME` pointed at a fixture): `$HOME/vizfold-src` removed once, its inner targets folded in, no warnings.
- Prefix nested inside the clone: the clone survived.
- `vizfold install` with a stub `install/init.sh` dispatched correctly with `OPENFOLD_HOME` set.