### PR TITLE
ESMFold backend: install, status, and runnable via queue-run/execute-run

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,12 @@ Vizfold is a platform for running protein-structure models and inspecting what t
 1. Model inference & feature extraction: Run protein structure prediction models and extract intermediate activations (hidden representations) and attention maps from any chosen layer.
 2. Visualization & analysis: Explore, visualize, and analyze the extracted activations and attention maps.
 
-The `vizfold` CLI is the platform; a model backend plugs in underneath it. **OpenFold** is
-today's default (and only) backend, installed by `vizfold install`; the same `install/` scripts
-are built to host others (openfold3, boltz, esmfold) as they land.
+The `vizfold` CLI is the platform; a model backend plugs in underneath it. Install one with
+`vizfold install <backend>` — **OpenFold** (the full cluster install: micromamba env, CUDA
+extension build, AlphaFold2 databases) or **ESMFold** (a lightweight venv with PyTorch +
+Transformers, weights pulled from HuggingFace at run time). `vizfold status` shows the resolved
+config and which backends are installed. The same `install/` scripts are built to host others
+(openfold3, boltz) as they land.
 
 ---
 
@@ -25,27 +28,28 @@ curl -sL https://raw.githubusercontent.com/AI2Science/vizfold-foundation/main/in
 
 That downloads the prebuilt `vizfold` binary for your architecture from the latest GitHub
 release and installs it to `~/.local/bin` (set `VIZFOLD_VERSION=vX.Y.Z` to pin a release). Then
-install the OpenFold backend:
+install a backend — OpenFold below, or the lighter `vizfold install esmfold` (see
+[docs/esmfold.md](docs/esmfold.md)):
 
 ```bash
-vizfold install
+vizfold install openfold
 ```
 
