### PR TITLE
release: v0.2.1

### DIFF
--- a/science-gateway/apps/executor/Cargo.lock
+++ b/science-gateway/apps/executor/Cargo.lock
@@ -629,7 +629,7 @@ dependencies = [
 
 [[package]]
 name = "executor"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "axum",

--- a/science-gateway/apps/executor/Cargo.toml
+++ b/science-gateway/apps/executor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "executor"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 default-run = "vizfold"
 


### PR DESCRIPTION
Tags the work merged in #89 so it reaches users. Without a bump, the 0.2.0 binary keeps cloning the 0.2.0 tag — `clone_checkout` pins `vizfold-src` to `v{CARGO_PKG_VERSION}`.

## Requires deleting your existing database

#89 replaced seven migrations with one baseline, so any `vizfold.db` created before it fails every command:

    Migration file of version 'm20260707_000001_...' is missing

Delete the file and let it recreate — seeding is existence-guarded, so defaults repopulate. The error message names this fix. Resolution order is `VIZFOLD_DB` → `<OPENFOLD_PREFIX>/vizfold.db` → `$XDG_DATA_HOME/vizfold/vizfold.db`.

## What users get

- `--cpus` follows the host instead of defaulting to 1, and is clamped to the execution target's maximum — without the clamp, any host with more than 14 cores failed at execute time
- `--model-device` consults the scheduler before probing, so queueing from a GPU-less login node still yields `cuda:0` for a fold that will `srun` onto a GPU node
- fold output streams live instead of buffering until exit
- a GPU preflight check that warns rather than failing, so CPU-only hosts degrade instead of erroring
- each run stores an immutable provenance snapshot, fixing a bug where a mutated profile relocated where a completed run's outputs were looked up

## Under the hood

7,858 → 6,957 Rust LOC: the `repositories/` pass-through layer, four dead cargo examples, the single-implementation `PreflightRunner` trait, and the execution-workflow ceremony are gone; seven migrations became one baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SH8DGEBhjDKU37rCnmW7nF