### PR TITLE
Add --save_full_attn: dense attention .npz capture (from #79)

### DIFF
--- a/openfold/model/evoformer.py
+++ b/openfold/model/evoformer.py
@@ -497,6 +497,51 @@ def save_attention_topk(attention_dict, save_dir, layer_name, layer_idx, attn_ty
     print(f"[Done] Saved top {top_k} entries for {attn_type} to {output_path}")
 
 
+def save_attention_full(attention_dict, save_dir, layer_name, layer_idx, attn_type, triangle_residue_idx):
+    """
+    Save the full attention matrices for MSA Row and Triangle Start attention maps.
+
+    Args:
+        attention_dict (dict): Dictionary holding recent attention maps.
+        save_dir (str): Directory to save output files.
+        layer_name (str): Full name of the layer.
+        layer_idx (int): Layer number.
+        attn_type (str): Either "msa_row_attn" or "triangle_start_attn".
+    """
+
+    if layer_name not in attention_dict:
+        print(f"[Warning] Layer {layer_name} not found in recent attention.")
+        return
+
+    attn_array = attention_dict[layer_name]
+
+    if isinstance(attn_array, list):
+        attn_array = attn_array[0] if len(attn_array) == 1 else np.concatenate(attn_array, axis=0)
+
+    if attn_type == "msa_row_attn":
+        attn_array = attn_array[0]  # Shape: (N, S, S)
+    elif attn_type == "triangle_start_attn":
+        if triangle_residue_idx is None:
+            print(f"[Warning] Triangle residue index not provided. Using average of all residues.")
+            attn_array = np.mean(attn_array, axis=0)
+            triangle_residue_idx = 'avg'
+        else:
+            attn_array = attn_array[triangle_residue_idx]
+            triangle_residue_idx = str(triangle_residue_idx)
+    else:
+        raise ValueError(f"Unknown attention type: {attn_type}")
+
+    os.makedirs(save_dir, exist_ok=True)
+
+    if attn_type == "msa_row_attn":
+        output_path = os.path.join(save_dir, f"{attn_type}_layer{layer_idx}.npz")
+    elif attn_type == "triangle_start_attn":
+        output_path = os.path.join(save_dir, f"{attn_type}_layer{layer_idx}_residue_idx_{triangle_residue_idx}.npz")
+
+    np.savez_compressed(output_path, attn=attn_array)
+    print(f"[Done] Saved full attention for {attn_type} to {output_path}")
+
+
 def save_all_topk_from_recent_attention(save_dir, triangle_residue_idx, top_k=500):
     """
     Scan ATTENTION_METADATA.recent_attention and save top-K attention maps for MSA and Triangle.
@@ -533,6 +578,41 @@ def save_all_topk_from_recent_attention(save_dir, triangle_residue_idx, top_k=50
                 attn_type=attn_type,
                 triangle_residue_idx=triangle_residue_idx,
                 top_k=top_k
+            )
+
+
+def save_all_full_from_recent_attention(save_dir, triangle_residue_idx):
+    """
+    Scan ATTENTION_METADATA.recent_attention and save dense attention arrays for MSA and Triangle.
+
+    Args:
+        save_dir (str): Where to store the npz files.
+        triangle_residue_idx (int): Residue index for triangle start/end attention.
+    """
+    os.makedirs(save_dir, exist_ok=True)
+
+    for k, v in ATTENTION_METADATA.recent_attention.items():
+        attn_type, layer_idx = parse_attention_metadata_key(k)
+
+        if attn_type is not None and layer_idx >= 0:
+            if isinstance(v, list) and isinstance(v[0], np.ndarray):
+                try:
+                    v_concat = v[0] if len(v) == 1 else np.concatenate(v, axis=0)
+                except Exception as e:
+                    print(f"[WARNING] Could not concatenate attention for {k}: {e}")
+                    continue
+            else:
+                v_concat = v
+
+            temp_dict = {k: v_concat}
+
+            save_attention_full(
+                attention_dict=temp_dict,
+                save_dir=save_dir,
+                layer_name=k,
+                layer_idx=layer_idx,
+                attn_type=attn_type,
+                triangle_residue_idx=triangle_residue_idx,
             )
 
 
@@ -726,7 +806,10 @@ class EvoformerBlock(MSABlock):
             # compute top-k and save to text file for demo
             if self.attention_config.get("demo_attn", False) and hasattr(ATTENTION_METADATA, "recent_attention"):
                 triangle_residue_idx = self.attention_config.get("triangle_residue_idx", None)
-                save_all_topk_from_recent_attention(self.attn_map_dir, triangle_residue_idx, top_k=500)
+                top_k = self.attention_config.get("top_k", 500)
+                save_all_topk_from_recent_attention(self.attn_map_dir, triangle_residue_idx, top_k=top_k)
+                if self.attention_config.get("save_full_attn", False):
+                    save_all_full_from_recent_attention(self.attn_map_dir, triangle_residue_idx)
                 # Clear after use to free memory
                 ATTENTION_METADATA.recent_attention.clear()
         return m, z

--- a/openfold/model/model.py
+++ b/openfold/model/model.py
@@ -90,6 +90,8 @@ class AlphaFold(nn.Module):
         attention_config = {
             "demo_attn": config.attention_config.get("demo_attn", False),
             "triangle_residue_idx": config.attention_config.get("triangle_residue_idx"),
+            "top_k": config.attention_config.get("top_k", 500),
+            "save_full_attn": config.attention_config.get("save_full_attn", False),
         }
 
         # Main trunk + structure module

--- a/run_pretrained_openfold.py
+++ b/run_pretrained_openfold.py
@@ -303,6 +303,7 @@ def main(args):
     config.num_recycles_save = args.num_recycles_save
     attention_config = {
                 "demo_attn": args.demo_attn,
+                "save_full_attn": args.save_full_attn,
                 "triangle_residue_idx": args.triangle_residue_idx,
         }
     config.attention_config = attention_config
@@ -524,6 +525,10 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--demo_attn", action='store_true', default=False
+    )
+    parser.add_argument(
+        "--save_full_attn", action='store_true', default=False,
+        help="Save dense attention arrays (.npz) alongside the top-K text files, for full-matrix visualization."
     )
     parser.add_argument(
         "--triangle_residue_idx", default=None, type=int  # for demo visualizations we need to select a residue idx


### PR DESCRIPTION
Salvages the attention-producer half of #79. Adds `run_pretrained_openfold.py
--save_full_attn`, which writes the dense attention matrices (numpy `.npz`) alongside
the existing top-K text files. Downstream visualization and archiving then have the
full matrix instead of a sparse top-K dump.

## What's included

- `openfold/model/evoformer.py`: `save_attention_full` and
  `save_all_full_from_recent_attention` save the full MSA-row and triangle-start
  attention as compressed `.npz`. The `--demo_attn` hook calls them when
  `save_full_attn` is set, and now reads `top_k` from the attention config rather than
  hardcoding 500.
- `openfold/model/model.py`, `run_pretrained_openfold.py`: thread `save_full_attn`
  (and `top_k`) through the attention config.

Opt-in and off by default — a dense dump is large, so it stays alongside, not
replacing, the top-K text output.

## What's intentionally left out of #79

The 632-line Plotly heatmap module, the Flask web app, and the re-serialized notebook.
`web_app/templates/index.html` already renders per-head attention in the browser, and
#79's diff to it deleted `redrawHeatmap` — a function the app calls — which fails
`node --check` and would break the viewer. The `primitives.py` flash-attn load guard
in that branch is a separate concern and was left for its own change.

## Test plan

- `python -m py_compile` on all three files — clean.
- `save_attention_full` verified on synthetic attention tensors: MSA-row selects
  `[0]`, triangle-start selects `[idx]` (and averages over residues with the `avg`
  filename when no index is given), list inputs concatenate, a missing layer warns
  without crashing, and every `.npz` round-trips to the expected array.
- A full model run (the hook firing during inference) needs a GPU and was not run here.

Credit to the author of #79.
