### PR TITLE
install: template expanse off $ALLOC like the other sites

### DIFF
--- a/install/sites/expanse.json
+++ b/install/sites/expanse.json
@@ -1,5 +1,6 @@
 {
-  "OPENFOLD_BASE": "/expanse/lustre/projects/$OPENFOLD_ACCOUNT/$USER",
+  "OPENFOLD_ACCOUNT": "$ALLOC",
+  "OPENFOLD_BASE": "/expanse/lustre/projects/$ALLOC/$USER",
   "OPENFOLD_EXAMPLE": "6KWC_1",
   "OPENFOLD_GPU_GRES": "gpu:v100:1",
   "OPENFOLD_GPU_PARTITION": "gpu-shared",

--- a/install/sites/expanse.sh
+++ b/install/sites/expanse.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-# SDSC Expanse ("expanse"). No mirror; no default account, so the first association is used for both the account and the /expanse dir the prefix templates off.
+# SDSC Expanse ("expanse"). No mirror; no default account, so the first association is the atom: expanse.json templates both the slurm account and the /expanse project dir off $ALLOC.
 
-slurm::discover() { export OPENFOLD_ACCOUNT=${OPENFOLD_ACCOUNT:-$(sacctmgr -nP show assoc user="$USER" format=Account 2>/dev/null | grep . | head -1)}; }
+slurm::discover() { ALLOC=$(interactive::resolve OPENFOLD_ALLOCATION allocation "${ALLOC:-$(sacctmgr -nP show assoc user="$USER" format=Account 2>/dev/null | grep . | head -1)}"); [ -n "$ALLOC" ] || die "no usable allocation; set OPENFOLD_ALLOCATION"; export ALLOC; }


### PR DESCRIPTION
`expanse.json` referenced `$OPENFOLD_ACCOUNT` where every other site templates off the discovered `$ALLOC` atom. The discover hook now exports `ALLOC`, and the JSON derives both values from it — matching `delta.json`'s `"$ALLOC-delta-cpu"`.

`OPENFOLD_ACCOUNT` is still declared because `slurm::run` needs it for `--account=` and Expanse has no SLURM default account to fall back on — that is why this site has a discover hook at all. Only its source changed.

**Also decouples two things that were tangled.** `OPENFOLD_BASE` used to template off the account, so overriding `OPENFOLD_ACCOUNT` silently relocated the install directory:

    OPENFOLD_ACCOUNT=other  ->  /expanse/lustre/projects/other/$USER   (before)
    OPENFOLD_ACCOUNT=other  ->  /expanse/lustre/projects/$ALLOC/$USER  (after)

Verified against `config::fill` with a stubbed environment: `ALLOC=abc123` yields `OPENFOLD_ACCOUNT=abc123`, `OPENFOLD_BASE=/expanse/lustre/projects/abc123/$USER`, `OPENFOLD_PREFIX=…/vizfold`; and an inline `OPENFOLD_ACCOUNT` override is preserved while the base stays put.

Not run on Expanse itself — that site is `⚙️ profile` status (paths probed, full install never run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SH8DGEBhjDKU37rCnmW7nF