### PR TITLE
Add ESMFold backend (amputated from #44)

### DIFF
--- a/docs/esmfold.md
+++ b/docs/esmfold.md
@@ -1,0 +1,139 @@
+# ESMFold backend
+
+The ESMFold backend runs [ESMFold](https://github.com/facebookresearch/esm) via **HuggingFace Transformers** (`EsmForProteinFolding`) and writes **VizFold-compatible** trace archives: structure + optional attention and activation tensors with metadata. Using Transformers avoids the OpenFold build dependency (no CUDA compilation on cluster).
+
+## Install
+
+**Option A – conda (recommended)**  
+Use `environment-mac.yml` (Mac) or `environment.yml` (Linux):
+
+```bash
+conda env create -f environment-mac.yml   # or environment.yml on Linux
+conda activate openfold-env
+```
+
+**Option B – pip (after PyTorch is installed)**  
+From repo root:
+
+```bash
+pip install -r requirements-esmfold.txt
+# Optional: pip install -e .  for vizfold package
+```
+
+`requirements-esmfold.txt` pins `transformers>=4.36.0`. PyTorch must be installed separately.
+
+## Run locally
+
+**Structure only (fast):**
+
+```bash
+python run_pretrained_esmf.py \
+  --fasta examples/monomer/fasta_dir_6KWC/6KWC.fasta \
+  --out outputs/esmf_6KWC \
+  --trace_mode none
+```
+
+**Structure + attention + activations:**
+
+```bash
+python run_pretrained_esmf.py \
+  --fasta examples/monomer/fasta_dir_6KWC/6KWC.fasta \
+  --out outputs/esmf_6KWC \
+  --model facebook/esmfold_v1 \
+  --device cuda \
+  --trace_mode attention+activations \
+  --layers all \
+  --save_fp16
+```
+
+**Limit layers/heads (saves memory and disk):**
+
+```bash
+python run_pretrained_esmf.py \
+  --fasta examples/monomer/fasta_dir_6KWC/6KWC.fasta \
+  --out outputs/esmf_6KWC \
+  --trace_mode attention \
+  --layers 0,1,2,5 \
+  --heads 0,1,2
+```
+
+**Structure + IPA attention + per-recycle backbone (structure module traces):**
+
+```bash
+python run_pretrained_esmf.py \
+  --fasta examples/monomer/fasta_dir_6KWC/6KWC.fasta \
+  --out outputs/esmf_6KWC \
+  --trace_mode attention+activations \
+  --structure_traces \
+  --save_fp16
+```
+
+## Output layout
+
+After a run, `--out` contains:
+
+```
+outputs/esmf_6KWC/
+  meta.json              # Run metadata (backend, model, shapes, seed, etc.)
+  structure/
+    predicted.pdb        # Predicted structure (PDB)
+    predicted.pt          # Optional coordinate tensor
+  trace/
+    attention/
+      layer_000.pt
+      layer_001.pt
+      ...
+    activations/
+      layer_000.pt
+      ...
+    trunk/                # Evoformer intermediates (per-block + final)
+      block_000_seq.pt    # [L, C_s]  per-block sequence state (last recycle)
+      block_000_pair.pt   # [L, L, C_z]  per-block pair state (last recycle)
+      ...
+      s_s.pt              # [L, C_s]  final trunk single representations
+      s_z.pt              # [L, L, C_z]  final trunk pair representations
+    structure_module/     # Only with --structure_traces
+      ipa_attention/
+        recycle_00_block_00.pt   # IPA attention [H, N, N]
+        ...
+      backbone/
+        recycle_00_positions.pt  # Per-recycle backbone coords
+        recycle_00_states.pt     # Per-recycle single representations
+        ...
+    summary.json          # Per-layer attention entropy, sparsity, norms
+    index.json            # Maps layer/head to path, dtype, shape
+  attention/
+    msa_row_attn_layer0.txt   # VizFold text format (top-k per head)
+    ...
+  logs.txt               # Log lines from the run
+```
+
+## meta.json
+
+Includes:
+
+- `backend`, `model_name`, `date_time`, `device`, `dtype`
+- `sequence_length`, `input_fasta_hash`, `input_fasta_path`
+- `layer_count`, `head_count`, `trace_mode`, `tensor_format` (fp16/fp32)
+- `trace_formats`: which output formats were produced (`pt`, `txt`)
+- `shapes_recorded`: per-file shapes for attention, activations, trunk, and structure module
+- `seed`, `deterministic` (if set)
+- `repo_commit` (if run from a git repo)
+
+## Reproducibility
+
+- `--seed 42` fixes the PyTorch RNG.
+- `--deterministic` sets CuDNN deterministic mode (can be slower).
+
+Both are recorded in `meta.json`.
+
+## Long sequences
+
+Attention storage is O(N²). For long proteins the script warns and suggests:
+
+- `--trace_mode activations` (no attention), or
+- `--layers 0,1,2` to save only a few layers.
+
+## Running on ICE (SLURM)
+
+See [hpc_ice.md](hpc_ice.md) for batch submission, environment setup, and a short smoke test.

--- a/docs/esmfold_backend_repro.md
+++ b/docs/esmfold_backend_repro.md
@@ -1,0 +1,181 @@
+# ESMFold Backend Reproducibility Guide
+
+This document describes how to run the HuggingFace-based ESMFold backend with
+VizFold-compatible trace export using the shared `feature/esmfold-backend`
+integration branch.
+
+It provides instructions for verifying structure inference, attention extraction,
+activation extraction, and expected archive outputs locally and on the ICE cluster.
+
+## Environment Setup (Local)
+
+Create a virtual environment:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+```
+
+Install dependencies:
+
+```bash
+pip install -r requirements-esmfold.txt
+pip install torch
+pip install -e . --no-build-isolation
+```
+
+## Structure-Only Inference Test
+
+Run:
+
+```bash
+python run_pretrained_esmf.py \
+  --fasta examples/monomer/fasta_dir_6KWC/6KWC.fasta \
+  --out outputs/test_run \
+  --trace_mode none \
+  --device cpu
+```
+
+Expected outputs:
+
+- `outputs/test_run/meta.json`
+- `outputs/test_run/structure/predicted.pdb`
+
+Successful execution confirms:
+
+- model loads correctly
+- inference pipeline runs end-to-end
+- archive metadata generation works
+
+## Trace Extraction Test (Attention + Activations)
+
+Run:
+
+```bash
+python run_pretrained_esmf.py \
+  --fasta examples/monomer/fasta_dir_6KWC/6KWC.fasta \
+  --out outputs/test_trace \
+  --trace_mode attention+activations \
+  --device cpu
+```
+
+Expected outputs:
+
+- `outputs/test_trace/meta.json`
+- `outputs/test_trace/structure/predicted.pdb`
+- `outputs/test_trace/trace/`
+
+Trace directory should contain:
+
+- `trace/attention/`
+- `trace/activations/`
+
+## Verified Tensor Outputs (Local Validation)
+
+Successful execution produces:
+
+- 36 attention tensors
+- 36 activation tensors
+- 72 total `.pt` trace tensors
+
+Attention tensors follow expected shape:
+
+`[B, H, N, N]`
+
+where:
+
+- B = batch size
+- H = number of attention heads
+- N = sequence length (after special-token slicing)
+
+This confirms compatibility with VizFold's visualization pipeline.
+
+## Archive Structure Validation
+
+Expected archive layout:
+
+```
+outputs/test_trace/
+├── meta.json
+├── structure/
+│   └── predicted.pdb
+└── trace/
+    ├── attention/
+    └── activations/
+```
+
+This structure matches the OpenFold-compatible VizFold archive schema.
+
+## Running on ICE Cluster (PACE)
+
+Login:
+
+```bash
+ssh <gt_username>@login-ice.pace.gatech.edu
+```
+
+Navigate to the repository:
+
+```bash
+cd attention-viz-demo
+```
+
+Activate environment:
+
+```bash
+source .venv/bin/activate
+```
+
+Run structure inference:
+
+```bash
+python run_pretrained_esmf.py \
+  --fasta examples/monomer/fasta_dir_6KWC/6KWC.fasta \
+  --out outputs/test_run \
+  --trace_mode none \
+  --device cuda
+```
+
+Run trace extraction:
+
+```bash
+python run_pretrained_esmf.py \
+  --fasta examples/monomer/fasta_dir_6KWC/6KWC.fasta \
+  --out outputs/test_trace \
+  --trace_mode attention+activations \
+  --device cuda
+```
+
+Expected outputs:
+
+- `structure/predicted.pdb`
+- `meta.json`
+- `trace/attention/`
+- `trace/activations/`
+
+GPU execution confirms cluster compatibility for larger inference workloads.
+
+
+## Additional Intermediate Output Validation
+
+The latest shared `feature/esmfold-backend` branch now exports additional intermediate outputs beyond the original encoder attention and activation traces.
+
+Verified local outputs include:
+
+- 36 attention tensors in `trace/attention/`
+- 36 activation tensors in `trace/activations/`
+- ~98 Evoformer trunk intermediate tensors in `trace/trunk/`
+- 36 VizFold attention text files in `attention/`
+
+Expected tensor shapes include:
+
+- attention tensors: `[B, H, N, N]`
+- activation tensors: `[B, N, D]`
+- pair representations (`s_z`): `[N, N, D]`
+
+If recycling outputs are enabled, they are expected to appear under `trace/trunk/` with keys such as:
+
+- `recycle_*_s_s`
+- `recycle_*_s_z`
+
+If structure-module / IPA outputs are enabled, they should also be saved as `.pt` tensors in the trace archive and can be validated separately for expected attention dimensions.

--- a/docs/hpc_ice.md
+++ b/docs/hpc_ice.md
@@ -1,0 +1,105 @@
+# Running VizFold (ESMFold) on ICE
+
+This guide covers running the ESMFold backend and trace export on an ICE cluster via SLURM.
+
+## Prerequisites
+
+- Access to ICE with GPU nodes
+- Conda (or module environment) with PyTorch (CUDA), and `transformers` installed
+
+## Environment
+
+### Option A: Conda (simpler)
+
+```bash
+conda create -n vizfold python=3.10
+conda activate vizfold
+conda install pytorch pytorch-cuda=12.1 -c pytorch -c nvidia
+pip install transformers
+# From repo root:
+pip install -e .
+```
+
+### Option B: Container (if ICE supports Apptainer/Singularity)
+
+Use a image that includes PyTorch + fair-esm. Not required; mention in job script if available.
+
+## Interactive GPU session (debugging)
+
+Request an interactive GPU node:
+
+```bash
+salloc --gres=gpu:1 --cpus-per-task=8 --mem=48G --time=02:00:00
+```
+
+Then:
+
+```bash
+module load cuda   # or your site’s module
+conda activate vizfold
+cd /path/to/vizfold-foundation
+python -c "import torch; print(torch.cuda.is_available())"
+```
+
+## Submitting a batch job
+
+1. Set environment variables (or edit `scripts/hpc/ice/run_esmf_ice.slurm`):
+
+   - `FASTA` – path to input FASTA (single sequence)
+   - `OUTDIR` – where to write outputs (e.g. `outputs/esmf_6KWC`)
+   - `TRACE_MODE` – `none`, `attention`, `activations`, or `attention+activations`
+
+2. Submit:
+
+```bash
+export FASTA=examples/monomer/fasta_dir_6KWC/6KWC.fasta
+export OUTDIR=outputs/esmf_6KWC
+sbatch scripts/hpc/ice/run_esmf_ice.slurm
+```
+
+3. Monitor:
+
+```bash
+squeue -u $USER
+```
+
+4. Logs and outputs:
+
+- SLURM stdout/stderr: `outputs/logs/esmf_<jobid>.out` and `.err`
+- Run outputs: under `OUTDIR`: `meta.json`, `structure/`, `trace/`, `logs.txt`
+
+## Minimal smoke test (<5 minutes)
+
+To verify the job runs without using much GPU time:
+
+```bash
+# Create a tiny FASTA (e.g. 50 residues)
+echo -e ">tiny\nMKFLKFSLLTAVLLSVVFAFSSCGDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD" > /tmp/tiny.fasta
+export FASTA=/tmp/tiny.fasta
+export OUTDIR=outputs/esmf_smoke
+export TRACE_MODE=none
+sbatch scripts/hpc/ice/run_esmf_ice.slurm
+```
+
+Then run with trace:
+
+```bash
+export TRACE_MODE=attention
+# Optional: limit layers to speed up
+# (add --layers 0,1 to the script or run CLI manually)
+```
+
+## Common issues
+
+| Issue | What to check |
+|-------|----------------|
+| CUDA not found | Load correct `cuda` module; `nvidia-smi` on the node |
+| `torch` not seeing GPU | Install PyTorch with CUDA: `conda install pytorch pytorch-cuda=...` |
+| Missing packages | `pip install transformers`; run from repo root or `pip install -e .` |
+| Disk quota | Use `OUTDIR` on scratch or project space, not home if limited |
+| Job killed (OOM) | Increase `--mem` or use shorter sequence / `--trace_mode none` |
+
+## Partition and resources
+
+- Use your site’s GPU partition name in the script if different (e.g. `#SBATCH --partition=gpu`).
+- Adjust `--time`, `--mem`, and `--cpus-per-task` to match queue limits and job size.

--- a/requirements-esmfold.txt
+++ b/requirements-esmfold.txt
@@ -1,0 +1,4 @@
+# ESMFold backend (run_pretrained_esmf.py). Install after PyTorch.
+# Uses HuggingFace Transformers to avoid OpenFold build dependency.
+# Use: pip install torch && pip install -r requirements-esmfold.txt
+transformers>=4.36.0,<5.0.0

--- a/run_pretrained_esmf.py
+++ b/run_pretrained_esmf.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""
+ESMFold inference with VizFold-compatible trace export.
+
+Produces an archive under --out with:
+  meta.json, structure/, trace/attention/, trace/activations/, trace/index.json, logs.txt
+
+Example:
+  python run_pretrained_esmf.py \\
+    --fasta examples/monomer/fasta_dir_6KWC/6KWC.fasta \\
+    --out outputs/esmf_6KWC \\
+    --model facebook/esmfold_v1 \\
+    --device cuda \\
+    --trace_mode attention+activations \\
+    --layers all \\
+    --save_fp16
+"""
+import argparse
+import json
+import os
+import sys
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Run ESMFold and export VizFold-compatible traces.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--fasta",
+        type=str,
+        required=True,
+        help="Path to FASTA file (single sequence).",
+    )
+    parser.add_argument(
+        "--out",
+        type=str,
+        required=True,
+        help="Output directory (will be created).",
+    )
+    parser.add_argument(
+        "--model",
+        type=str,
+        default="facebook/esmfold_v1",
+        help="HuggingFace model id (e.g. facebook/esmfold_v1).",
+    )
+    parser.add_argument(
+        "--device",
+        type=str,
+        default=None,
+        help="Device: cuda, cuda:0, cpu. Default: cuda if available else cpu.",
+    )
+    parser.add_argument(
+        "--dtype",
+        type=str,
+        default="float32",
+        choices=["float32", "float16"],
+        help="Model dtype (float16 reduces VRAM but may lower accuracy).",
+    )
+    parser.add_argument(
+        "--trace_mode",
+        type=str,
+        default="attention+activations",
+        choices=["none", "attention", "activations", "attention+activations"],
+        help="What to extract: none (structure only), attention, activations, or both.",
+    )
+    parser.add_argument(
+        "--layers",
+        type=str,
+        default="all",
+        help="Layers to save: 'all' or '0,1,2' or '0:12'.",
+    )
+    parser.add_argument(
+        "--heads",
+        type=str,
+        default="all",
+        help="Heads to save: 'all' or '0,1,2'.",
+    )
+    parser.add_argument(
+        "--save_fp16",
+        action="store_true",
+        help="Save trace tensors in fp16 to reduce size.",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="Random seed for reproducibility.",
+    )
+    parser.add_argument(
+        "--deterministic",
+        action="store_true",
+        help="Use deterministic CuDNN (may reduce speed).",
+    )
+    parser.add_argument(
+        "--top_k",
+        type=int,
+        default=50,
+        help="Number of top attention values to save per head in VizFold text files.",
+    )
+    parser.add_argument(
+        "--structure_traces",
+        action="store_true",
+        help="Capture IPA attention weights and per-recycle backbone positions from the structure module.",
+    )
+    args = parser.parse_args()
+
+    if not os.path.isfile(args.fasta):
+        print(f"Error: FASTA not found: {args.fasta}", file=sys.stderr)
+        return 1
+
+    if args.device is None:
+        try:
+            import torch
+            args.device = "cuda" if torch.cuda.is_available() else "cpu"
+        except ImportError:
+            args.device = "cpu"
+
+    try:
+        from vizfold.backends.esmfold.inference import ESMFoldRunner
+    except ImportError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+    runner = ESMFoldRunner(
+        model_name=args.model,
+        device=args.device,
+        dtype=args.dtype,
+        seed=args.seed,
+        deterministic=args.deterministic,
+    )
+    result = runner.run(
+        fasta_path=args.fasta,
+        out_dir=args.out,
+        trace_mode=args.trace_mode,
+        layers=args.layers,
+        heads=args.heads,
+        save_fp16=args.save_fp16,
+        top_k=args.top_k,
+        structure_traces=args.structure_traces,
+    )
+    print(f"Done. Outputs in {args.out}")
+    print(f"  attention layers: {result.get('attention_layers', 0)}, "
+          f"activation layers: {result.get('activation_layers', 0)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/hpc/ice/run_esmf_ice.slurm
+++ b/scripts/hpc/ice/run_esmf_ice.slurm
@@ -1,0 +1,62 @@
+#!/bin/bash
+#SBATCH --job-name=esmf_vizfold
+#SBATCH --gres=gpu:1
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=48G
+#SBATCH --time=06:00:00
+#SBATCH --output=outputs/logs/esmf_%j.out
+#SBATCH --error=outputs/logs/esmf_%j.err
+#
+# ESMFold inference with VizFold trace export on ICE.
+# Usage:
+#   export FASTA=/path/to/seq.fasta OUTDIR=outputs/esmf_run
+#   sbatch run_esmf_ice.slurm
+# Or override on the command line:
+#   sbatch run_esmf_ice.slurm  (uses FASTA and OUTDIR from environment)
+#
+# For a quick smoke test (<5 min): use a short FASTA and --trace_mode none
+
+set -e
+
+# Defaults if not set
+FASTA="${FASTA:-examples/monomer/fasta_dir_6KWC/6KWC.fasta}"
+OUTDIR="${OUTDIR:-outputs/esmf_ice_${SLURM_JOB_ID}}"
+TRACE_MODE="${TRACE_MODE:-attention+activations}"
+DEVICE="${DEVICE:-cuda}"
+
+mkdir -p outputs/logs
+mkdir -p "$OUTDIR"
+
+# Uncomment and set for your ICE environment:
+# module load cuda/11.8
+# module load anaconda3
+# source activate vizfold
+
+# Or conda in project:
+# eval "$(conda shell.bash hook)"
+# conda activate vizfold
+
+cd "${VIZFOLD_REPO:-.}"
+
+# Sanity check: fail fast if the environment is not set up
+python -c "import torch; import transformers" 2>/dev/null || {
+    echo "ERROR: torch or transformers not importable."
+    echo "Activate your conda env before submitting, e.g.:"
+    echo "  conda activate vizfold"
+    echo "Or uncomment the module/conda lines above in this script."
+    exit 1
+}
+
+echo "FASTA=$FASTA OUTDIR=$OUTDIR TRACE_MODE=$TRACE_MODE"
+echo "Running ESMFold..."
+
+python run_pretrained_esmf.py \
+  --fasta "$FASTA" \
+  --out "$OUTDIR" \
+  --model facebook/esmfold_v1 \
+  --device "$DEVICE" \
+  --trace_mode "$TRACE_MODE" \
+  --layers all \
+  --save_fp16
+
+echo "Done. Outputs in $OUTDIR"

--- a/tests/test_esmf_smoke.py
+++ b/tests/test_esmf_smoke.py
@@ -1,0 +1,431 @@
+"""
+Smoke test for ESMFold backend: CLI and output layout.
+
+Runs in CPU mode on a tiny sequence so CI stays fast.
+Skips actual ESMFold inference if transformers is not installed.
+
+Run with: pytest tests/test_esmf_smoke.py -v
+Or without pytest: python tests/test_esmf_smoke.py
+"""
+import os
+import subprocess
+import sys
+import tempfile
+import torch
+from pathlib import Path
+
+# Repo root
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+try:
+    import pytest
+except ImportError:
+    pytest = None
+
+
+def _has_esm() -> bool:
+    try:
+        from transformers import EsmForProteinFolding  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+def test_esmf_import():
+    """Backend and runner can be imported when transformers is present."""
+    if not _has_esm():
+        return  # skip when no transformers
+    from vizfold.backends.esmfold.inference import ESMFoldRunner
+    from vizfold.backends.esmfold.schema import build_meta, write_meta
+    assert ESMFoldRunner is not None
+    meta = build_meta(
+        backend="esmfold",
+        model_name="facebook/esmfold_v1",
+        out_dir="/tmp",
+        fasta_path=None,
+        device="cpu",
+        dtype="float32",
+        sequence_length=10,
+        fasta_hash="abc",
+        layer_count=1,
+        head_count=4,
+        trace_mode="none",
+        trace_formats=[],
+        shapes_recorded={},
+    )
+    assert meta["backend"] == "esmfold"
+    assert "date_time" in meta
+
+
+def test_cli_help():
+    """CLI runs and shows help."""
+    result = subprocess.run(
+        [sys.executable, str(REPO_ROOT / "run_pretrained_esmf.py"), "--help"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert "--fasta" in result.stdout
+    assert "--trace_mode" in result.stdout
+
+
+def test_cli_missing_fasta():
+    """CLI exits non-zero when FASTA is missing."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(REPO_ROOT / "run_pretrained_esmf.py"),
+            "--fasta", "/nonexistent.fasta",
+            "--out", "/tmp/out_esmf_smoke",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "not found" in result.stderr or "Error" in result.stderr
+
+
+def test_esmf_smoke_run_cpu(tmp_path=None):
+    """
+    Run ESMFold on a tiny sequence (CPU), check output layout.
+    Kept minimal so it stays under a few minutes.
+    """
+    if not _has_esm():
+        return  # skip when no transformers
+    if tmp_path is None:
+        tmp_path = Path(tempfile.mkdtemp())
+    fasta = tmp_path / "tiny.fasta"
+    fasta.write_text(">tiny\nMKFLKFSLLTAVLLSVVFAFSSCGDDDD\n")
+    out_dir = tmp_path / "out"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(REPO_ROOT / "run_pretrained_esmf.py"),
+            "--fasta", str(fasta),
+            "--out", str(out_dir),
+            "--device", "cpu",
+            "--trace_mode", "none",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert result.returncode == 0, (result.stdout, result.stderr)
+
+    assert (out_dir / "meta.json").exists()
+    assert (out_dir / "logs.txt").exists()
+    structure_dir = out_dir / "structure"
+    if structure_dir.exists():
+        assert list(structure_dir.iterdir())
+
+
+def test_esmf_trace_extraction(tmp_path=None):
+    """
+    Run ESMFold with attention+activations, verify trace tensors are
+    written and have the expected shape.
+    """
+    if not _has_esm():
+        return
+    import torch
+
+    if tmp_path is None:
+        tmp_path = Path(tempfile.mkdtemp())
+    fasta = tmp_path / "tiny.fasta"
+    fasta.write_text(">tiny\nMKFLKFSL\n")
+    out_dir = tmp_path / "out_trace"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(REPO_ROOT / "run_pretrained_esmf.py"),
+            "--fasta", str(fasta),
+            "--out", str(out_dir),
+            "--device", "cpu",
+            "--trace_mode", "attention+activations",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+    assert result.returncode == 0, (result.stdout, result.stderr)
+
+    assert (out_dir / "meta.json").exists()
+    assert (out_dir / "structure" / "predicted.pdb").exists()
+    trace_dir = out_dir / "trace"
+    assert trace_dir.exists()
+
+    pt_files = list(trace_dir.rglob("*.pt"))
+    assert len(pt_files) >= 36, f"Expected >=36 trace tensors, got {len(pt_files)}"
+
+    attn_files = sorted((trace_dir / "attention").glob("*.pt"))
+    assert attn_files, "No attention .pt files found"
+    sample = torch.load(attn_files[0], map_location="cpu", weights_only=True)
+    assert sample.dim() == 4, f"Expected 4D attention tensor [B,H,N,N], got {sample.shape}"
+    assert sample.shape[0] == 1, f"Expected batch dim == 1, got {sample.shape[0]}"
+    assert sample.shape[2] == sample.shape[3], f"Attention map not square: {sample.shape}"
+
+
+# Pytest decorators when available
+if pytest is not None:
+    test_esmf_import = pytest.mark.skipif(not _has_esm(), reason="transformers not installed")(test_esmf_import)
+    test_esmf_smoke_run_cpu = pytest.mark.skipif(not _has_esm(), reason="transformers not installed")(test_esmf_smoke_run_cpu)
+    test_esmf_trace_extraction = pytest.mark.skipif(not _has_esm(), reason="transformers not installed")(test_esmf_trace_extraction)
+
+
+if __name__ == "__main__":
+    # Run without pytest
+    failed = []
+    # CLI help
+    print("test_cli_help ...", end=" ")
+    try:
+        test_cli_help()
+        print("ok")
+    except AssertionError as e:
+        print("FAIL", e)
+        failed.append("test_cli_help")
+    # CLI missing fasta
+    print("test_cli_missing_fasta ...", end=" ")
+    try:
+        test_cli_missing_fasta()
+        print("ok")
+    except AssertionError as e:
+        print("FAIL", e)
+        failed.append("test_cli_missing_fasta")
+    # Schema/build_meta (no ESM needed)
+    print("test_schema_build_meta ...", end=" ")
+    try:
+        from vizfold.backends.esmfold.schema import build_meta
+        meta = build_meta(
+            backend="esmfold", model_name="x", out_dir="/tmp", fasta_path=None,
+            device="cpu", dtype="float32", sequence_length=10, fasta_hash="h",
+            layer_count=1, head_count=4, trace_mode="none", trace_formats=[],
+            shapes_recorded={},
+        )
+        assert meta["backend"] == "esmfold" and "date_time" in meta
+        print("ok")
+    except Exception as e:
+        print("FAIL", e)
+        failed.append("test_schema_build_meta")
+    # ESMFold import (when transformers present)
+    print("test_esmf_import ...", end=" ")
+    try:
+        test_esmf_import()
+        print("ok (or skipped)")
+    except Exception as e:
+        print("FAIL", e)
+        failed.append("test_esmf_import")
+    # Full smoke run (when transformers present)
+    print("test_esmf_smoke_run_cpu ...", end=" ")
+    try:
+        test_esmf_smoke_run_cpu()
+        print("ok (or skipped)")
+    except Exception as e:
+        print("FAIL", e)
+        failed.append("test_esmf_smoke_run_cpu")
+    # Trace extraction
+    print("test_esmf_trace_extraction ...", end=" ")
+    try:
+        test_esmf_trace_extraction()
+        print("ok (or skipped)")
+    except Exception as e:
+        print("FAIL", e)
+        failed.append("test_esmf_trace_extraction")
+    if failed:
+        print("Failed:", failed)
+        sys.exit(1)
+    print("All checks passed.")
+
+
+def test_esmfold_backend_smoke(tmp_path):
+    if not _has_esm():
+        return  # needs transformers + the 2.6 GB facebook/esmfold_v1 download
+    output_dir = tmp_path / "test_trace_ci"
+
+    cmd = [
+        sys.executable,
+        "run_pretrained_esmf.py",
+        "--fasta",
+        "examples/monomer/fasta_dir_6KWC/6KWC.fasta",
+        "--out",
+        str(output_dir),
+        "--trace_mode",
+        "attention+activations",
+        "--device",
+        "cpu",
+    ]
+
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+
+    # expected top-level outputs
+    assert os.path.exists(output_dir / "meta.json")
+    assert os.path.exists(output_dir / "structure" / "predicted.pdb")
+    assert os.path.exists(output_dir / "trace")
+
+    # collect all .pt trace files
+    trace_files = []
+    for root, _, files in os.walk(output_dir / "trace"):
+        trace_files += [
+            os.path.join(root, f) for f in files if f.endswith(".pt")
+        ]
+
+    assert len(trace_files) >= 72
+
+    # validate attention tensor shape specifically
+    attention_dir = output_dir / "trace" / "attention"
+    assert attention_dir.exists()
+
+    attention = [
+        attention_dir / f
+        for f in os.listdir(attention_dir)
+        if f.endswith(".pt")
+    ]
+
+    assert len(attention) == 36
+
+    sample_attention = torch.load(attention[0], map_location="cpu")
+    assert len(sample_attention.shape) == 4
+    assert sample_attention.shape[0] == 1
+    assert sample_attention.shape[2] == sample_attention.shape[3]
+
+    # validate activation tensors exist
+    activation_dir = output_dir / "trace" / "activations"
+    assert activation_dir.exists()
+
+    activation_files = [
+        activation_dir / f
+        for f in os.listdir(activation_dir)
+        if f.endswith(".pt")
+    ]
+
+    assert len(activation_files) == 36
+
+    sample_activation = torch.load(activation_files[0], map_location="cpu")
+    assert len(sample_activation.shape) == 3
+    assert sample_activation.shape[0] == 1
+
+    # validate Evoformer trunk intermediates
+    trunk_dir = output_dir / "trace" / "trunk"
+    assert trunk_dir.exists()
+
+    trunk_files = [
+        trunk_dir / f
+        for f in os.listdir(trunk_dir)
+        if f.endswith(".pt")
+    ]
+
+    assert len(trunk_files) >= 96
+
+    # if final or pair outputs exist, validate s_z style shape [N, N, D]
+    trunk_sz_candidates = [
+        f for f in trunk_files
+        if "s_z" in f.name or "pair" in f.name
+    ]
+    if trunk_sz_candidates:
+        sample_sz = torch.load(trunk_sz_candidates[0], map_location="cpu")
+        assert len(sample_sz.shape) == 3
+        assert sample_sz.shape[0] == sample_sz.shape[1]
+
+    # validate attention text export
+    attention_txt_dir = output_dir / "attention"
+    assert attention_txt_dir.exists()
+
+    attention_txt_files = [
+        attention_txt_dir / f
+        for f in os.listdir(attention_txt_dir)
+        if f.endswith(".txt")
+    ]
+
+    assert len(attention_txt_files) == 36
+
+    # optional validation for recycling outputs if present
+    recycle_ss = [
+        f for f in activation_files
+        if "recycle_" in f.name and "_s_s" in f.name
+    ]
+    recycle_sz = [
+        f for f in activation_files
+        if "recycle_" in f.name and "_s_z" in f.name
+    ]
+
+    if recycle_ss:
+        sample_recycle_ss = torch.load(recycle_ss[0], map_location="cpu")
+        assert len(sample_recycle_ss.shape) == 3
+
+    if recycle_sz:
+        sample_recycle_sz = torch.load(recycle_sz[0], map_location="cpu")
+        assert len(sample_recycle_sz.shape) == 3
+        assert sample_recycle_sz.shape[0] == sample_recycle_sz.shape[1]
+
+    # optional validation for structure-module / IPA outputs if present
+    ipa_candidates = []
+    for root, _, files in os.walk(output_dir / "trace"):
+        ipa_candidates += [
+            os.path.join(root, f)
+            for f in files
+            if f.endswith(".pt") and "ipa" in f.lower()
+        ]
+
+    if ipa_candidates:
+        sample_ipa = torch.load(ipa_candidates[0], map_location="cpu")
+        assert len(sample_ipa.shape) >= 3
+
+
+def test_esmfold_full_validation(tmp_path):
+    if not _has_esm():
+        return  # needs transformers + the 2.6 GB facebook/esmfold_v1 download
+    output_dir = tmp_path / "test_trace_ci"
+
+    cmd = [
+        sys.executable,
+        "run_pretrained_esmf.py",
+        "--fasta",
+        "examples/monomer/fasta_dir_6KWC/6KWC.fasta",
+        "--out",
+        str(output_dir),
+        "--trace_mode",
+        "attention+activations",
+        "--device",
+        "cpu",
+    ]
+
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+
+    # expected outputs
+    assert os.path.exists(f"{output_dir}/meta.json")
+    assert os.path.exists(f"{output_dir}/structure/predicted.pdb")
+    assert os.path.exists(f"{output_dir}/trace")
+
+    # collect all trace tensor files
+    trace_files = []
+    for root, _, files in os.walk(f"{output_dir}/trace"):
+        trace_files += [
+            os.path.join(root, f) for f in files if f.endswith(".pt")
+        ]
+
+    assert len(trace_files) >= 36
+
+    # validate attention tensor shape specifically
+    attention_dir = os.path.join(output_dir, "trace", "attention")
+    attention = [
+        os.path.join(attention_dir, f)
+        for f in os.listdir(attention_dir)
+        if f.endswith(".pt")
+    ]
+
+    assert len(attention) >= 1
+
+    sample_tensor = torch.load(attention[0], map_location="cpu")
+    assert len(sample_tensor.shape) == 4
+    assert sample_tensor.shape[0] == 1
+    assert sample_tensor.shape[2] == sample_tensor.shape[3]

--- a/vizfold/__init__.py
+++ b/vizfold/__init__.py
@@ -1,0 +1,1 @@
+# VizFold: multi-backend interpretability for protein structure prediction

--- a/vizfold/backends/__init__.py
+++ b/vizfold/backends/__init__.py
@@ -1,0 +1,6 @@
+"""
+VizFold backends: pluggable inference and trace extraction.
+
+Each backend (openfold, esmfold) runs inference and writes traces in a common
+on-disk layout so visualization and analysis can consume them uniformly.
+"""

--- a/vizfold/backends/esmfold/__init__.py
+++ b/vizfold/backends/esmfold/__init__.py
@@ -1,0 +1,12 @@
+"""
+ESMFold backend: inference and trace export via HuggingFace Transformers.
+"""
+# Lazy import so schema/ can be used without requiring torch/fair-esm
+def __getattr__(name):
+    if name == "ESMFoldRunner":
+        from vizfold.backends.esmfold.inference import ESMFoldRunner
+        return ESMFoldRunner
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+__all__ = ["ESMFoldRunner"]

--- a/vizfold/backends/esmfold/hooks.py
+++ b/vizfold/backends/esmfold/hooks.py
@@ -1,0 +1,466 @@
+"""
+Hook-based extraction of attention weights and hidden states from HuggingFace ESMFold.
+
+HF EsmForProteinFolding does NOT support output_attentions / output_hidden_states.
+We capture traces by registering forward hooks on three stages:
+
+  1. ESM-2 trunk (model.esm):
+     Attention weights: hook on each EsmSelfAttention module, monkey-patching
+                        the forward to force attn_weights to be returned.
+     Activations:       hook on each EsmLayer (full transformer block output).
+
+  2. Folding trunk (model.trunk):
+     Per-block: hook on each EsmFoldTriangularSelfAttentionBlock to capture
+                sequence_state [B, L, C_s] and pairwise_state [B, L, L, C_z].
+     Final:     capture out.s_s and out.s_z from the model output.
+
+  3. Structure module (model.trunk.structure_module):
+     IPA attention: StructureModuleTraceCollector wraps ipa.softmax to capture
+                    the attention matrix [H, N, N] at each block per recycle.
+     Backbone:      hook on structure_module to capture per-recycle positions
+                    and single representations.
+
+The ESM-2 tokenizer adds <cls> and <eos> tokens, so attention maps are
+(seq_len+2, seq_len+2). We slice out the special tokens so stored tensors
+are (seq_len, seq_len), matching the FASTA sequence.
+
+Structure module tracing:
+  StructureModuleTraceCollector hooks into model.trunk.structure_module.ipa
+  to capture IPA attention weights [H, N, N] at each block within each
+  recycling iteration, and hooks on trunk.structure_module to capture
+  per-recycle backbone positions and single representations.
+"""
+import inspect
+import re
+import warnings
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+import torch
+import torch.nn as nn
+
+
+class ESMFoldTraceCollector:
+    """
+    Collects attention weights, hidden states, and folding trunk intermediates
+    from HuggingFace EsmForProteinFolding.
+    """
+
+    def __init__(
+        self,
+        want_attention: bool = True,
+        want_activations: bool = True,
+        layer_indices: Optional[List[int]] = None,
+        head_indices: Optional[List[int]] = None,
+        expected_seq_len: Optional[int] = None,
+    ):
+        self.want_attention = want_attention
+        self.want_activations = want_activations
+        self.layer_indices = layer_indices  # None => all
+        self.head_indices = head_indices
+        self.expected_seq_len = expected_seq_len
+        # ESM-2 encoder outputs
+        self.attention: Dict[str, torch.Tensor] = {}
+        self.activations: Dict[str, torch.Tensor] = {}
+        self._handles: List[Any] = []
+        self._patched_forwards: List[Tuple[nn.Module, Callable]] = []
+        self.recycled_s_s: List[torch.Tensor] = []
+        self.recycled_s_z: List[torch.Tensor] = []
+        # Per-block evoformer intermediates from trunk.blocks[i]
+        self.trunk_blocks: Dict[str, torch.Tensor] = {}
+        self._slice_validated = False
+
+    def clear(self) -> None:
+        self.attention.clear()
+        self.activations.clear()
+        self.recycled_s_s.clear()
+        self.recycled_s_z.clear()
+        self.trunk_blocks.clear()
+        self._slice_validated = False
+
+    def _should_store_layer(self, layer_idx: int) -> bool:
+        return self.layer_indices is None or layer_idx in self.layer_indices
+
+    def register_hooks(self, esm_model: nn.Module) -> None:
+        """
+        Register hooks on the ESM-2 trunk (model.esm passed in).
+
+        Targets:
+          - encoder.layer[i].attention.self  -> attention weights [B, H, N, N]
+          - encoder.layer[i]                 -> activations [B, N, D]
+
+        For HF ESM, EsmSelfAttention.forward() only returns attn_weights when
+        the framework's output capturing mechanism requests it. We monkey-patch
+        the forward to always emit (output, attn_weights).
+        """
+        encoder_layers = self._find_encoder_layers(esm_model)
+        if not encoder_layers:
+            warnings.warn(
+                "Could not find encoder.layer ModuleList in ESM trunk. "
+                "Trace extraction may not work.",
+                UserWarning,
+            )
+            return
+
+        for layer_idx, layer_module in enumerate(encoder_layers):
+            if not self._should_store_layer(layer_idx):
+                continue
+
+            if self.want_attention:
+                self_attn = self._find_self_attention(layer_module)
+                if self_attn is not None:
+                    self._patch_and_hook_attention(self_attn, layer_idx)
+
+            if self.want_activations:
+                h = layer_module.register_forward_hook(self._make_activation_hook(layer_idx))
+                self._handles.append(h)
+
+    def remove_hooks(self) -> None:
+        for h in self._handles:
+            h.remove()
+        self._handles.clear()
+        for module, orig_forward in self._patched_forwards:
+            module.forward = orig_forward
+        self._patched_forwards.clear()
+
+    def _find_encoder_layers(self, esm_model: nn.Module) -> Optional[nn.ModuleList]:
+        """Find the nn.ModuleList of transformer layers in the ESM encoder."""
+        if hasattr(esm_model, "encoder"):
+            enc = esm_model.encoder
+            if hasattr(enc, "layer") and isinstance(enc.layer, nn.ModuleList):
+                return enc.layer
+        for name, module in esm_model.named_modules():
+            if isinstance(module, nn.ModuleList) and re.match(r".*encoder.*layer$", name):
+                return module
+        return None
+
+    def _find_self_attention(self, layer_module: nn.Module) -> Optional[nn.Module]:
+        """Find the self-attention submodule inside a transformer layer."""
+        if hasattr(layer_module, "attention"):
+            attn = layer_module.attention
+            if hasattr(attn, "self"):
+                return attn.self
+            return attn
+        return None
+
+    def _patch_and_hook_attention(self, self_attn: nn.Module, layer_idx: int) -> None:
+        """
+        Monkey-patch EsmSelfAttention.forward to always return attn_weights,
+        then register a hook to capture them.
+
+        HF EsmSelfAttention returns (attn_output, attn_weights) from its
+        internal attention function. But the outer EsmAttention layer discards
+        attn_weights with `attn_output, _ = self.self(...)`. We hook self_attn
+        directly to get the full tuple.
+        """
+        orig_forward = self_attn.forward
+        params = list(inspect.signature(orig_forward).parameters)
+        # Find output_attentions position by name — robust to signature changes
+        oa_pos = params.index("output_attentions") if "output_attentions" in params else -1
+
+        def patched_forward(*args, **kwargs):
+            if oa_pos >= 0 and oa_pos < len(args):
+                args = args[:oa_pos] + (True,) + args[oa_pos + 1:]
+            else:
+                kwargs["output_attentions"] = True
+            return orig_forward(*args, **kwargs)
+
+        self_attn.forward = patched_forward
+        self._patched_forwards.append((self_attn, orig_forward))
+
+        h = self_attn.register_forward_hook(self._make_attention_hook(layer_idx))
+        self._handles.append(h)
+
+    def _make_attention_hook(self, layer_idx: int) -> Callable:
+        """Hook that captures attn_weights from (attn_output, attn_weights) tuple."""
+        def hook(module: nn.Module, inp: Any, out: Any) -> None:
+            if not isinstance(out, tuple) or len(out) < 2:
+                return
+            attn_weights = out[1]
+            if attn_weights is None:
+                return
+            # attn_weights shape: [B, H, N+2, N+2] (includes <cls> and <eos>)
+            # Slice out special tokens -> [B, H, N, N]
+            if attn_weights.dim() == 4 and attn_weights.shape[-1] >= 3:
+                attn_weights = attn_weights[:, :, 1:-1, 1:-1]
+
+            # Validate that the sliced shape matches expected sequence length
+            if (self.expected_seq_len is not None
+                    and not self._slice_validated
+                    and attn_weights.dim() == 4):
+                actual_n = attn_weights.shape[-1]
+                if actual_n != self.expected_seq_len:
+                    warnings.warn(
+                        f"Attention slice mismatch: after removing special tokens, "
+                        f"attention dimension is {actual_n} but expected sequence "
+                        f"length is {self.expected_seq_len}. Attention maps may be "
+                        f"misaligned with residue indices.",
+                        UserWarning,
+                    )
+                self._slice_validated = True
+
+            # Filter heads if requested, to save memory
+            if self.head_indices is not None:
+                head_dim = 1 if attn_weights.dim() == 4 else 0
+                idx = torch.tensor(self.head_indices, device=attn_weights.device)
+                attn_weights = attn_weights.index_select(head_dim, idx)
+
+            key = f"layer_{layer_idx:03d}"
+            self.attention[key] = attn_weights.detach().cpu()
+        return hook
+
+    def _make_activation_hook(self, layer_idx: int) -> Callable:
+        """Hook that captures the transformer layer output (hidden state).
+
+        Strips the leading <cls> and trailing <eos> special tokens so the
+        activation shape [B, N, D] matches the attention shape [B, H, N, N].
+        """
+        def hook(module: nn.Module, inp: Any, out: Any) -> None:
+            h = out[0] if isinstance(out, tuple) else out
+            if h is not None and isinstance(h, torch.Tensor) and h.dim() >= 2:
+                # Strip <cls> (index 0) and <eos> (index -1) to align with
+                # attention maps which are already sliced to seq_len.
+                if h.dim() == 3 and h.shape[1] >= 3:
+                    h = h[:, 1:-1, :]
+                key = f"layer_{layer_idx:03d}"
+                self.activations[key] = h.detach().cpu()
+        return hook
+
+    def _make_trunk_hook(self) -> Callable:
+        """Hook that captures s_s and s_z at every recycling iteration."""
+        def hook(module: nn.Module, inp: Any, out: Any) -> None:
+            s_s, s_z = None, None
+
+            # Handle HF returning a tuple (usually s_s is index 0 and s_z is index 1)
+            if isinstance(out, tuple) and len(out) >= 2:
+                s_s, s_z = out[0], out[1]
+            # Handle HF returning a dataclass or object
+            elif hasattr(out, 's_s') and hasattr(out, 's_z'):
+                s_s, s_z = out.s_s, out.s_z
+            # Handle dictionaries
+            elif isinstance(out, dict):
+                s_s, s_z = out.get('s_s'), out.get('s_z')
+
+            if s_s is not None and s_z is not None:
+                # Squeeze out the batch dimension and move to CPU to prevent RAM crashes
+                # s_s shape: [N, 1024] | s_z shape: [N, N, 128]
+                self.recycled_s_s.append(s_s.squeeze(0).cpu().detach())
+                self.recycled_s_z.append(s_z.squeeze(0).cpu().detach())
+        return hook
+
+    # -------------------------------------------------------------------
+    # Per-block evoformer hooks
+    # -------------------------------------------------------------------
+
+    def register_trunk_hooks(self, model: nn.Module) -> None:
+        """
+        Register hooks on each EsmFoldTriangularSelfAttentionBlock inside
+        model.trunk.blocks to capture per-block sequence_state [B, L, C_s]
+        and pairwise_state [B, L, L, C_z].
+
+        Note: these tensors can be large (pair state is L×L×C_z per block).
+        """
+        trunk = getattr(model, "trunk", None)
+        if trunk is None:
+            warnings.warn("model.trunk not found; trunk block hooks skipped.", UserWarning)
+            return
+        blocks = getattr(trunk, "blocks", None)
+        if blocks is None or not isinstance(blocks, nn.ModuleList):
+            warnings.warn("model.trunk.blocks not found; trunk block hooks skipped.", UserWarning)
+            return
+
+        for block_idx, block in enumerate(blocks):
+            h = block.register_forward_hook(self._make_trunk_block_hook(block_idx))
+            self._handles.append(h)
+
+    def _make_trunk_block_hook(self, block_idx: int) -> Callable:
+        """
+        Hook for EsmFoldTriangularSelfAttentionBlock.
+        Output is (sequence_state, pairwise_state).
+
+        Note: trunk blocks are called once per recycle iteration. Since dict
+        keys are the same across iterations, only the LAST recycle's data
+        is retained. This matches the behavior of recycled_s_s/s_z where
+        only the final values are used downstream. All recycle iterations
+        are captured in recycled_s_s/recycled_s_z lists for analysis if needed.
+        """
+        def hook(module: nn.Module, inp: Any, out: Any) -> None:
+            if not isinstance(out, tuple) or len(out) < 2:
+                return
+            seq_state, pair_state = out[0], out[1]
+            if isinstance(seq_state, torch.Tensor):
+                self.trunk_blocks[f"block_{block_idx:03d}_seq"] = seq_state.squeeze(0).detach().cpu()
+            if isinstance(pair_state, torch.Tensor):
+                self.trunk_blocks[f"block_{block_idx:03d}_pair"] = pair_state.squeeze(0).detach().cpu()
+        return hook
+
+    def _make_trunk_hook(self) -> Callable:
+        """Hook that captures s_s and s_z at every recycling iteration."""
+        def hook(module: nn.Module, inp: Any, out: Any) -> None:
+            s_s, s_z = None, None
+
+            # Handle HF returning a tuple (usually s_s is index 0 and s_z is index 1)
+            if isinstance(out, tuple) and len(out) >= 2:
+                s_s, s_z = out[0], out[1]
+            # Handle HF returning a dataclass or object
+            elif hasattr(out, 's_s') and hasattr(out, 's_z'):
+                s_s, s_z = out.s_s, out.s_z
+            # Handle dictionaries
+            elif isinstance(out, dict):
+                s_s, s_z = out.get('s_s'), out.get('s_z')
+
+            if s_s is not None and s_z is not None:
+                # Squeeze out the batch dimension and move to CPU to prevent RAM crashes
+                # s_s shape: [N, 1024] | s_z shape: [N, N, 128]
+                self.recycled_s_s.append(s_s.squeeze(0).cpu().detach())
+                self.recycled_s_z.append(s_z.squeeze(0).cpu().detach())
+        return hook
+
+
+class StructureModuleTraceCollector:
+    """
+    Captures IPA attention weights and per-recycling-iteration backbone
+    outputs from the ESMFold structure module.
+
+    Hook targets:
+      - trunk.structure_module.ipa: monkey-patched to stash the softmax
+        attention matrix a [*, H, N, N] before it's consumed internally.
+        Fires num_blocks times per recycle (IPA is a single shared module
+        reused across all structure module blocks).
+      - trunk.structure_module: captures the full output per recycle,
+        including stacked positions [num_blocks, B, N, 14, 3], frames,
+        and the final single representation. Handles both dict and
+        dataclass outputs from HuggingFace.
+    """
+
+    def __init__(self) -> None:
+        self.ipa_attention: Dict[str, torch.Tensor] = {}
+        self.backbone_positions: Dict[str, torch.Tensor] = {}
+        self.backbone_frames: Dict[str, torch.Tensor] = {}
+        self.sm_states: Dict[str, torch.Tensor] = {}
+        self._handles: List[Any] = []
+        self._patched_forwards: List[Tuple[nn.Module, Callable]] = []
+        self._recycle_idx = 0
+        self._block_idx = 0
+
+    def clear(self) -> None:
+        self.ipa_attention.clear()
+        self.backbone_positions.clear()
+        self.backbone_frames.clear()
+        self.sm_states.clear()
+        self._recycle_idx = 0
+        self._block_idx = 0
+
+    def register_hooks(self, model: nn.Module) -> None:
+        """
+        Register hooks on model.trunk.structure_module and its IPA submodule.
+
+        Args:
+            model: the full EsmForProteinFolding model (we navigate to trunk).
+        """
+        trunk = getattr(model, "trunk", None)
+        if trunk is None:
+            warnings.warn("model.trunk not found; structure module hooks skipped.", UserWarning)
+            return
+        sm = getattr(trunk, "structure_module", None)
+        if sm is None:
+            warnings.warn("trunk.structure_module not found; hooks skipped.", UserWarning)
+            return
+
+        ipa = getattr(sm, "ipa", None)
+        if ipa is not None:
+            self._patch_ipa(ipa)
+
+        h = sm.register_forward_hook(self._sm_output_hook)
+        self._handles.append(h)
+
+    def _patch_ipa(self, ipa: nn.Module) -> None:
+        """
+        Monkey-patch IPA forward to stash the softmax attention matrix.
+
+        IPA computes a = softmax(scalar_attn + point_attn + pair_bias + mask)
+        but only returns the single-rep update. We intercept a after softmax
+        and store it, keyed by recycle_idx and block_idx.
+
+        ipa.softmax is an nn.Softmax module, so we can't replace it with a
+        plain function (PyTorch __setattr__ rejects non-Module assignments).
+        Instead we wrap it in an nn.Module subclass that captures the output.
+        """
+        orig_forward = ipa.forward
+        orig_softmax_module = ipa.softmax
+        collector = self
+
+        class CapturingSoftmax(nn.Module):
+            def __init__(self, wrapped: nn.Module):
+                super().__init__()
+                self.wrapped = wrapped
+                self.last_a: Optional[torch.Tensor] = None
+
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                result = self.wrapped(x)
+                self.last_a = result.detach()
+                return result
+
+        capturing = CapturingSoftmax(orig_softmax_module)
+        ipa.softmax = capturing
+
+        def patched_forward(*args, **kwargs):
+            capturing.last_a = None
+            out = orig_forward(*args, **kwargs)
+            if capturing.last_a is not None:
+                key = f"recycle_{collector._recycle_idx:02d}_block_{collector._block_idx:02d}"
+                collector.ipa_attention[key] = capturing.last_a
+            collector._block_idx += 1
+            return out
+
+        ipa.forward = patched_forward
+        self._patched_forwards.append((ipa, orig_forward))
+        self._orig_softmax = (ipa, orig_softmax_module)
+
+    def _extract_from_output(self, out: Any) -> dict:
+        """Extract fields from structure module output (dict or dataclass)."""
+        result = {}
+        # Try dict access first
+        if isinstance(out, dict):
+            for key in ("positions", "frames", "single"):
+                if key in out:
+                    result[key] = out[key]
+        else:
+            # Handle dataclass / namedtuple / object with attributes
+            for key in ("positions", "frames", "single"):
+                val = getattr(out, key, None)
+                if val is not None:
+                    result[key] = val
+        return result
+
+    def _sm_output_hook(self, module: nn.Module, inp: Any, out: Any) -> None:
+        """
+        Fires once per recycling iteration after the full structure module
+        forward (all blocks). Captures backbone positions and states.
+        Handles both dict and dataclass outputs from HuggingFace.
+        """
+        key = f"recycle_{self._recycle_idx:02d}"
+        fields = self._extract_from_output(out)
+
+        if "positions" in fields:
+            self.backbone_positions[key] = fields["positions"].detach().cpu()
+        if "frames" in fields:
+            self.backbone_frames[key] = fields["frames"].detach().cpu()
+        if "single" in fields:
+            self.sm_states[key] = fields["single"].detach().cpu()
+
+        # Always reset block counter and advance recycle counter,
+        # regardless of whether we captured any data.
+        self._recycle_idx += 1
+        self._block_idx = 0
+
+    def remove_hooks(self) -> None:
+        for h in self._handles:
+            h.remove()
+        self._handles.clear()
+        for module, orig_forward in self._patched_forwards:
+            module.forward = orig_forward
+        self._patched_forwards.clear()
+        if hasattr(self, "_orig_softmax"):
+            ipa_mod, orig_sm = self._orig_softmax
+            ipa_mod.softmax = orig_sm
+            del self._orig_softmax

--- a/vizfold/backends/esmfold/inference.py
+++ b/vizfold/backends/esmfold/inference.py
@@ -1,0 +1,517 @@
+"""
+ESMFold inference: load model, run forward, optionally extract traces.
+
+Uses HuggingFace Transformers (EsmForProteinFolding) to avoid OpenFold build dependency.
+"""
+import os
+import warnings
+from typing import Any, Dict, List, Optional, Tuple
+
+import torch
+
+from vizfold.backends.esmfold.hooks import ESMFoldTraceCollector, StructureModuleTraceCollector
+from vizfold.backends.esmfold.schema import _read_fasta_and_hash
+from vizfold.backends.esmfold.trace_adapter import (
+    build_and_write_meta,
+    write_structure,
+    write_traces,
+    write_trace_summary,
+    write_attention_txt,
+)
+
+# HuggingFace ESMFold
+try:
+    from transformers import AutoTokenizer, EsmForProteinFolding
+    HAS_ESM = True
+except ImportError:
+    HAS_ESM = False
+    AutoTokenizer = None  # type: ignore
+    EsmForProteinFolding = None  # type: ignore
+
+# PDB conversion (bundled in transformers)
+def _get_pdb_utils():
+    try:
+        from transformers.models.esm.openfold_utils.feats import atom14_to_atom37
+        from transformers.models.esm.openfold_utils.protein import Protein as OFProtein, to_pdb
+        return atom14_to_atom37, OFProtein, to_pdb
+    except ImportError:
+        return None, None, None
+
+
+LONG_SEQ_WARN_THRESHOLD = 400
+HF_MODEL_DEFAULT = "facebook/esmfold_v1"
+
+AA_1TO3 = {
+    "A": "ALA", "R": "ARG", "N": "ASN", "D": "ASP", "C": "CYS",
+    "E": "GLU", "Q": "GLN", "G": "GLY", "H": "HIS", "I": "ILE",
+    "L": "LEU", "K": "LYS", "M": "MET", "F": "PHE", "P": "PRO",
+    "S": "SER", "T": "THR", "W": "TRP", "Y": "TYR", "V": "VAL",
+    "U": "SEC", "O": "PYL", "X": "UNK",
+}
+
+
+def _parse_layers_arg(layers_arg: Optional[str]) -> Optional[List[int]]:
+    if not layers_arg or layers_arg.lower() == "all":
+        return None
+    indices = []
+    for part in layers_arg.split(","):
+        part = part.strip()
+        if ":" in part:
+            a, b = part.split(":", 1)
+            indices.extend(range(int(a), int(b)))
+        else:
+            indices.append(int(part))
+    return sorted(set(indices))
+
+
+def _parse_heads_arg(heads_arg: Optional[str]) -> Optional[List[int]]:
+    if not heads_arg or heads_arg.lower() == "all":
+        return None
+    return [int(x.strip()) for x in heads_arg.split(",")]
+
+
+def read_fasta(fasta_path: str) -> Tuple[str, str, str]:
+    """Return (sequence, seq_id, fasta_hash)."""
+    seq, fasta_hash = _read_fasta_and_hash(fasta_path)
+    seq_id = "seq"
+    with open(fasta_path) as f:
+        for line in f:
+            if line.startswith(">"):
+                seq_id = line[1:].strip().split()[0]
+                break
+    return seq, seq_id, fasta_hash
+
+
+class ESMFoldRunner:
+    """
+    Runs ESMFold inference and writes VizFold-compatible output.
+
+    Uses HuggingFace EsmForProteinFolding (no fair-esm / OpenFold build).
+    """
+
+    def __init__(
+        self,
+        model_name: str = HF_MODEL_DEFAULT,
+        device: str = "cpu",
+        dtype: str = "float32",
+        seed: Optional[int] = None,
+        deterministic: bool = False,
+    ):
+        if not HAS_ESM:
+            raise RuntimeError(
+                "ESMFold backend requires transformers. Install with: pip install transformers torch"
+            )
+        self.model_name = model_name
+        self.device = device
+        self.dtype = dtype
+        self.seed = seed
+        self.deterministic = deterministic
+        self._model = None
+        self._tokenizer = None
+
+
+    def load_model(
+        self,
+        model_name: Optional[str] = None,
+        device: Optional[str] = None,
+        dtype: Optional[str] = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Load the model. Returns the model object."""
+        if model_name is not None:
+            self.model_name = model_name
+        if device is not None:
+            self.device = device
+        if dtype is not None:
+            self.dtype = dtype
+        return self._load_model()
+
+    def run_inference(
+        self,
+        fasta_path: str,
+        out_dir: str,
+        trace_cfg: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Run inference and optionally write traces."""
+        trace_mode = "attention+activations"
+        top_k = 50
+        if trace_cfg:
+            trace_mode = trace_cfg.get("trace_mode", trace_mode)
+            top_k = trace_cfg.get("top_k", top_k)
+        return self.run(
+            fasta_path=fasta_path,
+            out_dir=out_dir,
+            trace_mode=trace_mode,
+            top_k=top_k,
+            **kwargs,
+        )
+
+    def supports_attention(self) -> bool:
+        """Whether this backend can extract attention maps."""
+        return True
+
+    def supports_activations(self) -> bool:
+        """Whether this backend can extract layer activations (hidden states)."""
+        return True
+
+    # --- Internal model loading ---
+
+    def _load_model(self) -> Any:
+        if self._model is not None:
+            return self._model
+        if self.seed is not None:
+            torch.manual_seed(self.seed)
+        if self.deterministic:
+            try:
+                torch.backends.cudnn.deterministic = True
+                torch.backends.cudnn.benchmark = False
+            except Exception:
+                pass
+            warnings.warn("Deterministic mode may reduce speed.", UserWarning)
+
+        self._tokenizer = AutoTokenizer.from_pretrained(self.model_name)
+        self._model = EsmForProteinFolding.from_pretrained(self.model_name, use_safetensors=True)
+        self._model = self._model.eval()
+        dtype_t = torch.float16 if self.dtype == "float16" else torch.float32
+        self._model = self._model.to(device=self.device, dtype=dtype_t)
+        return self._model
+
+    def run(
+        self,
+        fasta_path: str,
+        out_dir: str,
+        trace_mode: str = "attention+activations",
+        layers: Optional[str] = None,
+        heads: Optional[str] = None,
+        save_fp16: bool = False,
+        top_k: int = 50,
+        structure_traces: bool = False,
+        log_path: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        Run inference and write structure + optional traces.
+
+        trace_mode: "attention" | "activations" | "attention+activations" | "none"
+        layers: "all" or "0,1,2" or "0:12"
+        heads: "all" or "0,1,2"
+        structure_traces: if True, capture IPA attention weights and per-recycle
+            backbone positions from the folding trunk structure module.
+        """
+        os.makedirs(out_dir, exist_ok=True)
+        if log_path is None:
+            log_path = os.path.join(out_dir, "logs.txt")
+
+        def log(msg: str) -> None:
+            with open(log_path, "a") as f:
+                f.write(msg + "\n")
+            print(msg)
+
+        seq, seq_id, fasta_hash = read_fasta(fasta_path)
+        seq_len = len(seq)
+
+        if seq_len > LONG_SEQ_WARN_THRESHOLD and "attention" in trace_mode:
+            log(
+                f"Warning: sequence length {seq_len} > {LONG_SEQ_WARN_THRESHOLD}. "
+                "Attention storage is N^2; consider --layers 0,1 or --trace_mode activations."
+            )
+
+        model = self._load_model()
+        tokenizer = self._tokenizer
+        want_attn = "attention" in trace_mode
+        want_act = "activations" in trace_mode
+        layer_list = _parse_layers_arg(layers)
+        head_list = _parse_heads_arg(heads)
+
+        collector = ESMFoldTraceCollector(
+            want_attention=want_attn,
+            want_activations=want_act,
+            layer_indices=layer_list,
+            head_indices=head_list,
+            expected_seq_len=seq_len,
+        )
+
+        # Tokenize (HF ESMFold: add_special_tokens=False per standard usage)
+        inputs = tokenizer(
+            [seq],
+            return_tensors="pt",
+            add_special_tokens=False,
+            padding=False,
+        )
+        input_ids = inputs["input_ids"].to(device=self.device)
+        attention_mask = inputs.get("attention_mask")
+        if attention_mask is not None:
+            attention_mask = attention_mask.to(device=self.device)
+
+        # Hooks on model.esm capture ESM-2 encoder traces during forward.
+        if trace_mode != "none":
+            esm_trunk = getattr(model, "esm", model)
+            collector.register_hooks(esm_trunk)
+            # Hook the folding trunk to catch recycling iterations
+            if hasattr(model, "trunk"):
+                trunk_handle = model.trunk.register_forward_hook(collector._make_trunk_hook())
+                collector._handles.append(trunk_handle)
+            # Hook each evoformer block to capture per-block sequence/pair state
+            collector.register_trunk_hooks(model)
+
+        # Structure module hooks: IPA attention + per-recycle backbone
+        sm_collector = None
+        if structure_traces:
+            sm_collector = StructureModuleTraceCollector()
+            sm_collector.register_hooks(model)
+            log("Structure module hooks registered (IPA attention + backbone).")
+
+        with torch.no_grad():
+            out = model(input_ids=input_ids, attention_mask=attention_mask)
+
+        if trace_mode != "none":
+            collector.remove_hooks()
+
+            # Archive the recycled s_s and s_z tensors we caught
+            if want_act and len(collector.recycled_s_s) > 0:
+                num_iters = len(collector.recycled_s_s)
+                log(f"[{self.model_name}] [{trace_mode}] Captured {num_iters} trunk recycling iterations.")
+                for i in range(num_iters):
+                    collector.activations[f"recycle_{i}_s_s"] = collector.recycled_s_s[i]
+                    collector.activations[f"recycle_{i}_s_z"] = collector.recycled_s_z[i]
+
+            # out.s_s: folding trunk single representations [B, N, 1024].
+            # These are the per-residue embeddings produced by ESMFold's
+            # structure module, complementing the ESM-2 encoder traces.
+            if hasattr(out, 's_s') and out.s_s is not None:
+                single_reps = out.s_s.squeeze(0).cpu()
+                log(f"[{self.model_name}] [{trace_mode}] Extracted folding trunk s_s: {single_reps.shape}")
+            else:
+                log(f"[{self.model_name}] [{trace_mode}] out.s_s not found — folding trunk single representations missing.")
+
+        if sm_collector is not None:
+            sm_collector.remove_hooks()
+            log(f"Structure module traces: {len(sm_collector.ipa_attention)} IPA blocks, "
+                f"{len(sm_collector.backbone_positions)} recycle iterations.")
+
+        log(f"Forward pass complete. Captured {len(collector.attention)} attention layers, "
+            f"{len(collector.activations)} activation layers.")
+
+        # Structure: PDB + optional coords tensor
+        pdb_str, coords = self._extract_structure(out, seq, log)
+        struct_paths = write_structure(out_dir, pdb_str, coords)
+        log(f"Structure written: {struct_paths}")
+
+        # Traces
+        shapes_recorded = {"attention": {}, "activations": {}}
+        if trace_mode != "none" and (collector.attention or collector.activations):
+            attn_idx, act_idx = write_traces(
+                out_dir,
+                collector,
+                save_fp16=save_fp16,
+                layer_indices=layer_list,
+                head_indices=head_list,
+            )
+            for k, v in attn_idx.items():
+                shapes_recorded["attention"][k] = v.get("shape", [])
+            for k, v in act_idx.items():
+                shapes_recorded["activations"][k] = v.get("shape", [])
+            # Save per-block evoformer intermediates + final s_s/s_z into trace/trunk/
+            trunk_tensors = dict(collector.trunk_blocks)  # block_000_seq, block_000_pair, ...
+            # Add final trunk outputs: recycled_s_s[-1] == out.s_s (last recycle iteration).
+            # Saved here rather than from out.s_s to avoid a redundant copy.
+            if collector.recycled_s_s:
+                trunk_tensors["s_s"] = collector.recycled_s_s[-1]  # [L, C_s]
+            if collector.recycled_s_z:
+                trunk_tensors["s_z"] = collector.recycled_s_z[-1]  # [L, L, C_z]
+
+            if trunk_tensors:
+                trunk_dir = os.path.join(out_dir, "trace", "trunk")
+                os.makedirs(trunk_dir, exist_ok=True)
+                shapes_recorded["trunk"] = {}
+                for key, t in trunk_tensors.items():
+                    path = os.path.join(trunk_dir, f"{key}.pt")
+                    torch.save(t if not save_fp16 else t.half(), path)
+                    shapes_recorded["trunk"][key] = {
+                        "path": os.path.relpath(path, out_dir),
+                        "shape": list(t.shape),
+                    }
+                log(f"Evoformer trunk intermediates written to {trunk_dir} "
+                    f"({len(trunk_tensors)} tensors: "
+                    f"{len(collector.trunk_blocks)} blocks + "
+                    f"{len(trunk_tensors) - len(collector.trunk_blocks)} final)")
+
+            try:
+                write_trace_summary(out_dir, collector)
+            except Exception as e:
+                log(f"Warning: trace summary failed: {e}")
+
+            # VizFold-compatible text-file attention export
+            if want_attn and collector.attention:
+                txt_dir = write_attention_txt(out_dir, collector, top_k=top_k)
+                if txt_dir:
+                    attn_files = [f for f in os.listdir(txt_dir) if f.endswith(".txt")]
+                    shapes_recorded["attention"] = attn_files
+                    log(f"VizFold text attention saved to {txt_dir} ({len(attn_files)} files)")
+
+        # Write structure module traces (IPA attention + backbone per recycle)
+        if sm_collector is not None:
+            sm_dir = os.path.join(out_dir, "trace", "structure_module")
+            ipa_dir = os.path.join(sm_dir, "ipa_attention")
+            bb_dir = os.path.join(sm_dir, "backbone")
+            os.makedirs(ipa_dir, exist_ok=True)
+            os.makedirs(bb_dir, exist_ok=True)
+
+            shapes_recorded["structure_module"] = {"ipa_attention": {}, "backbone": {}}
+
+            for key, t in sm_collector.ipa_attention.items():
+                path = os.path.join(ipa_dir, f"{key}.pt")
+                torch.save(t.cpu() if not save_fp16 else t.cpu().half(), path)
+                shapes_recorded["structure_module"]["ipa_attention"][key] = {
+                    "path": os.path.relpath(path, out_dir),
+                    "shape": list(t.shape),
+                }
+
+            for key, t in sm_collector.backbone_positions.items():
+                path = os.path.join(bb_dir, f"{key}_positions.pt")
+                torch.save(t if not save_fp16 else t.half(), path)
+                shapes_recorded["structure_module"]["backbone"][f"{key}_positions"] = {
+                    "path": os.path.relpath(path, out_dir),
+                    "shape": list(t.shape),
+                }
+
+            for key, t in sm_collector.sm_states.items():
+                path = os.path.join(bb_dir, f"{key}_states.pt")
+                torch.save(t if not save_fp16 else t.half(), path)
+                shapes_recorded["structure_module"]["backbone"][f"{key}_states"] = {
+                    "path": os.path.relpath(path, out_dir),
+                    "shape": list(t.shape),
+                }
+
+            log(f"Structure module traces written: "
+                f"{len(sm_collector.ipa_attention)} IPA attention maps, "
+                f"{len(sm_collector.backbone_positions)} backbone snapshots.")
+
+        layer_count = len(collector.attention) if trace_mode != "none" else 0
+        head_count = 0
+        if collector.attention:
+            first_attn = next(iter(collector.attention.values()))
+            if first_attn.dim() == 4:
+                head_count = first_attn.shape[1]
+            elif first_attn.dim() == 3:
+                head_count = first_attn.shape[0]
+
+        build_and_write_meta(
+            out_dir=out_dir,
+            model_name=self.model_name,
+            fasta_path=os.path.abspath(fasta_path),
+            device=self.device,
+            dtype=self.dtype,
+            seq_len=seq_len,
+            fasta_hash=fasta_hash,
+            layer_count=layer_count,
+            head_count=head_count,
+            trace_mode=trace_mode,
+            shapes_recorded=shapes_recorded,
+            seed=self.seed,
+            deterministic=self.deterministic,
+            save_fp16=save_fp16,
+            top_k=top_k,
+        )
+        log("meta.json written.")
+
+        return {
+            "structure": struct_paths,
+            "out_dir": out_dir,
+            "trace_mode": trace_mode,
+            "attention_layers": len(collector.attention),
+            "activation_layers": len(collector.activations),
+        }
+
+    def _extract_structure(self, out: Any, seq: str, log) -> Tuple[Optional[str], Optional[torch.Tensor]]:
+        """Extract PDB string and coordinates from model output."""
+        pdb_str = None
+        coords = None
+        atom14_to_atom37, OFProtein, to_pdb = _get_pdb_utils()
+
+        def _get(key: str):
+            if hasattr(out, key):
+                return getattr(out, key)
+            if isinstance(out, dict) and key in out:
+                return out[key]
+            return None
+
+        positions = _get("positions")
+        if positions is None:
+            log("Warning: no positions in model output; structure/ may be incomplete.")
+            return pdb_str, coords
+
+        # Fallback chain: full OpenFold PDB conversion → CA-only minimal PDB.
+        # When transformers bundles openfold_utils we get proper all-atom PDB;
+        # otherwise we write a CA-only PDB so downstream tools still have geometry.
+        try:
+            if atom14_to_atom37 and OFProtein is not None and to_pdb is not None:
+                # ESMFold returns positions as [recycling_iters, B, N, 14, 3];
+                # take the last iteration for the final refined structure.
+                pos = positions[-1] if positions.dim() == 5 else positions
+                final_atom37 = atom14_to_atom37(pos, out)
+                coords = final_atom37
+                out_cpu = {}
+                for k in ("aatype", "atom37_atom_exists", "residue_index", "plddt", "chain_index"):
+                    v = _get(k)
+                    if v is not None:
+                        out_cpu[k] = v.cpu().numpy() if isinstance(v, torch.Tensor) else v
+                pos_np = final_atom37.cpu().numpy()
+                pred = OFProtein(
+                    aatype=out_cpu["aatype"][0],
+                    atom_positions=pos_np[0],
+                    atom_mask=out_cpu["atom37_atom_exists"][0],
+                    residue_index=out_cpu["residue_index"][0] + 1,
+                    b_factors=out_cpu["plddt"][0],
+                    chain_index=out_cpu.get("chain_index", [None])[0] if "chain_index" in out_cpu else None,
+                )
+                pdb_str = to_pdb(pred)
+            else:
+                pos = positions
+                if pos.dim() == 5:
+                    pos = pos[-1, 0]
+                elif pos.dim() == 4:
+                    pos = pos[0]
+                coords = pos
+                pdb_str = _coords_to_minimal_pdb(coords, seq)
+        except Exception as e:
+            log(f"Warning: PDB conversion failed ({e}); writing minimal PDB.")
+            try:
+                if positions is not None:
+                    pos = positions
+                    if pos.dim() == 5:
+                        pos = pos[-1, 0]
+                    elif pos.dim() == 4:
+                        pos = pos[0]
+                    pdb_str = _coords_to_minimal_pdb(pos, seq)
+                    coords = pos
+            except Exception:
+                pass
+
+        if pdb_str is None and coords is not None:
+            pdb_str = _coords_to_minimal_pdb(coords, seq)
+        if pdb_str is None:
+            log("Warning: no PDB output from model; structure/ may be incomplete.")
+
+        return pdb_str, coords
+
+
+def _coords_to_minimal_pdb(coords: torch.Tensor, seq: str) -> str:
+    """Write minimal CA-only PDB from coords [N, 14, 3] or [N, 37, 3] or [N, 3]."""
+    if coords.dim() == 3:
+        ca = coords[:, 1, :]  # atom37/atom14 order: N=0, CA=1, C=2, ...
+    else:
+        ca = coords
+    lines = []
+    for i in range(min(ca.shape[0], len(seq))):
+        a = ca[i].float().cpu().numpy()
+        res3 = AA_1TO3.get(seq[i], "UNK")
+        # PDB ATOM format: columns 1-6 record type, 7-11 serial, 13-16 name,
+        # 17 altLoc, 18-20 resName, 22 chainID, 23-26 resSeq, 27 iCode,
+        # 31-38 x, 39-46 y, 47-54 z, 55-60 occupancy, 61-66 tempFactor
+        lines.append(
+            f"ATOM  {i+1:5d}  CA  {res3:>3s} A{i+1:4d}    "
+            f"{a[0]:8.3f}{a[1]:8.3f}{a[2]:8.3f}  1.00  0.00           C"
+        )
+    lines.append("END")
+    return "\n".join(lines) + "\n"

--- a/vizfold/backends/esmfold/requirements.txt
+++ b/vizfold/backends/esmfold/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn

--- a/vizfold/backends/esmfold/schema.py
+++ b/vizfold/backends/esmfold/schema.py
@@ -1,0 +1,111 @@
+"""
+Trace schema and metadata helpers for ESMFold outputs.
+
+Ensures VizFold-compatible archive format and publication-grade metadata.
+"""
+import hashlib
+import json
+import os
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+
+def _git_head(repo_path: Optional[str] = None) -> Optional[str]:
+    try:
+        cmd = ["git", "rev-parse", "HEAD"]
+        if repo_path:
+            cmd = ["git", "-C", repo_path, "rev-parse", "HEAD"]
+        return subprocess.check_output(cmd, text=True).strip()
+    except Exception:
+        return None
+
+
+def _read_fasta_and_hash(path: str) -> Tuple[str, str]:
+    with open(path) as f:
+        raw = f.read()
+    lines = [line.strip() for line in raw.splitlines() if line.strip() and not line.startswith(">")]
+    seq = "".join(lines)
+    h = hashlib.sha256(raw.encode()).hexdigest()[:16]
+    return seq, h
+
+
+def build_meta(
+    *,
+    backend: str = "esmfold",
+    model_name: str,
+    out_dir: str,
+    fasta_path: Optional[str] = None,
+    device: str,
+    dtype: str,
+    sequence_length: int,
+    fasta_hash: str,
+    layer_count: int,
+    head_count: int,
+    trace_mode: str,
+    trace_formats: List[str],
+    shapes_recorded: Dict[str, Any],
+    seed: Optional[int] = None,
+    deterministic: bool = False,
+    save_fp16: bool = False,
+    top_k: int = 50,
+    repo_path: Optional[str] = None,
+) -> Dict[str, Any]:
+    """
+    Build meta.json content for a VizFold-compatible run.
+
+    shapes_recorded: e.g. {"attention": {"layer_000": [num_heads, N, N]}, "activations": {...}}
+    """
+    meta: Dict[str, Any] = {
+        "backend": backend,
+        "model_name": model_name,
+        "date_time": datetime.now(timezone.utc).isoformat(),
+        "device": device,
+        "dtype": dtype,
+        "sequence_length": sequence_length,
+        "input_fasta_hash": fasta_hash,
+        "layer_count": layer_count,
+        "head_count": head_count,
+        "trace_mode": trace_mode,
+        "trace_formats": trace_formats,
+        "tensor_format": "fp16" if save_fp16 else "fp32",
+        "top_k": top_k,
+        "shapes_recorded": shapes_recorded,
+    }
+    if fasta_path:
+        meta["input_fasta_path"] = fasta_path
+    if seed is not None:
+        meta["seed"] = seed
+    if deterministic:
+        meta["deterministic"] = True
+    commit = _git_head(repo_path)
+    if commit:
+        meta["repo_commit"] = commit
+    return meta
+
+
+def write_meta(meta: Dict[str, Any], out_dir: str) -> str:
+    path = os.path.join(out_dir, "meta.json")
+    with open(path, "w") as f:
+        json.dump(meta, f, indent=2)
+    return path
+
+
+def write_trace_index(
+    out_dir: str,
+    attention: Dict[str, Any],
+    activations: Dict[str, Any],
+) -> str:
+    """
+    Write trace/index.json mapping layers/heads to file paths and shapes.
+    """
+    index = {
+        "attention": attention,
+        "activations": activations,
+    }
+    path = os.path.join(out_dir, "trace", "index.json")
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(index, f, indent=2)
+    return path

--- a/vizfold/backends/esmfold/trace_adapter.py
+++ b/vizfold/backends/esmfold/trace_adapter.py
@@ -1,0 +1,278 @@
+"""
+Writes ESMFold traces into VizFold-compatible archive layout.
+
+Layout:
+  out_dir/
+    meta.json
+    structure/
+      predicted.pdb
+      predicted.pt   (optional)
+    trace/
+      attention/
+        layer_000.pt
+        ...
+      activations/
+        layer_000.pt
+        ...
+      trunk/
+        block_000_seq.pt       [L, C_s]  per-block sequence state (last recycle)
+        block_000_pair.pt      [L, L, C_z]  per-block pair state (last recycle)
+        ...
+        s_s.pt                 [L, C_s]  final trunk single representations
+        s_z.pt                 [L, L, C_z]  final trunk pair representations
+      index.json
+    attention/
+      msa_row_attn_layer0.txt   (VizFold text format)
+      ...
+    logs.txt (caller appends)
+"""
+import os
+import re
+from typing import Any, Dict, Optional, Tuple
+
+import torch
+
+from vizfold.backends.esmfold.schema import (
+    build_meta,
+    write_meta,
+    write_trace_index,
+)
+from vizfold.backends.esmfold.hooks import ESMFoldTraceCollector
+
+
+def _save_tensor(path: str, t: torch.Tensor, save_fp16: bool = False) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    if save_fp16 and t.dtype == torch.float32:
+        t = t.half()
+    torch.save(t.cpu(), path)
+
+
+def write_structure(out_dir: str, pdb_str: Optional[str], coords: Optional[torch.Tensor]) -> Dict[str, str]:
+    base = os.path.join(out_dir, "structure")
+    os.makedirs(base, exist_ok=True)
+    paths = {}
+    if pdb_str:
+        pdb_path = os.path.join(base, "predicted.pdb")
+        with open(pdb_path, "w") as f:
+            f.write(pdb_str)
+        paths["pdb"] = pdb_path
+    if coords is not None:
+        pt_path = os.path.join(base, "predicted.pt")
+        torch.save(coords.cpu(), pt_path)
+        paths["coords"] = pt_path
+    return paths
+
+
+def write_traces(
+    out_dir: str,
+    collector: ESMFoldTraceCollector,
+    save_fp16: bool = False,
+    layer_indices: Optional[list] = None,
+    head_indices: Optional[list] = None,
+) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    """
+    Write attention and activations from collector to trace/attention/ and trace/activations/.
+    Returns (attention_index, activations_index) for index.json.
+    """
+    trace_root = os.path.join(out_dir, "trace")
+    attn_dir = os.path.join(trace_root, "attention")
+    act_dir = os.path.join(trace_root, "activations")
+    os.makedirs(attn_dir, exist_ok=True)
+    os.makedirs(act_dir, exist_ok=True)
+
+    attention_index: Dict[str, Any] = {}
+    activations_index: Dict[str, Any] = {}
+
+    for key, t in collector.attention.items():
+        path = os.path.join(attn_dir, f"{key}.pt")
+        # Head filtering is done in the hook (ESMFoldTraceCollector), so
+        # tensors here are already filtered if head_indices was specified.
+        _save_tensor(path, t, save_fp16=save_fp16)
+        attention_index[key] = {
+            "path": os.path.relpath(path, out_dir),
+            "dtype": str(t.dtype),
+            "shape": list(t.shape),
+        }
+
+    for key, t in collector.activations.items():
+        path = os.path.join(act_dir, f"{key}.pt")
+        _save_tensor(path, t, save_fp16=save_fp16)
+        activations_index[key] = {
+            "path": os.path.relpath(path, out_dir),
+            "dtype": str(t.dtype),
+            "shape": list(t.shape),
+        }
+
+    write_trace_index(out_dir, attention_index, activations_index)
+    return attention_index, activations_index
+
+
+def write_attention_txt(
+    out_dir: str,
+    collector: ESMFoldTraceCollector,
+    top_k: int = 50,
+) -> Optional[str]:
+    """
+    Write VizFold-compatible text-file attention maps from collector.
+
+    Converts each [B, H, N, N] attention tensor into the standard
+    msa_row_attn_layer*.txt format used by VizFold visualization tools
+    (PyMOL scripts, arc diagrams, etc.).
+
+    Does not require OpenFold to be installed — uses a self-contained
+    implementation of the top-k writing logic with numpy only.
+
+    Args:
+        out_dir: Root output directory. Files go to out_dir/attention/.
+        collector: ESMFoldTraceCollector with populated .attention dict.
+        top_k: Number of top attention values to save per head.
+
+    Returns:
+        Path to the attention directory, or None if no attention data.
+    """
+    import numpy as np
+
+    if not collector.attention:
+        return None
+
+    attn_dir = os.path.join(out_dir, "attention")
+    os.makedirs(attn_dir, exist_ok=True)
+
+    # Try to use OpenFold's implementation for format consistency;
+    # fall back to the self-contained version if openfold is not installed.
+    try:
+        from openfold.model.evoformer import save_attention_topk as _of_save
+
+        def _save(arr: "np.ndarray", layer_idx: int) -> None:
+            key = f"layer_{layer_idx:03d}"
+            _of_save(
+                attention_dict={key: arr},
+                save_dir=attn_dir,
+                layer_name=key,
+                layer_idx=layer_idx,
+                attn_type="msa_row_attn",
+                triangle_residue_idx=None,
+                top_k=top_k,
+            )
+
+    except ImportError:
+        # Standalone implementation — same output format as save_attention_topk.
+        # arr shape: [B, H, N, N]; msa_row_attn slices batch dim → [H, N, N].
+        def _save(arr: "np.ndarray", layer_idx: int) -> None:  # type: ignore[misc]
+            heads = arr[0]  # [H, N, N]
+            path = os.path.join(attn_dir, f"msa_row_attn_layer{layer_idx}.txt")
+            with open(path, "w") as f:
+                for head_idx, attn_map in enumerate(heads):
+                    S = attn_map.shape[0]
+                    k = min(top_k, S * S)
+                    flat = np.argsort(attn_map.flatten())[::-1][:k]
+                    rows, cols = np.unravel_index(flat, (S, S))
+                    scores = attn_map[rows, cols]
+                    f.write(f"Layer {layer_idx}, Head {head_idx}\n")
+                    for r, c, s in zip(rows, cols, scores):
+                        f.write(f"{r} {c} {s:.6f}\n")
+            print(f"[Done] Saved top {top_k} entries for msa_row_attn to {path}")
+
+    for key, t in collector.attention.items():
+        m = re.search(r"\d+", key)
+        layer_idx = int(m.group()) if m else 0
+        arr = t.float().cpu().numpy()
+        _save(arr, layer_idx)
+
+    return attn_dir
+
+
+def write_trace_summary(
+    out_dir: str,
+    collector: "ESMFoldTraceCollector",
+) -> Optional[str]:
+    """
+    Write trace/summary.json with per-layer attention entropy, mean/std, sparsity proxy,
+    and activation norms. Cheap to compute; useful for analysis.
+    """
+    import json
+    import numpy as np
+    summary = {"attention": {}, "activations": {}}
+    for key, t in collector.attention.items():
+        a = t.float().cpu().numpy()
+        # a: [..., heads, N, N]
+        if a.size == 0:
+            continue
+        if a.ndim == 3:
+            a = a[np.newaxis, ...]
+        # Per-layer (first dim after batch) stats
+        for i in range(a.shape[0]):
+            layer_key = f"{key}_slice{i}" if a.shape[0] > 1 else key
+            block = a[i]
+            if block.ndim >= 3:
+                # block: [heads, N, N] — each row is a distribution over keys
+                # Entropy per row (axis=-1), averaged over all rows and heads
+                ent = -np.sum(block * np.log(block + 1e-12), axis=-1).mean()
+                summary["attention"][layer_key] = {
+                    "mean": float(block.mean()),
+                    "std": float(block.std()),
+                    "entropy_proxy": float(ent),
+                    "sparsity_proxy": float((block < 1e-5).mean()),
+                }
+    for key, t in collector.activations.items():
+        h = t.float().cpu().numpy()
+        if h.size == 0:
+            continue
+        summary["activations"][key] = {
+            "norm_mean": float(np.sqrt((h ** 2).mean())),
+            "mean": float(h.mean()),
+            "std": float(h.std()),
+        }
+    path = os.path.join(out_dir, "trace", "summary.json")
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(summary, f, indent=2)
+    return path
+
+
+def build_and_write_meta(
+    out_dir: str,
+    model_name: str,
+    fasta_path: str,
+    device: str,
+    dtype: str,
+    seq_len: int,
+    fasta_hash: str,
+    layer_count: int,
+    head_count: int,
+    trace_mode: str,
+    shapes_recorded: Dict[str, Any],
+    seed: Optional[int] = None,
+    deterministic: bool = False,
+    save_fp16: bool = False,
+    top_k: int = 50,
+) -> str:
+    # Determine which formats were actually produced
+    formats = []
+    if os.path.isdir(os.path.join(out_dir, "trace", "attention")):
+        formats.append("pt")
+    if os.path.isdir(os.path.join(out_dir, "attention")):
+        formats.append("txt")
+    if not formats:
+        formats = ["none"]
+
+    meta = build_meta(
+        backend="esmfold",
+        model_name=model_name,
+        out_dir=out_dir,
+        fasta_path=fasta_path,
+        device=device,
+        dtype=dtype,
+        sequence_length=seq_len,
+        fasta_hash=fasta_hash,
+        layer_count=layer_count,
+        head_count=head_count,
+        trace_mode=trace_mode,
+        trace_formats=formats,
+        shapes_recorded=shapes_recorded,
+        seed=seed,
+        deterministic=deterministic,
+        save_fp16=save_fp16,
+        top_k=top_k,
+    )
+    return write_meta(meta, out_dir)


### PR DESCRIPTION
> **Draft.** The ESMFold inference path is unchanged from #44 and needs a GPU plus the
> 2.6 GB `facebook/esmfold_v1` model to verify end to end — that run has not been done
> here. What *is* verified: syntax across all files, and the CLI (`--help` and the
> missing-FASTA error path) runs correctly after the amputation.

Salvages the ESMFold backend from #44, separated from the prototype UI and scaffolding
that made that PR unmergeable, and rebased onto current main.

## What's included

- `vizfold/backends/esmfold/` — inference, hooks, trace adapter, schema. Runs ESMFold
  via HuggingFace `EsmForProteinFolding` (no OpenFold build dependency) and writes
  structure plus attention/activation traces.
- `run_pretrained_esmf.py` — CLI entry point.
- `docs/esmfold*.md`, `docs/hpc_ice.md`, `scripts/hpc/ice/run_esmf_ice.slurm`,
  `tests/test_esmf_smoke.py`.

## Amputated from #44

- The Vite `frontend/` and `server.py` — a second dashboard in the wrong stack; the
  workbench is the dashboard.
- `vizfold/backends/base.py` — a single-implementation ABC. `ESMFoldRunner` is now a
  plain class.
- Root-level scratch scripts (`run_test.py`, `test_trace.py`), `environment-mac.yml`,
  and the committed `openfold/resources/stereo_chemical_props.txt` (a downloaded resource).
- The OpenFold CPU-fallback edits (`structure_module.py`, `attention_core.py`) — a
  separate "run OpenFold without the compiled CUDA kernel" concern, left for its own PR.

## Fixes applied

- The two full-fold tests now skip without `transformers` instead of triggering the
  2.6 GB model download.
- Attention text export renamed `attention_files/` → `attention/`, matching the
  executor's `<workspace>/attention` convention so registered attention artifacts line up.

## Test plan

- `python -m py_compile` across all 15 files — clean.
- `run_pretrained_esmf.py --help` exits 0 and lists `--fasta`/`--trace_mode`; the
  missing-FASTA path exits 1 with a clear error (both verified live).
- A real fold (attention/activation trace extraction) needs a GPU and the ESMFold
  model download, and is the remaining gate before this leaves draft.

Credit to the author of #44.
