### PR TITLE
Salvage visualization utilities from closed PRs #67 and #75

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -44,6 +44,8 @@ dependencies:
   - PyYAML
   - requests
   - scipy
+  - matplotlib-base      # attention plots (run/viz.py + the visualize_* modules); -base skips the GUI toolkit (renders go to PNG)
+  - pymol-open-source    # 3D structure + attention head renders
   - tqdm
   - typing-extensions
   - wandb

--- a/run/viz.py
+++ b/run/viz.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Render attention visualizations for a completed fold.
+
+Produces 3D PyMOL head renders, arc diagrams, and combined panels from the attention
+maps and relaxed PDB a fold left behind. Running the fold is run/fold.sh's job; this
+only consumes its outputs. Lifted from the visualization half of closed PR #67 (the
+inference half duplicated run/fold.sh and was dropped).
+
+Example:
+  python run/viz.py \\
+      --fasta-file examples/monomer/fasta_dir_6KWC/6KWC.fasta \\
+      --output-dir "$OPENFOLD_PREFIX/outputs/6KWC_1" \\
+      --protein 6KWC
+"""
+import argparse
+import logging
+import os
+import sys
+
+# run/ sits one level below the repo root that holds the visualize_* modules.
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+
+def derived_paths(output_dir, protein, tri_residue_idx, config_preset, attn_map_dir=None):
+    """Output layout produced by a --demo_attn fold (attention_files_/images_ tags,
+    predictions/<tag>_relaxed.pdb)."""
+    tag = f"{protein}_demo_tri_{tri_residue_idx}"
+    attn_map_dir = attn_map_dir or os.path.join(output_dir, f"attention_files_{tag}")
+    image_dir = os.path.join(output_dir, f"attention_images_{tag}")
+    pdb_file = os.path.join(output_dir, "predictions", f"{protein}_1_{config_preset}_relaxed.pdb")
+    return attn_map_dir, image_dir, pdb_file
+
+
+def run_visualizations(fasta_file, protein, attn_map_dir, image_dir, pdb_file,
+                       layer_idx, top_k, tri_residue_idx):
+    from visualize_attention_general_utils import (
+        render_pdb_to_image,
+        generate_combined_attention_panels,
+    )
+    from visualize_attention_3d_demo_utils import plot_pymol_attention_heads
+    from visualize_attention_arc_diagram_demo_utils import (
+        generate_arc_diagrams,
+        parse_fasta_sequence,
+    )
+
+    residue_sequence = parse_fasta_sequence(fasta_file)
+    msa_dir = os.path.join(image_dir, "msa_row_attention_plots")
+    tri_dir = os.path.join(image_dir, "tri_start_attention_plots")
+    combined_dir = os.path.join(image_dir, "combined")
+
+    logging.info("rendering predicted structure...")
+    render_pdb_to_image(pdb_file, image_dir, f"predicted_structure_{protein}_tri_{tri_residue_idx}.png")
+
+    logging.info("rendering 3D attention heads...")
+    plot_pymol_attention_heads(pdb_file=pdb_file, attention_dir=attn_map_dir, output_dir=msa_dir,
+                               protein=protein, attention_type="msa_row",
+                               top_k=top_k, layer_idx=layer_idx)
+    plot_pymol_attention_heads(pdb_file=pdb_file, attention_dir=attn_map_dir, output_dir=tri_dir,
+                               protein=protein, attention_type="triangle_start",
+                               residue_indices=[tri_residue_idx], top_k=top_k, layer_idx=layer_idx)
+
+    logging.info("rendering arc diagrams...")
+    generate_arc_diagrams(attention_dir=attn_map_dir, residue_sequence=residue_sequence,
+                          output_dir=msa_dir, protein=protein, attention_type="msa_row",
+                          top_k=top_k, layer_idx=layer_idx)
+    generate_arc_diagrams(attention_dir=attn_map_dir, residue_sequence=residue_sequence,
+                          output_dir=tri_dir, protein=protein, attention_type="triangle_start",
+                          residue_indices=[tri_residue_idx], top_k=top_k, layer_idx=layer_idx)
+
+    logging.info("assembling combined panels...")
+    generate_combined_attention_panels(attention_type="msa_row", protein=protein, layer_idx=layer_idx,
+                                       output_dir_3d=msa_dir, output_dir_arc=msa_dir,
+                                       combined_output_dir=combined_dir)
+    generate_combined_attention_panels(attention_type="triangle_start", protein=protein, layer_idx=layer_idx,
+                                       output_dir_3d=tri_dir, output_dir_arc=tri_dir,
+                                       combined_output_dir=combined_dir, residue_indices=[tri_residue_idx])
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--fasta-file", required=True, help="Single-sequence FASTA used for the fold.")
+    parser.add_argument("--output-dir", required=True,
+                        help="The fold's output directory (holds predictions/ and the attention maps).")
+    parser.add_argument("--protein", required=True, help="Protein tag used to name outputs (e.g. 6KWC).")
+    parser.add_argument("--tri-residue-idx", type=int, default=18,
+                        help="Residue index for triangle-start focus (default 18).")
+    parser.add_argument("--layer-idx", type=int, default=47, help="Model layer to visualize (default 47).")
+    parser.add_argument("--top-k", type=int, default=50, help="Max attention edges per head (default 50).")
+    parser.add_argument("--config-preset", default="model_1_ptm",
+                        help="Config preset used for the fold (names the relaxed PDB).")
+    parser.add_argument("--attn-map-dir", default=None,
+                        help="Override the attention-map directory (auto-derived otherwise).")
+    parser.add_argument("--log-level", default="INFO", choices=["DEBUG", "INFO", "WARNING", "ERROR"])
+    args = parser.parse_args()
+
+    logging.basicConfig(level=getattr(logging, args.log_level),
+                        format="%(asctime)s %(levelname)s %(message)s")
+
+    attn_map_dir, image_dir, pdb_file = derived_paths(
+        args.output_dir, args.protein, args.tri_residue_idx, args.config_preset, args.attn_map_dir)
+
+    for label, path in [("fasta file", args.fasta_file), ("attention map directory", attn_map_dir),
+                        ("relaxed PDB", pdb_file)]:
+        if not os.path.exists(path):
+            parser.error(f"{label} not found: {path} (run the fold with --demo_attn first)")
+
+    logging.info(f"protein:      {args.protein}")
+    logging.info(f"attn_map_dir: {attn_map_dir}")
+    logging.info(f"image_dir:    {image_dir}")
+    run_visualizations(args.fasta_file, args.protein, attn_map_dir, image_dir, pdb_file,
+                       args.layer_idx, args.top_k, args.tri_residue_idx)
+    logging.info("done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/visualize_attention_general_utils.py
+++ b/visualize_attention_general_utils.py
@@ -1,4 +1,5 @@
 import os
+import numpy as np
 from pymol import cmd
 import matplotlib.pyplot as plt
 import matplotlib.image as mpimg
@@ -126,3 +127,80 @@ def generate_combined_attention_panels(
                         combine_3d_and_arc_images(struct_path, arc_path, out_path, fig_title=generate_title)
                     else:
                         print(f"[Skipped] Missing image for {prefix}")
+
+
+def compute_ca_distance_matrix(pdb_file, chain_id="A"):
+    """Pairwise Cα–Cα distance matrix (Å) for one chain of a predicted structure."""
+    from Bio import PDB
+
+    structure = PDB.PDBParser(QUIET=True).get_structure("protein", pdb_file)
+    coords = np.array([
+        residue["CA"].get_vector().get_array()
+        for model_ in structure
+        for chain in model_ if chain.id == chain_id
+        for residue in chain
+        if PDB.is_aa(residue, standard=True) and "CA" in residue
+    ])
+    diff = coords[:, None, :] - coords[None, :, :]
+    return np.sqrt((diff ** 2).sum(axis=-1))
+
+
+def render_contact_attention_panel(
+    pdb_file,
+    output_path,
+    attention_map=None,
+    chain_id="A",
+    contact_threshold=8.0,
+    region=None,
+    title=None,
+    show_plot=True,
+):
+    """Cα distance map, contact map, and — when an NxN ``attention_map`` is supplied —
+    an attention overlay with contacts marked, saved as one figure.
+
+    The caller passes an already-aggregated attention map (mean over heads/layers)
+    rather than re-running inference here. ``region`` is an optional ``(start, end)``
+    residue window. Lifted from the contact-map work in closed PR #75.
+    """
+    dist = compute_ca_distance_matrix(pdb_file, chain_id)
+    n = dist.shape[0]
+    r0, r1 = region if region else (0, n)
+    extent = [r0 - 0.5, r1 - 0.5, r0 - 0.5, r1 - 0.5]
+    dist_r = dist[r0:r1, r0:r1]
+
+    n_panels = 3 if attention_map is not None else 2
+    fig, axes = plt.subplots(1, n_panels, figsize=(7 * n_panels, 6))
+
+    im0 = axes[0].imshow(dist_r, cmap="viridis_r", origin="lower", extent=extent)
+    axes[0].set_title("Cα distance map")
+    plt.colorbar(im0, ax=axes[0], label="Distance (Å)")
+
+    axes[1].imshow(dist_r < contact_threshold, cmap="Greys", origin="lower", extent=extent)
+    axes[1].set_title(f"Contact map (Cα < {contact_threshold} Å)")
+
+    if attention_map is not None:
+        attn = np.asarray(attention_map)
+        if attn.shape != (n, n):
+            raise ValueError(f"attention_map is {attn.shape}, expected ({n}, {n}) to match the structure")
+        attn_r = ((attn + attn.T) / 2)[r0:r1, r0:r1]
+        im2 = axes[2].imshow(attn_r, cmap="hot_r", origin="lower", extent=extent)
+        ci, cj = np.where(dist_r < contact_threshold)
+        axes[2].scatter(cj + r0, ci + r0, s=0.3, c="cyan", alpha=0.5, label=f"Cα < {contact_threshold} Å")
+        axes[2].set_title("Attention vs. contacts")
+        axes[2].legend(markerscale=10, fontsize=8)
+        plt.colorbar(im2, ax=axes[2], label="Attention weight")
+
+    for ax in axes:
+        ax.set_xlabel("Residue index")
+        ax.set_ylabel("Residue index")
+    if title:
+        fig.suptitle(title, fontsize=13, fontweight="bold")
+    plt.tight_layout()
+
+    os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
+    plt.savefig(output_path, dpi=150, bbox_inches="tight")
+    if show_plot:
+        plt.show()
+    else:
+        plt.close(fig)
+    print(f"[Saved] Contact/attention panel to {output_path}")


### PR DESCRIPTION
Carries forward the genuinely-new, reusable pieces from two PRs closed during the
backlog triage (#67, #75), separated from the scaffolding that made them unmergeable
as-is.

## run/viz.py (from #67)

A runnable post-fold visualization pass: 3D PyMOL head renders, arc diagrams, and
combined panels, produced by orchestrating the existing `visualize_*` modules over a
fold's attention maps and relaxed PDB. This turns notebook-only helpers into a single
command.

Only the visualization half of #67 is lifted — its `run_inference` half duplicated
`run/fold.sh` and the Rust command planner, so it was dropped. The script validates
its inputs and derives paths from the `--demo_attn` output layout
(`attention_files_<tag>/`, `predictions/<tag>_relaxed.pdb`).

## Contact/attention panel (from #75)

`compute_ca_distance_matrix` and `render_contact_attention_panel` in
`visualize_attention_general_utils.py`: a Cα distance map, a contact map, and — when an
aggregated NxN attention map is supplied — an attention-vs-contacts overlay, in one
figure. Nothing on main computed a contact map before this. The caller supplies the
attention map rather than re-running inference (the original PR's 300+ lines of model
loading and forward hooks re-derived attention capture that already ships via
`run_pretrained_openfold.py --demo_attn`, and were dropped).

## environment.yml

Add `matplotlib-base` and `pymol-open-source` — the `visualize_*` modules import both,
but the environment never declared them, so the visualization path could not run on a
fresh install.

## Test plan

- `python -m py_compile run/viz.py visualize_attention_general_utils.py` — clean.
- `compute_ca_distance_matrix` and `render_contact_attention_panel` verified on a
  synthetic 5-residue structure: correct distances, symmetry, zero diagonal, both the
  2-panel and 3-panel figures render, and a mismatched attention map raises.
- `run/viz.py` calls only functions that already exist on main, with matching
  signatures; a full render needs a GPU-produced fold plus PyMOL and was not run here.

Credit to the original authors of #67 and #75.
