### PR TITLE
Bump version to 0.2.2

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "executor"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "async-trait",
  "chrono",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "executor"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 default-run = "vizfold"
 


### PR DESCRIPTION
Release cut for the backend-isolation reorg (#102) so a #102 binary reaches the release channel (needed to test the OpenFold install+fold cycle on Delta / Delta-AI, which have no Rust toolchain).