### PR TITLE
release: v0.2.0

### DIFF
--- a/science-gateway/apps/executor/Cargo.lock
+++ b/science-gateway/apps/executor/Cargo.lock
@@ -629,7 +629,7 @@ dependencies = [
 
 [[package]]
 name = "executor"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/science-gateway/apps/executor/Cargo.toml
+++ b/science-gateway/apps/executor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "executor"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
Bumps the executor to 0.2.0 so the streaming install and the srun fold seam reach users.

**Why the bump is load-bearing.** `clone_checkout` pins the `vizfold-src` checkout to `v{CARGO_PKG_VERSION}`. Users on the 0.1.1 binary clone the **0.1.1 tag**, which still contains the old `sbatch` install — so even the pure-bash streaming fix is invisible without a new tag.

**Minor, not patch:** `vizfold install` no longer returns immediately, which breaks anyone scripting it.

**Validated on NCSA Delta** against this exact `install/` tree:
- install runs via `srun` (not `sbatch`), streaming `== micromamba (+0s)` / `== env (+3s)` live, with micromamba's ANSI progress spinners rendering — proving `--pty` gives the remote task a real terminal
- a fold srun'd onto an A100, streamed live, and completed: inference 2.94s, relaxation 7.16s, 2839-atom relaxed structure, exit 0
- all four scheduler contexts behave correctly: login node + partition → full `srun`; `SLURM_JOB_ID` → `srun --ntasks=1`; `SLURM_STEP_ID` → bare, no nesting; no partition → bare

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SH8DGEBhjDKU37rCnmW7nF