### PR TITLE
Consolidate attention-file parsing into one module (from #72)

### DIFF
--- a/tests/test_visualize_attention_data.py
+++ b/tests/test_visualize_attention_data.py
@@ -1,0 +1,50 @@
+import os
+import tempfile
+import unittest
+
+from visualize_attention_data import (
+    get_attention_file_path,
+    load_attention_map,
+    parse_fasta_sequence,
+)
+
+
+class TestVisualizeAttentionData(unittest.TestCase):
+    def test_load_attention_map_groups_sorts_and_filters_heads(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "msa_row_attn_layer47.txt")
+            with open(path, "w") as f:
+                f.write("layer 47 head 0\n")
+                f.write("2 3 0.1\n")
+                f.write("0 1 0.9\n")
+                f.write("layer 47 head 1\n")
+                f.write("4 5 0.4\n")
+                f.write("6 7 0.2\n")
+
+            heads = load_attention_map(path, top_k=1)
+
+        self.assertEqual(heads, {0: [(0, 1, 0.9)], 1: [(4, 5, 0.4)]})
+
+    def test_get_attention_file_path_uses_expected_names(self):
+        self.assertEqual(
+            get_attention_file_path("/tmp/attn", "msa_row", 47),
+            "/tmp/attn/msa_row_attn_layer47.txt",
+        )
+        self.assertEqual(
+            get_attention_file_path("/tmp/attn", "triangle_start", 47, residue_idx=18),
+            "/tmp/attn/triangle_start_attn_layer47_residue_idx_18.txt",
+        )
+
+    def test_parse_fasta_sequence_joins_sequence_lines(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "protein.fasta")
+            with open(path, "w") as f:
+                f.write(">protein\n")
+                f.write("ACD\n")
+                f.write("EFG\n")
+
+            self.assertEqual(parse_fasta_sequence(path), "ACDEFG")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/visualize_attention_3d_demo_utils.py
+++ b/visualize_attention_3d_demo_utils.py
@@ -10,39 +10,11 @@ import matplotlib.pyplot as plt
 import matplotlib.image as mpimg
 import os
 
+from visualize_attention_data import get_attention_file_path, load_attention_map
+
 
 # ========== Attention File I/O ==========
-def load_all_heads(connections_file, top_k=None):
-    """
-    Loads all heads' connections from a combined text file.
-    Returns a dict mapping head_index -> list of (res1, res2, weight).
-    """
-    heads = {}
-    current_head = None
-
-    with open(connections_file, 'r') as f:
-        for line in f:
-            line = line.strip()
-            if not line:
-                continue
-            if line.lower().startswith('layer'):
-                # New head section
-                parts = line.replace(',', '').split()
-                head_idx = int(parts[-1])
-                current_head = head_idx
-                heads[current_head] = []
-            else:
-                # Residue-residue-weight line
-                res1, res2, weight = map(float, line.split())
-                heads[current_head].append((int(res1), int(res2), weight))
-
-    # Sort each head's connections
-    for head_idx, conns in heads.items():
-        conns.sort(key=lambda x: x[2], reverse=True)
-        if top_k is not None:
-            heads[head_idx] = conns[:top_k]
-
-    return heads
+load_all_heads = load_attention_map
 
 
 def load_connections(connections_file, top_k=None):
@@ -297,8 +269,8 @@ def plot_pymol_attention_heads(
     os.makedirs(output_dir, exist_ok=True)
 
     if attention_type == "msa_row":
-        msa_file = os.path.join(attention_dir, f"msa_row_attn_layer{layer_idx}.txt")
-        msa_heads = load_all_heads(msa_file, top_k=top_k)
+        msa_file = get_attention_file_path(attention_dir, attention_type, layer_idx)
+        msa_heads = load_attention_map(msa_file, top_k=top_k)
 
         image_paths = []
         for head_idx, connections in msa_heads.items():
@@ -316,12 +288,14 @@ def plot_pymol_attention_heads(
         assert residue_indices is not None, "Must supply residue_indices for triangle attention"
 
         for res_idx in residue_indices:
-            tri_file = os.path.join(attention_dir, f"triangle_start_attn_layer{layer_idx}_residue_idx_{res_idx}.txt")
+            tri_file = get_attention_file_path(
+                attention_dir, attention_type, layer_idx, residue_idx=res_idx
+            )
             if not os.path.exists(tri_file):
                 print(f"[Warning] Missing attention file for residue {res_idx}")
                 continue
 
-            tri_heads = load_all_heads(tri_file, top_k=top_k)
+            tri_heads = load_attention_map(tri_file, top_k=top_k)
             res_pngs = []
             for head_idx, connections in tri_heads.items():
                 output_png = os.path.join(output_dir, f"tri_start_residue_{res_idx}_head_{head_idx}_layer_{layer_idx}_{protein}.png")

--- a/visualize_attention_arc_diagram_demo_utils.py
+++ b/visualize_attention_arc_diagram_demo_utils.py
@@ -2,43 +2,14 @@ import os
 import numpy as np
 import matplotlib.pyplot as plt
 
+from visualize_attention_data import (
+    get_attention_file_path,
+    load_attention_map,
+    parse_fasta_sequence,
+)
 
-# ========== Input Parsing ==========
-def load_all_heads(connections_file, top_k=None):
-    heads = {}
-    current_head = None
-    with open(connections_file, 'r') as f:
-        for line in f:
-            line = line.strip()
-            if not line:
-                continue
-            if line.lower().startswith('layer'):
-                parts = line.replace(',', '').split()
-                head_idx = int(parts[-1])
-                current_head = head_idx
-                heads[current_head] = []
-            else:
-                res1, res2, weight = map(float, line.split())
-                heads[current_head].append((int(res1), int(res2), weight))
-
-    for head_idx, conns in heads.items():
-        conns.sort(key=lambda x: x[2], reverse=True)
-        if top_k is not None:
-            heads[head_idx] = conns[:top_k]
-
-    return heads
-
-
-def parse_fasta_sequence(fasta_path):
-    """
-    Parse a single-entry FASTA file and return the sequence string.
-    """
-    with open(fasta_path, 'r') as f:
-        lines = f.readlines()
-    
-    seq_lines = [line.strip() for line in lines if not line.startswith('>')]
-    sequence = ''.join(seq_lines)
-    return sequence
+# Backward-compatible import path for notebooks/scripts that already use this file.
+load_all_heads = load_attention_map
 
 
 # ========== Arc Plotting ==========
@@ -116,8 +87,8 @@ def generate_arc_diagrams(
     os.makedirs(output_dir, exist_ok=True)
 
     if attention_type == "msa_row":
-        file_path = os.path.join(attention_dir, f"msa_row_attn_layer{layer_idx}.txt")
-        heads = load_all_heads(file_path, top_k=top_k)
+        file_path = get_attention_file_path(attention_dir, attention_type, layer_idx)
+        heads = load_attention_map(file_path, top_k=top_k)
         pngs = []
 
         for head_idx, connections in heads.items():
@@ -131,12 +102,14 @@ def generate_arc_diagrams(
         assert residue_indices is not None, "residue_indices required for triangle_start attention"
 
         for res_idx in residue_indices:
-            file_path = os.path.join(attention_dir, f"triangle_start_attn_layer{layer_idx}_residue_idx_{res_idx}.txt")
+            file_path = get_attention_file_path(
+                attention_dir, attention_type, layer_idx, residue_idx=res_idx
+            )
             if not os.path.exists(file_path):
                 print(f"[Warning] Missing file for residue {res_idx}")
                 continue
 
-            heads = load_all_heads(file_path, top_k=top_k)
+            heads = load_attention_map(file_path, top_k=top_k)
             pngs = []
 
             for head_idx, connections in heads.items():

--- a/visualize_attention_data.py
+++ b/visualize_attention_data.py
@@ -1,0 +1,100 @@
+"""
+Shared attention-map loading helpers for visualization modules.
+
+All visualization types should consume the parsed ``heads`` structure from this
+module instead of re-parsing attention text files independently.
+"""
+
+import os
+from typing import Dict, List, Optional, Tuple
+
+
+AttentionEdge = Tuple[int, int, float]
+AttentionHeads = Dict[int, List[AttentionEdge]]
+
+
+def filter_top_k_edges(heads: AttentionHeads, top_k: Optional[int] = None) -> AttentionHeads:
+    """Sort each head by descending weight and optionally keep only top-k edges."""
+    filtered = {}
+    for head_idx, conns in heads.items():
+        sorted_conns = sorted(conns, key=lambda x: x[2], reverse=True)
+        filtered[head_idx] = sorted_conns[:top_k] if top_k is not None else sorted_conns
+    return filtered
+
+
+def load_attention_map(connections_file: str, top_k: Optional[int] = None) -> AttentionHeads:
+    """
+    Load a combined attention text file into ``head_idx -> [(res_i, res_j, weight)]``.
+
+    Expected format:
+        layer 47 head 0
+        12 39 0.41
+        8 14 0.32
+        layer 47 head 1
+        ...
+    """
+    heads = {}
+    current_head = None
+
+    with open(connections_file, "r") as f:
+        for line_number, line in enumerate(f, start=1):
+            line = line.strip()
+            if not line:
+                continue
+
+            if line.lower().startswith("layer"):
+                parts = line.replace(",", "").split()
+                try:
+                    current_head = int(parts[-1])
+                except (IndexError, ValueError) as exc:
+                    raise ValueError(
+                        f"Could not parse head index on line {line_number}: {line}"
+                    ) from exc
+                heads[current_head] = []
+                continue
+
+            if current_head is None:
+                raise ValueError(
+                    f"Found attention edge before any head header on line {line_number}: {line}"
+                )
+
+            try:
+                res1, res2, weight = map(float, line.split())
+            except ValueError as exc:
+                raise ValueError(
+                    f"Could not parse attention edge on line {line_number}: {line}"
+                ) from exc
+            heads[current_head].append((int(res1), int(res2), weight))
+
+    return filter_top_k_edges(heads, top_k=top_k)
+
+
+def get_attention_file_path(
+    attention_dir: str,
+    attention_type: str,
+    layer_idx: int,
+    residue_idx: Optional[int] = None,
+) -> str:
+    """Return the canonical attention text-file path for a visualization request."""
+    if attention_type == "msa_row":
+        return os.path.join(attention_dir, f"msa_row_attn_layer{layer_idx}.txt")
+
+    if attention_type == "triangle_start":
+        if residue_idx is None:
+            raise ValueError("residue_idx is required for triangle_start attention")
+        return os.path.join(
+            attention_dir,
+            f"triangle_start_attn_layer{layer_idx}_residue_idx_{residue_idx}.txt",
+        )
+
+    raise ValueError(f"Unsupported attention_type: {attention_type}")
+
+
+def parse_fasta_sequence(fasta_path: str) -> str:
+    """Parse a single-entry FASTA file and return the sequence string."""
+    with open(fasta_path, "r") as f:
+        return "".join(line.strip() for line in f if not line.startswith(">"))
+
+
+# Backward-compatible name used by existing notebooks and scripts.
+load_all_heads = load_attention_map


### PR DESCRIPTION
Carries forward the refactor commit (`3ca68e4`) from closed PR #72, without the
heatmap/network and chord-diagram work stacked around it.

The attention top-K text parser was duplicated in four places across the
visualization modules. This extracts it into a single `visualize_attention_data`
module and points the 3D and arc-diagram utilities at it.

- `visualize_attention_data.py`: `get_attention_file_path` / `load_attention_map` —
  one parser for the attention `.txt` format, with unit tests.
- `visualize_attention_3d_demo_utils.py`,
  `visualize_attention_arc_diagram_demo_utils.py`: drop their private copies and
  import from the shared module (net −75 lines across the two).

## What's left out of #72

The `bb02f23` heatmap/network modules and the `5fc22ad` chord diagram (a polar-coordinate
re-plot of the existing arc diagram), plus that PR's re-serialized `viz_attention_demo*`
notebooks, whose reformatting conflicted with every other open attention PR.

## Test plan

- `python -m py_compile` on all four files — clean.
- `tests/test_visualize_attention_data.py` — 3 pass (the shared module imports only the
  standard library, so the parser is tested directly).
- The refactored 3D/arc modules import PyMOL and were syntax-checked but not run here.

Credit to the author of #72.