-`vizfold install` clones the matching checkout to `$HOME/vizfold-src` on first run (the binary
+`vizfold install <backend>` clones the matching checkout to `$HOME/vizfold-src` on first run (the binary
 ships only itself; the `install/` scripts and dashboard come from there), works out where it is
 running, picks the site, submits the OpenFold install to the scheduler, and prints the exact
 command to fold a test sequence. Cold: ~8 min on NCSA Delta, ~25 min where the AlphaFold
 databases have to be downloaded.
 
-`vizfold install` holds your terminal and streams every step of the install as it happens. On a
+`vizfold install openfold` holds your terminal and streams every step of the install as it happens. On a
 cluster it runs as a blocking `srun` job, so a queue wait shows as
 `srun: job N queued and waiting for resources`. Use `tmux` or `screen` for long installs — if the
-connection drops, re-run `vizfold install` and it continues from the last completed step.
+connection drops, re-run `vizfold install openfold` and it continues from the last completed step.
 
 To keep a log, wrap the whole command rather than piping it:
 
 ```bash
-script -q -e -c 'vizfold install' install.log
+script -q -e -c 'vizfold install openfold' install.log
 ```
 
 Do not pipe to `tee` — that replaces the terminal with a pipe, which suppresses download progress
@@ -57,8 +61,8 @@ meters and makes the output arrive in delayed bursts.
 vizfold uninstall
 ```
 
-Lists everything the install generated — the conda environment and the rest of the install
-prefix, the package caches beside it, the symlinks and build droppings it left in the checkout,
+Lists everything the install generated — the conda environment (and any ESMFold venv) and the
+rest of the install prefix, the package caches beside it, the symlinks and build droppings it left in the checkout,
 the run database, the checkout it cloned into `$HOME/vizfold-src`, and
 `~/.config/vizfold/vizfold.json` — then removes it once you confirm (`--yes` skips the prompt).
 Fold outputs under the prefix, a checkout you pointed it at yourself, and the `vizfold` binary
@@ -66,8 +70,8 @@ are left alone; drop the binary with `rm ~/.local/bin/vizfold`.
 
 ### Supported clusters
 
-Dispatch is on the SLURM `ClusterName`, so on these machines `vizfold install` needs no
-arguments. Accounts and the install prefix are worked out live (your project space, the
+Dispatch is on the SLURM `ClusterName`, so on these machines `vizfold install openfold` needs no
+site arguments. Accounts and the install prefix are worked out live (your project space, the
 accounts you can charge); the values below are what a fresh install settles on.
 
 | `ClusterName` (cluster) | Verified | Arch | AF2 databases | Build → fold partition (GPU) | Install prefix |
@@ -110,7 +114,7 @@ exactly what you care about and nothing else:
 
 | | | |
 | --- | --- | --- |
-| 1 | inline environment | `OPENFOLD_PREFIX=/scratch/me/vizfold vizfold install` |
+| 1 | inline environment | `OPENFOLD_PREFIX=/scratch/me/vizfold vizfold install openfold` |
 | 2 | `~/.config/vizfold/vizfold.json` | written by the install; edit to make a choice stick |
 | 3 | `install/sites/<site>.json` | the site's defaults, in the repo — edit to change them for everyone |
 
@@ -154,7 +158,7 @@ memory:
 To override for one run, put the variable inline — it wins over both files:
 
 ```bash
-OPENFOLD_EXAMPLE=1UBQ_1 OPENFOLD_PARTITION=cpuA100x4 vizfold install
+OPENFOLD_EXAMPLE=1UBQ_1 OPENFOLD_PARTITION=cpuA100x4 vizfold install openfold
 ```
 
 Only the login-specific atom is discovered at run time (the allocation, account, or install

--- a/docs/esmfold.md
+++ b/docs/esmfold.md
@@ -4,7 +4,24 @@ The ESMFold backend runs [ESMFold](https://github.com/facebookresearch/esm) via 
 
 ## Install
 
-**Option A – conda (recommended)**  
+**Option A – `vizfold install` (recommended)**  
+The executor CLI provisions a self-contained venv (PyTorch + Transformers) and records it in
+`~/.config/vizfold/vizfold.json`:
+
+```bash
+vizfold install esmfold
+vizfold status          # shows resolved config + which backends are installed
+```
+
+Override the torch wheel when a specific CUDA build is needed:
+
+```bash
+ESMFOLD_TORCH_SPEC=torch \
+ESMFOLD_PIP_INDEX_URL=https://download.pytorch.org/whl/cu128 \
+  vizfold install esmfold
+```
+
+**Option B – conda**  
 Use `environment-mac.yml` (Mac) or `environment.yml` (Linux):
 
 ```bash
@@ -12,7 +29,7 @@ conda env create -f environment-mac.yml   # or environment.yml on Linux
 conda activate openfold-env
 ```
 
-**Option B – pip (after PyTorch is installed)**  
+**Option C – pip (after PyTorch is installed)**  
 From repo root:
 
 ```bash

--- a/install/esmfold.sh
+++ b/install/esmfold.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+# Install the ESMFold backend: a plain venv with PyTorch + Transformers. No SLURM/site machinery
+# and no AF2 databases -- ESMFold needs no CUDA build and pulls its weights from HuggingFace at
+# run time. Invoked by `vizfold install esmfold`. Idempotent: skips the pip work if the env
+# already imports torch + transformers.
+set -euo pipefail
+
+# OPENFOLD_HOME is exported by `vizfold install`; config.sh also fills unset vars from an existing
+# ~/.config/vizfold/vizfold.json (so an openfold install's PREFIX etc. carry over here).
+. "${OPENFOLD_HOME:-$(dirname "${BASH_SOURCE[0]}")/..}/install/config.sh"
+
+log() { echo "== $* (+$((SECONDS))s)"; }
+
+REPO=${OPENFOLD_HOME:-$REPO}
+PREFIX=${OPENFOLD_PREFIX:-$HOME/openfold}
+ENV=${ESMFOLD_ENV_PREFIX:-$PREFIX/esmfold-venv}
+REQ=$REPO/requirements-esmfold.txt
+test -f "$REQ" || die "$REQ not found; is $REPO a vizfold checkout?"
+command -v python3 >/dev/null || die "python3 is required to create the ESMFold venv"
+
+esmfold::present() { "$ENV/bin/python" -c 'import torch, transformers' 2>/dev/null; }
+
+esmfold::install() {
+    log "venv $ENV"
+    mkdir -p "$(dirname "$ENV")"
+    [ -x "$ENV/bin/python" ] || python3 -m venv "$ENV"
+    "$ENV/bin/python" -m pip install --upgrade pip
+    # torch first (own wheel index, e.g. a CUDA build); transformers from PyPI reads requirements.
+    log torch
+    local index=()
+    [ -n "${ESMFOLD_PIP_INDEX_URL:-}" ] && index=(--index-url "$ESMFOLD_PIP_INDEX_URL")
+    "$ENV/bin/pip" install ${index[@]+"${index[@]}"} "${ESMFOLD_TORCH_SPEC:-torch}"
+    log requirements
+    "$ENV/bin/pip" install -r "$REQ"
+}
+
+esmfold::verify() {
+    log verify
+    "$ENV/bin/python" - <<'PY'
+import torch, transformers
+print("torch", torch.__version__, "cuda", torch.cuda.is_available())
+print("transformers", transformers.__version__)
+PY
+}
+
+# Record what was resolved so `vizfold status` and the DB commands see this install.
+esmfold::config_save() {
+    log config
+    export OPENFOLD_HOME=$REPO OPENFOLD_PREFIX=$PREFIX ESMFOLD_ENV_PREFIX=$ENV
+    export VIZFOLD_DB=${VIZFOLD_DB:-$PREFIX/vizfold.db}
+    config::save OPENFOLD_HOME OPENFOLD_PREFIX ESMFOLD_ENV_PREFIX VIZFOLD_DB
+}
+
+main() {
+    if esmfold::present; then
+        log "already installed at $ENV"
+    else
+        esmfold::install
+    fi
+    esmfold::verify
+    esmfold::config_save
+    cat <<EOF
+== ready (+$((SECONDS))s)
+
+ESMFold env: $ENV
+
+Fold the bundled example (downloads facebook/esmfold_v1 on first run):
+
+  $ENV/bin/python $REPO/run_pretrained_esmf.py \\
+    --fasta $REPO/examples/monomer/fasta_dir_6KWC/6KWC.fasta \\
+    --out $PREFIX/outputs/esmf_6KWC --trace_mode none
+EOF
+}
+main "$@"

--- a/science-gateway/apps/executor/src/adapters/cli.rs
+++ b/science-gateway/apps/executor/src/adapters/cli.rs
@@ -15,8 +15,8 @@ use crate::core::{
     seed::seed_defaults,
     services::{
         artifacts, execution_targets, model_backends, model_invocation_profiles,
-        openfold_artifacts::register_known_openfold_artifacts,
-        openfold_execution::execute_openfold_run, runs,
+        openfold_artifacts::register_known_openfold_artifacts, openfold_execution::execute_run,
+        runs,
     },
 };
 
@@ -153,6 +153,41 @@ struct QueueRunArgs {
 enum QueueRunModel {
     /// Queue an OpenFold run.
     Openfold(OpenfoldQueueArgs),
+    /// Queue an ESMFold run.
+    Esmfold(EsmfoldQueueArgs),
+}
+
+#[derive(Clone, Debug, Args)]
+struct EsmfoldQueueArgs {
+    #[arg(long)]
+    input_id: String,
+    #[arg(long)]
+    input_sequence: String,
+    /// Single-sequence FASTA file to fold (ESMFold takes a file, not a directory).
+    #[arg(long)]
+    fasta: String,
+    /// Torch device. Defaults to cuda:0 when a GPU partition is configured to srun onto (the
+    /// HPC flow) or a GPU is visible locally, otherwise cpu.
+    #[arg(long)]
+    model_device: Option<String>,
+    /// HuggingFace model id.
+    #[arg(long, default_value = "facebook/esmfold_v1")]
+    model: String,
+    /// What to extract: none, attention, activations, or attention+activations.
+    #[arg(long, default_value = "attention+activations")]
+    trace_mode: String,
+    /// Layers to save: 'all' or a comma/colon list.
+    #[arg(long, default_value = "all")]
+    layers: String,
+    /// Model dtype.
+    #[arg(long, default_value = "float32")]
+    dtype: String,
+    /// Save trace tensors in fp16 to reduce size.
+    #[arg(long)]
+    save_fp16: bool,
+    /// Capture IPA attention and per-recycle backbone from the structure module.
+    #[arg(long)]
+    structure_traces: bool,
 }
 
 #[derive(Clone, Debug, Args)]
@@ -276,8 +311,9 @@ pub async fn run() -> Result<(), DbErr> {
         },
         Command::QueueRun(queue) => match queue.model {
             QueueRunModel::Openfold(args) => queue_openfold_run(&database, args).await?,
+            QueueRunModel::Esmfold(args) => queue_esmfold_run(&database, args).await?,
         },
-        Command::ExecuteRun { run_id } => execute_openfold(&database, run_id).await?,
+        Command::ExecuteRun { run_id } => execute(&database, run_id).await?,
         Command::RegisterArtifacts { run_id } => register_artifacts(&database, run_id).await?,
         Command::Install(_) | Command::Status | Command::Uninstall(_) | Command::Serve(_) => {
             unreachable!("handled before DB connect")
@@ -650,9 +686,9 @@ async fn register_artifacts(
         .one(database)
         .await?
         .ok_or_else(|| DbErr::Custom("run model backend does not exist".into()))?;
-    if backend.slug != "openfold" {
+    if !matches!(backend.slug.as_str(), "openfold" | "esmfold") {
         return Err(DbErr::Custom(format!(
-            "artifact registration is currently only implemented for OpenFold runs (run {run_id} uses backend '{}')",
+            "artifact registration is currently only implemented for OpenFold and ESMFold runs (run {run_id} uses backend '{}')",
             backend.slug
         )));
     }
@@ -693,12 +729,9 @@ async fn register_artifacts(
     Ok(())
 }
 
-async fn execute_openfold(
-    database: &sea_orm::DatabaseConnection,
-    run_id: i32,
-) -> Result<(), DbErr> {
-    println!("Executing OpenFold run {run_id}");
-    let outcome = execute_openfold_run(database, run_id, &LocalCommandRunner).await?;
+async fn execute(database: &sea_orm::DatabaseConnection, run_id: i32) -> Result<(), DbErr> {
+    println!("Executing run {run_id}");
+    let outcome = execute_run(database, run_id, &LocalCommandRunner).await?;
 
     let label = if outcome.report.has_failures() {
         "failed"
@@ -777,7 +810,7 @@ async fn queue_openfold_run(
         &config::prefix(),
         &config::openfold_env_prefix(),
     );
-    let working_dir = local_openfold_working_dir(&profile)?;
+    let working_dir = local_working_dir(&profile)?;
     let fasta_dir_input = args
         .fasta_dir
         .clone()
@@ -856,6 +889,82 @@ async fn queue_openfold_run(
     Ok(())
 }
 
+async fn queue_esmfold_run(
+    database: &sea_orm::DatabaseConnection,
+    args: EsmfoldQueueArgs,
+) -> Result<(), DbErr> {
+    let backend = model_backend_entity::Entity::find()
+        .filter(model_backend_entity::Column::Slug.eq("esmfold"))
+        .one(database)
+        .await?
+        .ok_or_else(seed_required_error)?;
+    let target = execution_target_entity::Entity::find()
+        .filter(execution_target_entity::Column::Slug.eq("local-esmfold"))
+        .one(database)
+        .await?
+        .ok_or_else(seed_required_error)?;
+    let profile = model_invocation_profiles::list_model_invocation_profiles(database)
+        .await?
+        .into_iter()
+        .find(|profile| {
+            profile.model_backend_id == backend.id
+                && profile.execution_target_id == target.id
+                && profile.invocation_kind == "local_subprocess"
+        })
+        .ok_or_else(seed_required_error)?;
+    let provenance = runs::provenance_snapshot(
+        &backend.slug,
+        backend.version.as_deref(),
+        &target.slug,
+        &profile.invocation_kind,
+        &profile.config_json,
+        &config::openfold_home(),
+        &config::prefix(),
+        &config::esmfold_env_prefix(),
+    );
+    let working_dir = local_working_dir(&profile)?;
+    let fasta = canonicalize_local_path("--fasta", &args.fasta, &working_dir)?;
+    let model_device = args
+        .model_device
+        .clone()
+        .unwrap_or_else(default_model_device);
+
+    let run = runs::submit_run(
+        database,
+        runs::SubmitRunInput {
+            model_backend_id: backend.id,
+            execution_target_id: target.id,
+            invocation_profile_id: profile.id,
+            status: "submitted".into(),
+            input_id: args.input_id,
+            input_sequence: args.input_sequence,
+            model_parameters_json: json!({
+                "model": args.model,
+                "trace_mode": args.trace_mode,
+                "layers": args.layers,
+                "dtype": args.dtype,
+                "save_fp16": args.save_fp16,
+                "structure_traces": args.structure_traces,
+            })
+            .to_string(),
+            execution_parameters_json: json!({
+                "fasta": fasta,
+                "model_device": model_device,
+            })
+            .to_string(),
+            provenance_json: Some(provenance),
+        },
+    )
+    .await?;
+
+    println!("Queued ESMFold run {}", run.id);
+    println!("status: {}", run.status);
+    println!("input_id: {}", run.input_id);
+    println!("\nNext:");
+    println!("  vizfold execute-run {}", run.id);
+    Ok(())
+}
+
 /// `<OPENFOLD_HOME>/examples/monomer/fasta_dir_<id-stem>`, matching fold.sh's `${INPUT_ID%_*}`.
 fn default_fasta_dir(input_id: &str) -> String {
     let stem = input_id.rsplit_once('_').map_or(input_id, |(head, _)| head);
@@ -873,13 +982,13 @@ fn default_alignment_dir() -> String {
         .into_owned()
 }
 
-fn local_openfold_working_dir(
+fn local_working_dir(
     profile: &crate::core::entities::model_invocation_profiles::Model,
 ) -> Result<String, DbErr> {
     let config: serde_json::Value =
         serde_json::from_str(&profile.config_json).map_err(|error| {
             DbErr::Custom(format!(
-                "local OpenFold invocation profile config_json must be valid JSON: {error}"
+                "local invocation profile config_json must be valid JSON: {error}"
             ))
         })?;
     config
@@ -889,8 +998,7 @@ fn local_openfold_working_dir(
         .map(str::to_owned)
         .ok_or_else(|| {
             DbErr::Custom(
-                "local OpenFold invocation profile config_json requires a non-empty working_dir"
-                    .into(),
+                "local invocation profile config_json requires a non-empty working_dir".into(),
             )
         })
 }
@@ -915,7 +1023,7 @@ fn canonicalize_local_path(field: &str, path: &str, working_dir: &str) -> Result
 
 fn seed_required_error() -> DbErr {
     DbErr::Custom(
-        "OpenFold backend, local-openfold target, or matching profile is missing; run `vizfold seed`"
+        "the run's backend, local execution target, or matching profile is missing; run `vizfold seed`"
             .into(),
     )
 }
@@ -1149,6 +1257,41 @@ mod tests {
             }) if input_id == "6KWC_1" && input_sequence == "GSTI"
                 && fasta_dir.as_deref() == Some("fasta") && data_dir.as_deref() == Some("data")
                 && cpus == default_cpus()
+        ));
+    }
+
+    #[test]
+    fn parses_queue_esmfold_arguments() {
+        let cli = Cli::try_parse_from([
+            "vizfold",
+            "queue-run",
+            "esmfold",
+            "--input-id",
+            "6KWC_1",
+            "--input-sequence",
+            "GSTI",
+            "--fasta",
+            "6KWC.fasta",
+            "--trace-mode",
+            "attention",
+            "--save-fp16",
+        ])
+        .expect("queue-run esmfold command should parse");
+
+        assert!(matches!(
+            cli.command,
+            Command::QueueRun(QueueRunArgs {
+                model: QueueRunModel::Esmfold(EsmfoldQueueArgs {
+                    input_id,
+                    fasta,
+                    trace_mode,
+                    save_fp16: true,
+                    structure_traces: false,
+                    ref model,
+                    ..
+                })
+            }) if input_id == "6KWC_1" && fasta == "6KWC.fasta" && trace_mode == "attention"
+                && model == "facebook/esmfold_v1"
         ));
     }
 

--- a/science-gateway/apps/executor/src/adapters/cli.rs
+++ b/science-gateway/apps/executor/src/adapters/cli.rs
@@ -1,4 +1,4 @@
-use clap::{ArgAction, Args, Parser, Subcommand};
+use clap::{ArgAction, Args, Parser, Subcommand, ValueEnum};
 use sea_orm::{ColumnTrait, DbErr, EntityTrait, QueryFilter};
 use serde_json::json;
 use std::path::{Path, PathBuf};
@@ -29,8 +29,10 @@ pub struct Cli {
 
 #[derive(Debug, Subcommand)]
 enum Command {
-    /// Install a model backend (OpenFold) on this machine.
-    Install,
+    /// Install a model backend (openfold or esmfold) on this machine.
+    Install(InstallArgs),
+    /// Show resolved config and which backends are installed.
+    Status,
     /// Remove everything the install generated.
     Uninstall(UninstallArgs),
     /// Start the workbench dashboard.
@@ -47,6 +49,50 @@ enum Command {
     ExecuteRun { run_id: i32 },
     /// Register known artifacts for a completed run.
     RegisterArtifacts { run_id: i32 },
+}
+
+#[derive(Debug, Args)]
+struct InstallArgs {
+    /// Model backend to install.
+    #[arg(value_enum)]
+    backend: Backend,
+}
+
+/// A model backend `vizfold install` can provision. Each knows the installer script it runs
+/// (relative to the checkout) and the env prefix whose presence means "installed".
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+enum Backend {
+    Openfold,
+    Esmfold,
+}
+
+impl Backend {
+    fn slug(self) -> &'static str {
+        match self {
+            Self::Openfold => "openfold",
+            Self::Esmfold => "esmfold",
+        }
+    }
+
+    /// Installer script, relative to the vizfold checkout. `init.sh` picks a site and dispatches
+    /// OpenFold's cluster install; `esmfold.sh` is a self-contained venv install.
+    fn installer(self) -> &'static str {
+        match self {
+            Self::Openfold => "install/init.sh",
+            Self::Esmfold => "install/esmfold.sh",
+        }
+    }
+
+    fn env_prefix(self) -> PathBuf {
+        match self {
+            Self::Openfold => config::openfold_env_prefix(),
+            Self::Esmfold => config::esmfold_env_prefix(),
+        }
+    }
+
+    fn is_installed(self) -> bool {
+        self.env_prefix().is_dir()
+    }
 }
 
 #[derive(Debug, Args)]
@@ -193,17 +239,21 @@ fn clamp_cpus(cpus: i64, available_resources_json: &str) -> i64 {
 pub async fn run() -> Result<(), DbErr> {
     let cli = Cli::parse();
 
-    // `install` is the bootstrap and `uninstall` cleans up after a partial one; everything
-    // else requires an initialized config.
-    if !matches!(cli.command, Command::Install | Command::Uninstall(_)) && !config::is_initialized()
+    // `install` is the bootstrap, `uninstall` cleans up after a partial one, and `status` reports
+    // where things stand before either has run; everything else requires an initialized config.
+    if !matches!(
+        cli.command,
+        Command::Install(_) | Command::Uninstall(_) | Command::Status
+    ) && !config::is_initialized()
     {
-        eprintln!("run `vizfold install` first");
+        eprintln!("run `vizfold install openfold` first");
         std::process::exit(1);
     }
 
-    // These three touch the filesystem only; they need no database connection.
+    // These touch the filesystem only; they need no database connection.
     match cli.command {
-        Command::Install => return run_install(),
+        Command::Install(args) => return run_install(args.backend),
+        Command::Status => return run_status(),
         Command::Uninstall(args) => return run_uninstall(args),
         Command::Serve(args) => return run_serve(args),
         _ => {}
@@ -229,7 +279,7 @@ pub async fn run() -> Result<(), DbErr> {
         },
         Command::ExecuteRun { run_id } => execute_openfold(&database, run_id).await?,
         Command::RegisterArtifacts { run_id } => register_artifacts(&database, run_id).await?,
-        Command::Install | Command::Uninstall(_) | Command::Serve(_) => {
+        Command::Install(_) | Command::Status | Command::Uninstall(_) | Command::Serve(_) => {
             unreachable!("handled before DB connect")
         }
     }
@@ -237,22 +287,28 @@ pub async fn run() -> Result<(), DbErr> {
     Ok(())
 }
 
-/// Install a model backend (OpenFold) by running the checkout's `install/init.sh` with
-/// inherited stdio. The release binary ships only itself, so the checkout is cloned on
-/// first install. Idempotent: its steps are sentinel-guarded, so re-running is safe.
-fn run_install() -> Result<(), DbErr> {
+/// Install a model backend by running the checkout's installer for it (`install/init.sh` for
+/// OpenFold, `install/esmfold.sh` for ESMFold) with inherited stdio. The release binary ships
+/// only itself, so the checkout is cloned on first install. Idempotent: the installers are
+/// sentinel- or import-guarded, so re-running is safe.
+fn run_install(backend: Backend) -> Result<(), DbErr> {
     let src = config::vizfold_src();
-    let installer = src.join("install/init.sh");
+    let installer = src.join(backend.installer());
     if !installer.is_file() {
         clone_checkout(&src)?;
     }
     if !installer.is_file() {
         return Err(DbErr::Custom(format!(
-            "no vizfold checkout at {}; set VIZFOLD_SRC to a checkout",
-            src.display()
+            "no {} installer at {}; set VIZFOLD_SRC to a checkout",
+            backend.slug(),
+            installer.display()
         )));
     }
-    println!("Running model install: bash {}", installer.display());
+    println!(
+        "Installing {}: bash {}",
+        backend.slug(),
+        installer.display()
+    );
     let status = std::process::Command::new("bash")
         .arg(&installer)
         .env("OPENFOLD_HOME", &src)
@@ -262,6 +318,50 @@ fn run_install() -> Result<(), DbErr> {
         .success()
         .then_some(())
         .ok_or_else(|| DbErr::Custom(format!("model install exited with status {status}")))
+}
+
+/// Report resolved config plus which backends are installed. Runs before any install (so it can
+/// say "nothing initialized yet") and needs no database.
+fn run_status() -> Result<(), DbErr> {
+    let config_file = config::config_file();
+    println!("VizFold status\n");
+    if config::is_initialized() {
+        println!("Config: {}", config_file.display());
+        for (key, value) in config::config_entries() {
+            println!("  {key} = {value}");
+        }
+    } else {
+        println!("Config: {} (not initialized)", config_file.display());
+    }
+    if let Some(database) = config::database_path() {
+        let state = if database.is_file() {
+            "present"
+        } else {
+            "not created yet"
+        };
+        println!("  database = {} ({state})", database.display());
+    }
+
+    println!("\nBackends:");
+    print_table(
+        &["BACKEND", "STATUS", "ENV PREFIX"],
+        [Backend::Openfold, Backend::Esmfold]
+            .into_iter()
+            .map(|backend| {
+                let status = if backend.is_installed() {
+                    "installed"
+                } else {
+                    "not installed"
+                };
+                vec![
+                    backend.slug().to_owned(),
+                    status.to_owned(),
+                    backend.env_prefix().display().to_string(),
+                ]
+            })
+            .collect(),
+    );
+    Ok(())
 }
 
 /// Clone the vizfold checkout `vizfold install` runs its scripts (and serves the dashboard)
@@ -361,6 +461,7 @@ fn install_paths(prefix: &Path, home: &Path) -> Vec<PathBuf> {
         ".done",
         "params",
         "workbench",
+        "esmfold-venv",
         "vizfold.db",
     ]
     .iter()
@@ -1086,10 +1187,46 @@ mod tests {
     }
 
     #[test]
-    fn parses_install() {
-        let cli =
-            Cli::try_parse_from(["vizfold", "install"]).expect("install command should parse");
-        assert!(matches!(cli.command, Command::Install));
+    fn parses_install_backend() {
+        for (arg, want) in [
+            ("openfold", Backend::Openfold),
+            ("esmfold", Backend::Esmfold),
+        ] {
+            let cli = Cli::try_parse_from(["vizfold", "install", arg])
+                .expect("install <backend> should parse");
+            assert!(
+                matches!(cli.command, Command::Install(InstallArgs { backend }) if backend == want)
+            );
+        }
+        // The backend is required and constrained to the known set.
+        assert!(Cli::try_parse_from(["vizfold", "install"]).is_err());
+        assert!(Cli::try_parse_from(["vizfold", "install", "rosetta"]).is_err());
+    }
+
+    #[test]
+    fn parses_status() {
+        let cli = Cli::try_parse_from(["vizfold", "status"]).expect("status command should parse");
+        assert!(matches!(cli.command, Command::Status));
+    }
+
+    #[test]
+    fn backend_is_installed_tracks_its_env_prefix() {
+        let base = std::env::temp_dir().join(format!("vizfold-backend-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&base);
+        std::fs::create_dir_all(&base).unwrap();
+        // env_prefix() reads config; pin ESMFOLD_ENV_PREFIX so the check is deterministic.
+        // SAFETY: single-threaded test, no other thread reads the env concurrently.
+        unsafe { std::env::set_var("ESMFOLD_ENV_PREFIX", &base) };
+        assert!(
+            Backend::Esmfold.is_installed(),
+            "an existing env dir reads as installed"
+        );
+        std::fs::remove_dir_all(&base).unwrap();
+        assert!(
+            !Backend::Esmfold.is_installed(),
+            "a missing env dir reads as not installed"
+        );
+        unsafe { std::env::remove_var("ESMFOLD_ENV_PREFIX") };
     }
 
     #[test]
@@ -1123,6 +1260,7 @@ mod tests {
             prefix.join("data"),
             prefix.join(".done"),
             prefix.join("nvrtc-12.2"),
+            prefix.join("esmfold-venv"),
             base.join(".openfold-pkgs"),
             home.join("openfold/resources/params"),
         ] {
@@ -1179,7 +1317,8 @@ mod tests {
     fn copy_tree_skips_a_symlinked_directory() {
         // public/runs is a symlink to the run outputs; fs::copy would follow it into a directory
         // and fail with EISDIR. The stage must skip it, not choke on it.
-        let base = std::env::temp_dir().join(format!("vizfold-copytree-link-{}", std::process::id()));
+        let base =
+            std::env::temp_dir().join(format!("vizfold-copytree-link-{}", std::process::id()));
         let (src, dst, outputs) = (base.join("src"), base.join("dst"), base.join("outputs"));
         let _ = std::fs::remove_dir_all(&base);
         std::fs::create_dir_all(src.join("public")).unwrap();

--- a/science-gateway/apps/executor/src/core/config.rs
+++ b/science-gateway/apps/executor/src/core/config.rs
@@ -88,6 +88,24 @@ pub fn openfold_env_prefix() -> PathBuf {
         .unwrap_or_else(|| prefix().join("mamba/envs/openfold-env"))
 }
 
+/// venv prefix for the ESMFold backend (matches `install/esmfold.sh`'s
+/// `${ESMFOLD_ENV_PREFIX:-$PREFIX/esmfold-venv}`).
+pub fn esmfold_env_prefix() -> PathBuf {
+    resolved("ESMFOLD_ENV_PREFIX")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| prefix().join("esmfold-venv"))
+}
+
+/// The install-resolved config map as sorted (key, value) string pairs, for `vizfold status`.
+pub fn config_entries() -> Vec<(String, String)> {
+    let mut entries: Vec<(String, String)> = vizfold_config()
+        .iter()
+        .filter_map(|(key, value)| Some((key.clone(), value.as_str()?.to_owned())))
+        .collect();
+    entries.sort();
+    entries
+}
+
 pub fn prefix() -> PathBuf {
     resolved("OPENFOLD_PREFIX")
         .map(PathBuf::from)

--- a/science-gateway/apps/executor/src/core/model_runners/esmfold.rs
+++ b/science-gateway/apps/executor/src/core/model_runners/esmfold.rs
@@ -1,0 +1,168 @@
+use std::path::Path;
+
+use sea_orm::DbErr;
+use serde_json::Value;
+
+use crate::core::{
+    commands::CommandSpec,
+    entities::{model_invocation_profiles, runs},
+    output_locations::resolve_output_location,
+    preflight::{PreflightCheck, PreflightReport},
+};
+
+use super::openfold::{
+    base_command_checks, detect_gpu, gpu_check, input_id_check, output_dir_check,
+};
+
+/// Preflight for an ESMFold `run_pretrained_esmf.py` command. ESMFold is single-sequence
+/// (HuggingFace `EsmForProteinFolding`, weights fetched at run time) so it needs none of
+/// OpenFold's MSA/template checks: just the command itself, a readable `--fasta` file, and a
+/// writable output workspace. The planned command is built by the shared schema-driven planner.
+pub fn preflight_esmfold(
+    command: &CommandSpec,
+    invocation_profile: &model_invocation_profiles::Model,
+    run: &runs::Model,
+) -> Result<PreflightReport, DbErr> {
+    let execution_parameters: Value = serde_json::from_str(&run.execution_parameters_json)
+        .map_err(|error| {
+            DbErr::Custom(format!(
+                "run execution_parameters_json must be valid JSON: {error}"
+            ))
+        })?;
+
+    let mut checks = vec![gpu_check(detect_gpu().as_deref())];
+    checks.extend(base_command_checks(command));
+    checks.push(input_id_check(&run.input_id));
+    checks.push(fasta_file_check(&execution_parameters));
+    checks.push(output_dir_check(&resolve_output_location(
+        invocation_profile,
+        run,
+    )?));
+
+    Ok(PreflightReport::new(checks))
+}
+
+/// ESMFold folds a single FASTA *file* (`--fasta`), unlike OpenFold's `fasta_dir`.
+fn fasta_file_check(execution_parameters: &Value) -> PreflightCheck {
+    let Some(fasta) = execution_parameters
+        .get("fasta")
+        .and_then(Value::as_str)
+        .filter(|path| !path.trim().is_empty())
+    else {
+        return PreflightCheck::failed("fasta", "fasta is missing");
+    };
+
+    if Path::new(fasta).is_file() {
+        PreflightCheck::passed("fasta", format!("'{fasta}' exists"))
+    } else {
+        PreflightCheck::failed(
+            "fasta",
+            format!("'{fasta}' does not exist or is not a file"),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use chrono::Utc;
+    use serde_json::json;
+
+    use crate::core::{
+        commands::CommandSpec,
+        entities::{model_invocation_profiles, runs},
+        preflight::PreflightStatus,
+        test_support::TestLayout,
+    };
+
+    use super::preflight_esmfold;
+
+    fn invocation_profile(output_location: &std::path::Path) -> model_invocation_profiles::Model {
+        let now = Utc::now();
+        model_invocation_profiles::Model {
+            id: 3,
+            model_backend_id: 1,
+            execution_target_id: 2,
+            invocation_kind: "local_subprocess".into(),
+            config_json: json!({ "output_location": output_location }).to_string(),
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    fn run(execution_parameters: serde_json::Value) -> runs::Model {
+        let now = Utc::now();
+        runs::Model {
+            id: 4,
+            model_backend_id: 1,
+            execution_target_id: 2,
+            invocation_profile_id: 3,
+            status: "submitted".into(),
+            input_id: "6KWC_1".into(),
+            input_sequence: "MSTNPKPQRITF".into(),
+            model_parameters_json: "{}".into(),
+            execution_parameters_json: execution_parameters.to_string(),
+            provenance_json: None,
+            submitted_at: now,
+            started_at: None,
+            completed_at: None,
+            error_message: None,
+        }
+    }
+
+    fn command(layout: &TestLayout) -> CommandSpec {
+        CommandSpec {
+            program: "python3".into(),
+            args: vec!["-u".into(), "run_openfold.py".into()],
+            current_dir: Some(layout.working_dir.clone()),
+            ..Default::default()
+        }
+    }
+
+    fn status(report: &crate::core::preflight::PreflightReport, name: &str) -> PreflightStatus {
+        report
+            .checks
+            .iter()
+            .find(|check| check.name == name)
+            .unwrap_or_else(|| panic!("{name} check should be present"))
+            .status
+    }
+
+    #[test]
+    fn passes_when_fasta_file_and_workspace_parent_exist() {
+        let layout = TestLayout::new("6KWC_1");
+        let fasta = layout.fasta_dir.join("6KWC.fasta");
+        fs::write(&fasta, ">6KWC_1\nMSTNPKPQRITF\n").expect("fasta should be written");
+
+        let report = preflight_esmfold(
+            &command(&layout),
+            &invocation_profile(&layout.output_location),
+            &run(json!({ "fasta": fasta, "model_device": "cpu" })),
+        )
+        .expect("preflight should inspect local paths");
+
+        assert!(!report.has_failures());
+        assert_eq!(status(&report, "fasta"), PreflightStatus::Passed);
+        assert_eq!(
+            status(&report, "output_dir parent"),
+            PreflightStatus::Passed
+        );
+        // No MSA/template checks exist for ESMFold.
+        assert!(!report.checks.iter().any(|check| check.name == "data_dir"));
+    }
+
+    #[test]
+    fn fails_when_fasta_file_is_missing() {
+        let layout = TestLayout::new("6KWC_1");
+        let report = preflight_esmfold(
+            &command(&layout),
+            &invocation_profile(&layout.output_location),
+            &run(json!({ "fasta": layout.fasta_dir.join("absent.fasta") })),
+        )
+        .expect("preflight should inspect the fasta path");
+
+        assert!(report.has_failures());
+        assert_eq!(status(&report, "fasta"), PreflightStatus::Failed);
+    }
+}

--- a/science-gateway/apps/executor/src/core/model_runners/mod.rs
+++ b/science-gateway/apps/executor/src/core/model_runners/mod.rs
@@ -1,1 +1,2 @@
+pub mod esmfold;
 pub mod openfold;

--- a/science-gateway/apps/executor/src/core/model_runners/openfold.rs
+++ b/science-gateway/apps/executor/src/core/model_runners/openfold.rs
@@ -94,67 +94,8 @@ pub fn preflight_openfold(
         "run execution_parameters_json",
         &run.execution_parameters_json,
     )?;
-    let mut checks = Vec::new();
-    checks.push(gpu_check(detect_gpu().as_deref()));
-
-    if command.program.trim().is_empty() {
-        checks.push(PreflightCheck::failed(
-            "program configured",
-            "command program is empty",
-        ));
-    } else {
-        checks.push(PreflightCheck::passed(
-            "program configured",
-            format!("program '{}' is configured", command.program),
-        ));
-    }
-
-    let script = script_argument(command);
-    match script {
-        Some(script) => checks.push(PreflightCheck::passed(
-            "script argument configured",
-            format!("script argument '{script}' follows -u"),
-        )),
-        None => checks.push(PreflightCheck::failed(
-            "script argument configured",
-            "command args must include a script argument after -u",
-        )),
-    }
-
-    match &command.current_dir {
-        Some(current_dir) if current_dir.is_dir() => checks.push(PreflightCheck::passed(
-            "working directory",
-            format!("working directory '{}' exists", current_dir.display()),
-        )),
-        Some(current_dir) => checks.push(PreflightCheck::failed(
-            "working directory",
-            format!(
-                "working directory '{}' does not exist or is not a directory",
-                current_dir.display()
-            ),
-        )),
-        None => checks.push(PreflightCheck::warning(
-            "working directory",
-            "no working directory is configured; script resolution may depend on the caller",
-        )),
-    }
-
-    match (script, &command.current_dir) {
-        (Some(script), _) if Path::new(script).is_absolute() => {
-            checks.push(path_exists_check("script file", Path::new(script)));
-        }
-        (Some(script), Some(current_dir)) => {
-            checks.push(path_exists_check("script file", &current_dir.join(script)));
-        }
-        (Some(script), None) => checks.push(PreflightCheck::warning(
-            "script file",
-            format!("relative script '{script}' cannot be resolved without a working directory"),
-        )),
-        (None, _) => checks.push(PreflightCheck::failed(
-            "script file",
-            "script path is unavailable because the -u script argument is missing",
-        )),
-    }
+    let mut checks = vec![gpu_check(detect_gpu().as_deref())];
+    checks.extend(base_command_checks(command));
 
     checks.push(input_id_check(&run.input_id));
     checks.push(fasta_input_check(&execution_parameters, &run.input_id));
@@ -197,6 +138,69 @@ pub fn gpu_check(detected: Option<&str>) -> PreflightCheck {
     }
 }
 
+/// Program/script-argument/working-directory/script-file checks shared by every local_subprocess
+/// backend's preflight (OpenFold, ESMFold): they validate the planned command itself, independent
+/// of a backend's inputs. Callers push these after `gpu_check` and before their own input checks.
+pub(super) fn base_command_checks(command: &CommandSpec) -> Vec<PreflightCheck> {
+    let program = if command.program.trim().is_empty() {
+        PreflightCheck::failed("program configured", "command program is empty")
+    } else {
+        PreflightCheck::passed(
+            "program configured",
+            format!("program '{}' is configured", command.program),
+        )
+    };
+
+    let script = script_argument(command);
+    let script_arg = match script {
+        Some(script) => PreflightCheck::passed(
+            "script argument configured",
+            format!("script argument '{script}' follows -u"),
+        ),
+        None => PreflightCheck::failed(
+            "script argument configured",
+            "command args must include a script argument after -u",
+        ),
+    };
+
+    let working_dir = match &command.current_dir {
+        Some(current_dir) if current_dir.is_dir() => PreflightCheck::passed(
+            "working directory",
+            format!("working directory '{}' exists", current_dir.display()),
+        ),
+        Some(current_dir) => PreflightCheck::failed(
+            "working directory",
+            format!(
+                "working directory '{}' does not exist or is not a directory",
+                current_dir.display()
+            ),
+        ),
+        None => PreflightCheck::warning(
+            "working directory",
+            "no working directory is configured; script resolution may depend on the caller",
+        ),
+    };
+
+    let script_file = match (script, &command.current_dir) {
+        (Some(script), _) if Path::new(script).is_absolute() => {
+            path_exists_check("script file", Path::new(script))
+        }
+        (Some(script), Some(current_dir)) => {
+            path_exists_check("script file", &current_dir.join(script))
+        }
+        (Some(script), None) => PreflightCheck::warning(
+            "script file",
+            format!("relative script '{script}' cannot be resolved without a working directory"),
+        ),
+        (None, _) => PreflightCheck::failed(
+            "script file",
+            "script path is unavailable because the -u script argument is missing",
+        ),
+    };
+
+    vec![program, script_arg, working_dir, script_file]
+}
+
 fn script_argument(command: &CommandSpec) -> Option<&str> {
     command
         .args
@@ -207,7 +211,7 @@ fn script_argument(command: &CommandSpec) -> Option<&str> {
         .filter(|script| !script.is_empty())
 }
 
-fn path_exists_check(name: &str, path: &Path) -> PreflightCheck {
+pub(super) fn path_exists_check(name: &str, path: &Path) -> PreflightCheck {
     if path.exists() {
         PreflightCheck::passed(name, format!("'{}' exists", path.display()))
     } else {
@@ -230,7 +234,7 @@ fn required_directory_check(parameters: &Value, field_name: &str) -> PreflightCh
     }
 }
 
-fn input_id_check(input_id: &str) -> PreflightCheck {
+pub(super) fn input_id_check(input_id: &str) -> PreflightCheck {
     if input_id.trim().is_empty() {
         PreflightCheck::failed("input_id", "run input_id is missing or empty")
     } else {
@@ -401,7 +405,7 @@ fn precomputed_alignment_key_check(parameters: &Value, input_id: &str) -> Prefli
     }
 }
 
-fn output_dir_check(output_path: &Path) -> PreflightCheck {
+pub(super) fn output_dir_check(output_path: &Path) -> PreflightCheck {
     if output_path.exists() {
         return if output_path.is_dir() {
             PreflightCheck::passed(

--- a/science-gateway/apps/executor/src/core/seed.rs
+++ b/science-gateway/apps/executor/src/core/seed.rs
@@ -222,6 +222,92 @@ pub async fn seed_defaults(db: &DatabaseConnection) -> Result<(), DbErr> {
         .await?;
     }
 
+    seed_esmfold(db).await?;
+
+    Ok(())
+}
+
+/// ESMFold catalog rows: the backend's CLI schema, a local execution target, and a
+/// local_subprocess profile pointing at `run_pretrained_esmf.py`. Single-sequence, so no
+/// AlphaFold2 database schema -- just the model/trace flags and a `--device`.
+async fn seed_esmfold(db: &DatabaseConnection) -> Result<(), DbErr> {
+    if model_backends::Entity::find()
+        .filter(model_backends::Column::Slug.eq("esmfold"))
+        .one(db)
+        .await?
+        .is_none()
+    {
+        services::model_backends::register_model_backend(
+            db,
+            services::model_backends::RegisterModelBackendInput {
+                slug: "esmfold".into(),
+                label: "ESMFold".into(),
+                version: Some("esmfold_v1".into()),
+                description: Some("ESMFold backend (HuggingFace EsmForProteinFolding).".into()),
+                artifact_capabilities_json:
+                    r#"{"structure":{"formats":["pdb"],"required":true}}"#.into(),
+                parameter_schema_json:
+                    r#"{"type":"object","properties":{"fasta":{"type":"path","source":"execution_parameters","parameter":"fasta","cli_flag":"--fasta"},"out":{"type":"path","source":"run_output_workspace","cli_flag":"--out"},"model":{"type":"string","default":"facebook/esmfold_v1","cli_flag":"--model"},"dtype":{"type":"string","default":"float32","cli_flag":"--dtype"},"trace_mode":{"type":"string","default":"attention+activations","cli_flag":"--trace_mode"},"layers":{"type":"string","default":"all","cli_flag":"--layers"},"heads":{"type":"string","default":"all","cli_flag":"--heads"},"top_k":{"type":"integer","default":50,"cli_flag":"--top_k"},"save_fp16":{"type":"boolean","cli_flag":"--save_fp16"},"structure_traces":{"type":"boolean","cli_flag":"--structure_traces"}}}"#
+                        .into(),
+            },
+        )
+        .await?;
+    }
+
+    if execution_targets::Entity::find()
+        .filter(execution_targets::Column::Slug.eq("local-esmfold"))
+        .one(db)
+        .await?
+        .is_none()
+    {
+        services::execution_targets::register_execution_target(
+            db,
+            services::execution_targets::RegisterExecutionTargetInput {
+                slug: "local-esmfold".into(),
+                target_type: "local".into(),
+                description: Some("Local ESMFold subprocess execution target.".into()),
+                available_resources_json:
+                    r#"{"type":"object","properties":{"model_device":{"type":"string","enum":["cpu","cuda","cuda:0"],"default":"cuda:0","cli_flag":"--device"}}}"#
+                        .into(),
+            },
+        )
+        .await?;
+    }
+
+    let backend = model_backends::Entity::find()
+        .filter(model_backends::Column::Slug.eq("esmfold"))
+        .one(db)
+        .await?
+        .ok_or_else(|| DbErr::Custom("seeded ESMFold model backend is missing".into()))?;
+    let target = execution_targets::Entity::find()
+        .filter(execution_targets::Column::Slug.eq("local-esmfold"))
+        .one(db)
+        .await?
+        .ok_or_else(|| DbErr::Custom("seeded local ESMFold execution target is missing".into()))?;
+
+    let config = local_esmfold_config_json();
+    if let Some(profile) = model_invocation_profiles::Entity::find()
+        .filter(model_invocation_profiles::Column::ModelBackendId.eq(backend.id))
+        .filter(model_invocation_profiles::Column::ExecutionTargetId.eq(target.id))
+        .one(db)
+        .await?
+    {
+        if profile.config_json != config {
+            services::model_invocation_profiles::update_config(db, profile.id, config).await?;
+        }
+    } else {
+        services::model_invocation_profiles::register_model_invocation_profile(
+            db,
+            services::model_invocation_profiles::RegisterModelInvocationProfileInput {
+                model_backend_id: backend.id,
+                execution_target_id: target.id,
+                invocation_kind: "local_subprocess".into(),
+                config_json: config,
+            },
+        )
+        .await?;
+    }
+
     Ok(())
 }
 
@@ -229,6 +315,16 @@ fn local_openfold_config_json() -> String {
     json!({
         "program": "python3",
         "script": "run_pretrained_openfold.py",
+        "working_dir": config::openfold_home(),
+        "output_location": config::prefix().join("runs"),
+    })
+    .to_string()
+}
+
+fn local_esmfold_config_json() -> String {
+    json!({
+        "program": "python3",
+        "script": "run_pretrained_esmf.py",
         "working_dir": config::openfold_home(),
         "output_location": config::prefix().join("runs"),
     })

--- a/science-gateway/apps/executor/src/core/services/openfold_execution.rs
+++ b/science-gateway/apps/executor/src/core/services/openfold_execution.rs
@@ -7,22 +7,51 @@ use crate::core::{
     commands::{CommandOutput, CommandRunner, CommandSpec},
     config,
     entities::{execution_targets, model_backends, model_invocation_profiles, runs as run_entity},
-    model_runners::openfold::{plan_openfold_command, preflight_openfold},
+    model_runners::{
+        esmfold::preflight_esmfold,
+        openfold::{plan_openfold_command, preflight_openfold},
+    },
     output_locations::resolve_output_location,
     preflight::PreflightReport,
 };
 
 use super::runs::{self, UpdateRunStatusInput};
 
-/// Outcome of planning, preflighting, and (if preflight passed) executing an OpenFold run.
+/// Which backend a run targets. Selects the preflight and the way the planned command is wrapped
+/// for execution; the schema-driven planner and artifact registration are shared. Unknown slugs
+/// fall through to OpenFold (the default backend, and what the execution tests register).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum BackendKind {
+    Openfold,
+    Esmfold,
+}
+
+impl BackendKind {
+    fn from_slug(slug: &str) -> Self {
+        match slug {
+            "esmfold" => Self::Esmfold,
+            _ => Self::Openfold,
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Openfold => "OpenFold",
+            Self::Esmfold => "ESMFold",
+        }
+    }
+}
+
+/// Outcome of planning, preflighting, and (if preflight passed) executing a run.
 #[derive(Debug)]
 pub struct ExecutionOutcome {
     pub report: PreflightReport,
     pub output: Option<CommandOutput>,
 }
 
-/// Plans and executes an OpenFold run stored in the executor database.
-pub async fn execute_openfold_run(
+/// Plans and executes a run stored in the executor database, dispatching preflight and env
+/// wrapping on the run's model backend (OpenFold or ESMFold).
+pub async fn execute_run(
     db: &DatabaseConnection,
     run_id: i32,
     runner: &dyn CommandRunner,
@@ -33,11 +62,13 @@ pub async fn execute_openfold_run(
         .ok_or_else(|| DbErr::Custom(format!("run {run_id} does not exist")))?;
 
     let started_at = Utc::now();
+    let mut kind = BackendKind::Openfold;
     let execution: Result<ExecutionOutcome, DbErr> = async {
         let model_backend = model_backends::Entity::find_by_id(run.model_backend_id)
             .one(db)
             .await?
             .ok_or_else(|| DbErr::Custom("model backend does not exist".into()))?;
+        kind = BackendKind::from_slug(&model_backend.slug);
         let execution_target = execution_targets::Entity::find_by_id(run.execution_target_id)
             .one(db)
             .await?
@@ -48,32 +79,50 @@ pub async fn execute_openfold_run(
                 .await?
                 .ok_or_else(|| DbErr::Custom("model invocation profile does not exist".into()))?;
 
-        // fold.sh does `mkdir -p "$OUTPUT_DIR"`; create the run workspace (+ attention/)
-        // so a fresh install runs without a manual mkdir and preflight's output_dir check passes.
+        // Create the run workspace so a fresh install runs without a manual mkdir and preflight's
+        // output_dir check passes. OpenFold also seeds attention/ (its --attn_map_dir target);
+        // ESMFold's script creates its own subdirs under --out.
         let workspace = resolve_output_location(&invocation_profile, &run)?;
-        std::fs::create_dir_all(workspace.join("attention")).map_err(|error| {
+        let to_create = match kind {
+            BackendKind::Openfold => workspace.join("attention"),
+            BackendKind::Esmfold => workspace.clone(),
+        };
+        std::fs::create_dir_all(&to_create).map_err(|error| {
             DbErr::Custom(format!(
                 "failed to create run output workspace '{}': {error}",
                 workspace.display()
             ))
         })?;
 
+        // The shared schema-driven planner emits either backend's CLI from its parameter schema.
         let command =
             plan_openfold_command(&model_backend, &execution_target, &invocation_profile, &run)?;
 
-        // Preflight validates the real python3 command; the runner gets an env-activated
-        // wrapper so torch/openfold resolve without a manual `micromamba activate`. Gated on
-        // micromamba actually being installed at the prefix (so tests/dev run the command bare).
-        let prefix = config::prefix();
-        let exec_command = compose_exec_command(
-            &command,
-            &prefix,
-            &config::openfold_env_prefix(),
-            &config::gpu_launch_args(),
-            prefix.join("bin/micromamba").is_file(),
-        );
+        // Preflight validates the bare command; the runner gets an env-wrapped one so the model's
+        // deps resolve. OpenFold activates its micromamba env; ESMFold runs its venv's python.
+        // Both gate on the env actually being installed, so tests/dev run the command bare.
+        let exec_command = match kind {
+            BackendKind::Openfold => {
+                let prefix = config::prefix();
+                compose_exec_command(
+                    &command,
+                    &prefix,
+                    &config::openfold_env_prefix(),
+                    &config::gpu_launch_args(),
+                    prefix.join("bin/micromamba").is_file(),
+                )
+            }
+            BackendKind::Esmfold => {
+                let env_prefix = config::esmfold_env_prefix();
+                let use_venv = env_prefix.join("bin/python").is_file();
+                compose_esmfold_command(&command, &env_prefix, &config::gpu_launch_args(), use_venv)
+            }
+        };
 
-        let report = preflight_openfold(&command, &invocation_profile, &run)?;
+        let report = match kind {
+            BackendKind::Openfold => preflight_openfold(&command, &invocation_profile, &run)?,
+            BackendKind::Esmfold => preflight_esmfold(&command, &invocation_profile, &run)?,
+        };
         if report.has_failures() {
             return Ok(ExecutionOutcome {
                 report,
@@ -110,9 +159,9 @@ pub async fn execute_openfold_run(
                 .filter_map(|check| check.message.as_deref())
                 .collect::<Vec<_>>();
             let message = if failures.is_empty() {
-                "OpenFold preflight failed".to_owned()
+                format!("{} preflight failed", kind.label())
             } else {
-                format!("OpenFold preflight failed: {}", failures.join("; "))
+                format!("{} preflight failed: {}", kind.label(), failures.join("; "))
             };
             mark_failed(db, run_id, started_at, message).await?;
             Ok(outcome)
@@ -139,7 +188,11 @@ pub async fn execute_openfold_run(
                 super::openfold_artifacts::register_known_openfold_artifacts(db, run_id).await?;
             } else {
                 let message = if output.stderr.trim().is_empty() {
-                    format!("OpenFold command exited with code {}", output.exit_code)
+                    format!(
+                        "{} command exited with code {}",
+                        kind.label(),
+                        output.exit_code
+                    )
                 } else {
                     output.stderr.trim().to_owned()
                 };
@@ -227,6 +280,30 @@ fn compose_exec_command(
     }
 }
 
+/// Wrap a planned ESMFold command for execution. ESMFold installs into a plain venv (no
+/// micromamba, no activate.d hook), so running its interpreter directly -- `<env>/bin/python` --
+/// is the whole activation. srun still wraps it so the fold lands on a GPU node when a partition
+/// is configured. `use_venv` is false in tests/dev (no venv installed): the command runs bare.
+fn compose_esmfold_command(
+    command: &CommandSpec,
+    env_prefix: &Path,
+    launch: &[String],
+    use_venv: bool,
+) -> CommandSpec {
+    let command = if use_venv {
+        CommandSpec {
+            program: env_prefix.join("bin/python").display().to_string(),
+            ..command.clone()
+        }
+    } else {
+        command.clone()
+    };
+    CommandSpec {
+        stream: true,
+        ..srun_command(command, launch)
+    }
+}
+
 /// Prefix a command with the SLURM launcher. Applied *outside* the micromamba wrapper so the
 /// environment is activated on the compute node, not the submit host.
 fn srun_command(command: CommandSpec, launch: &[String]) -> CommandSpec {
@@ -271,7 +348,7 @@ mod tests {
         test_support::TestLayout,
     };
 
-    use super::{activate_env_command, compose_exec_command, execute_openfold_run};
+    use super::{activate_env_command, compose_exec_command, execute_run};
 
     #[test]
     fn srun_command_wraps_the_whole_activated_command() {
@@ -449,6 +526,54 @@ mod tests {
         .await
     }
 
+    /// An `esmfold` run: slug routes it through the ESMFold preflight/compose path, folding a
+    /// single `--fasta` file with no data_dir. Reuses TestLayout's script + fasta fixtures.
+    async fn create_esmfold_run(
+        db: &sea_orm::DatabaseConnection,
+        layout: &TestLayout,
+    ) -> Result<crate::core::entities::runs::Model, DbErr> {
+        // Reuse the seeded esmfold backend: its slug is what routes execution through the ESMFold
+        // path, and re-registering "esmfold" would violate the unique-slug constraint.
+        let backend = model_backends::list_model_backends(db)
+            .await?
+            .into_iter()
+            .find(|backend| backend.slug == "esmfold")
+            .expect("seeded esmfold backend");
+        let target = execution_targets::register_execution_target(
+            db,
+            RegisterExecutionTargetInput {
+                slug: "local-esmfold-test".into(),
+                target_type: "local".into(),
+                description: None,
+                available_resources_json: json!({"type":"object","properties":{
+                    "model_device":{"type":"string","enum":["cpu","cuda:0"],"default":"cuda:0","cli_flag":"--device"}
+                }}).to_string(),
+            },
+        )
+        .await?;
+        let profile = model_invocation_profiles::register_model_invocation_profile(db, RegisterModelInvocationProfileInput {
+            model_backend_id: backend.id, execution_target_id: target.id, invocation_kind: "local_subprocess".into(),
+            config_json: json!({"program":"python3","script":"run_openfold.py","working_dir":layout.working_dir,"output_location":layout.output_location}).to_string(),
+        }).await?;
+        let fasta = layout.fasta_dir.join("input.fasta");
+        runs::submit_run(
+            db,
+            SubmitRunInput {
+                model_backend_id: backend.id,
+                execution_target_id: target.id,
+                invocation_profile_id: profile.id,
+                status: "submitted".into(),
+                input_id: "test_input".into(),
+                input_sequence: "MSTNPKPQRITF".into(),
+                model_parameters_json: "{}".into(),
+                execution_parameters_json: json!({"fasta": fasta, "model_device": "cpu"})
+                    .to_string(),
+                provenance_json: None,
+            },
+        )
+        .await
+    }
+
     fn runner(
         exit_code: i32,
         stderr: &str,
@@ -474,7 +599,7 @@ mod tests {
     async fn missing_run_returns_clear_error() -> Result<(), DbErr> {
         let db = test_db().await?;
         let (runner, _, _) = runner(0, "");
-        let error = execute_openfold_run(&db, 999, &runner)
+        let error = execute_run(&db, 999, &runner)
             .await
             .expect_err("missing run should error");
         assert!(error.to_string().contains("run 999 does not exist"));
@@ -487,7 +612,7 @@ mod tests {
         let layout = TestLayout::new("test_input");
         let run = create_run(&db, &layout, false).await?;
         let (runner, called, command) = runner(0, "");
-        let result = execute_openfold_run(&db, run.id, &runner).await?;
+        let result = execute_run(&db, run.id, &runner).await?;
         assert!(called.load(Ordering::SeqCst));
         assert_eq!(result.output.expect("output").exit_code, 0);
         let command = command
@@ -518,12 +643,60 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn esmfold_run_completes_via_the_esmfold_path() -> Result<(), DbErr> {
+        let db = test_db().await?;
+        let layout = TestLayout::new("test_input");
+        let run = create_esmfold_run(&db, &layout).await?;
+        let (runner, called, command) = runner(0, "");
+
+        let result = execute_run(&db, run.id, &runner).await?;
+
+        assert!(called.load(Ordering::SeqCst));
+        assert_eq!(result.output.expect("output").exit_code, 0);
+        // The schema-driven planner emitted the ESMFold CLI; no venv installed in tests, so the
+        // program stays bare python3 (not <env>/bin/python).
+        let command = command
+            .lock()
+            .expect("command lock")
+            .clone()
+            .expect("planned command");
+        assert_eq!(command.program, "python3");
+        assert!(command.args.contains(&"--fasta".into()));
+        assert!(command.args.contains(&"--out".into()));
+        assert_pair(&command.args, "--device", "cpu");
+        assert!(command.stream);
+
+        let updated = run_entity::Entity::find_by_id(run.id)
+            .one(&db)
+            .await?
+            .expect("run exists");
+        assert_eq!(updated.status, "completed");
+        // ESMFold creates the workspace itself but not an attention/ subdir up front, so only the
+        // run output directory is registered.
+        let workspace = layout.output_location.join(run.id.to_string());
+        assert!(workspace.is_dir());
+        assert!(!workspace.join("attention").exists());
+        let artifacts =
+            crate::core::services::artifacts::list_artifacts_for_run(&db, run.id).await?;
+        assert_eq!(artifacts.len(), 1);
+        Ok(())
+    }
+
+    fn assert_pair(args: &[String], flag: &str, value: &str) {
+        let index = args
+            .iter()
+            .position(|arg| arg == flag)
+            .unwrap_or_else(|| panic!("{flag} should be present"));
+        assert_eq!(args[index + 1], value);
+    }
+
+    #[tokio::test]
     async fn non_zero_command_fails_run() -> Result<(), DbErr> {
         let db = test_db().await?;
         let layout = TestLayout::new("test_input");
         let run = create_run(&db, &layout, false).await?;
         let (runner, _, _) = runner(7, "OpenFold failed");
-        execute_openfold_run(&db, run.id, &runner).await?;
+        execute_run(&db, run.id, &runner).await?;
         let updated = run_entity::Entity::find_by_id(run.id)
             .one(&db)
             .await?
@@ -539,7 +712,7 @@ mod tests {
         let layout = TestLayout::new("test_input");
         let run = create_run(&db, &layout, true).await?;
         let (runner, called, _) = runner(0, "");
-        let result = execute_openfold_run(&db, run.id, &runner).await?;
+        let result = execute_run(&db, run.id, &runner).await?;
         assert!(!called.load(Ordering::SeqCst));
         assert!(result.output.is_none());
         assert!(result.report.has_failures());
@@ -564,7 +737,7 @@ mod tests {
         let run = create_run(&db, &layout, false).await?;
         let runner = FakeCommandRunner::fails("boom");
 
-        let error = execute_openfold_run(&db, run.id, &runner)
+        let error = execute_run(&db, run.id, &runner)
             .await
             .expect_err("runner error should propagate");
         assert!(error.to_string().contains("boom"));

--- a/science-gateway/apps/executor/src/core/tests.rs
+++ b/science-gateway/apps/executor/src/core/tests.rs
@@ -108,6 +108,45 @@ async fn seeds_local_openfold_target_and_profile() -> Result<(), DbErr> {
     Ok(())
 }
 
+#[tokio::test]
+async fn seeds_local_esmfold_target_and_profile() -> Result<(), DbErr> {
+    let db = test_db().await?;
+
+    seed::seed_defaults(&db).await?;
+    seed::seed_defaults(&db).await?;
+
+    let backend = model_backends::list_model_backends(&db)
+        .await?
+        .into_iter()
+        .find(|backend| backend.slug == "esmfold")
+        .expect("ESMFold backend should be seeded");
+    let target = execution_targets::list_execution_targets(&db)
+        .await?
+        .into_iter()
+        .find(|target| target.slug == "local-esmfold")
+        .expect("local ESMFold target should be seeded");
+    let profile = model_invocation_profiles::list_model_invocation_profiles(&db)
+        .await?
+        .into_iter()
+        .find(|profile| {
+            profile.model_backend_id == backend.id && profile.execution_target_id == target.id
+        })
+        .expect("local ESMFold profile should be seeded");
+
+    assert_eq!(profile.invocation_kind, "local_subprocess");
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&profile.config_json)
+            .map_err(|error| DbErr::Custom(error.to_string()))?,
+        json!({
+            "program": "python3",
+            "script": "run_pretrained_esmf.py",
+            "working_dir": config::openfold_home(),
+            "output_location": config::prefix().join("runs"),
+        })
+    );
+    Ok(())
+}
+
 fn sample_execution_target_input() -> RegisterExecutionTargetInput {
     RegisterExecutionTargetInput {
         slug: "test-target".into(),


### PR DESCRIPTION
Makes the ESMFold backend a first-class, runnable backend of the `vizfold` executor — installable, inspectable, and executable through the same pipeline as OpenFold.

## Commands

- **`vizfold install <backend>`** — required arg, `openfold` | `esmfold`. Dispatches to the checkout's per-backend installer: `install/init.sh` (OpenFold's site-aware cluster install, unchanged) or the new lightweight `install/esmfold.sh` (venv + PyTorch + Transformers, weights pulled from HuggingFace at run time; no SLURM/site machinery, no AF2 DBs). Idempotent; records `ESMFOLD_ENV_PREFIX`. `ESMFOLD_TORCH_SPEC`/`ESMFOLD_PIP_INDEX_URL` override the torch wheel.
- **`vizfold status`** — ungated, no DB. Prints the resolved config + database path, then a table of which backends are installed (env prefix present on disk).
- **`vizfold queue-run esmfold`** — single-sequence `--fasta` file + trace flags (`--trace-mode`, `--layers`, `--save-fp16`, `--structure-traces`, `--model`, `--dtype`, `--model-device`).
- **`vizfold execute-run <id>`** and **`register-artifacts <id>`** — now route by backend.

## How ESMFold runs

The command planner is already schema-driven, so seeding an `esmfold` backend whose `parameter_schema_json` describes `run_pretrained_esmf.py` is enough to plan its CLI — **no planner changes**. Seed adds the `esmfold` backend, a `local-esmfold` target (`--device`), and a `local_subprocess` profile.

`execute_openfold_run` became backend-dispatched `execute_run`: it shares the planner, status flow, and artifact registration; a `BackendKind` (defaulting to OpenFold) selects only the two things that actually differ per backend —

- **preflight**: ESMFold gets a lighter one (a single readable `--fasta` file + writable workspace; none of OpenFold's MSA/template/`data_dir` checks). The shared program/script/working-dir checks were extracted into `base_command_checks`.
- **env wrapping**: OpenFold activates its micromamba env; ESMFold runs its venv's `python` directly (no activate.d hook). Both gate on the env being installed, so tests/dev run bare.

Artifact registration (`run_output_directory` + `attention_output_directory`) was already backend-agnostic and is reused as-is.

## Out of scope

A bespoke ESMFold-trace viewer in the workbench (the run's structure/attention render via the existing directory artifacts).

## Test plan

- `cargo test` — 111 pass. New: ESMFold preflight (pass + missing-fasta), a full `execute_run` through the ESMFold path (schema plan emits `--fasta`/`--out`/`--device`, completes, registers only the run-output dir, no `data_dir` check), `queue-run esmfold` parse, and `seeds_local_esmfold_target_and_profile`. Existing OpenFold execution/preflight tests unchanged and green.
- `cargo clippy --all-targets` clean, `cargo fmt --check` clean.
- Live end-to-end in an isolated `$HOME`: `seed` → `list models` shows openfold + esmfold → `queue-run esmfold --fasta … --trace-mode none` queues run 1 → `execute-run 1` routes through the **ESMFold** preflight (its checks include `fasta` and the `run_pretrained_esmf.py` script, and exclude `data_dir`), plans the real command, runs it, and records status. (`No module named 'torch'` locally since there's no venv — the correct bare-python behavior; a real `vizfold install esmfold` box has torch.)
- ESMFold's actual fold was GPU-verified on a Delta A100 in the prior pass (job that produced the `esmf_check` tree: structure + 36 attention layers + traces).

> Note: `install/esmfold.sh` reaches released binaries only on the next tag — the installer clones `install/` scripts at its own version (dev checkouts via `VIZFOLD_SRC` get it immediately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)