### PR TITLE
Fix cold-start OpenFold install+fold on Delta; release v0.2.3

### DIFF
--- a/backends/openfold/install/setup.sh
+++ b/backends/openfold/install/setup.sh
@@ -136,7 +136,9 @@ setup::link_mirror() {
     log datasets
     for d in "$AF2"/*; do
         [ "${d##*/}" = uniclust30 ] && continue
-        ln -sfn "$d" "$DATA/"
+        # Explicit link name, not "$DATA/": GNU ln -sfn onto a real dir (empty on a cold start)
+        # errors with "cannot overwrite directory" instead of creating the link inside it.
+        ln -sfn "$d" "$DATA/${d##*/}"
     done
     ln -sfn "$AF2/params" "$OF/openfold/resources/params"
     # uniclust30_2018_08 goes in a writable canonical dir (not the read-only mirror symlink): the mirror's real set if present (single- or double-nested), else aliased from uniref30.
@@ -146,7 +148,9 @@ setup::link_mirror() {
         compgen -G "$c/uniclust30_2018_08_*" >/dev/null 2>&1 && { src=$c; break; }
     done
     if [ -n "$src" ]; then
-        ln -sfn "$src"/uniclust30_2018_08_* "$UNICLUST/"
+        # Per-file explicit link name (see the $DATA loop above): robust whether the glob matches
+        # one file or many, unlike a trailing-slash "$UNICLUST/" dest.
+        for u in "$src"/uniclust30_2018_08_*; do ln -sfn "$u" "$UNICLUST/${u##*/}"; done
     else
         for f in "$AF2"/uniref30/UniRef30_[0-9][0-9][0-9][0-9]_[0-9][0-9]*; do
             [ -e "$f" ] || continue

--- a/backends/openfold/install/sites/delta-gh.json
+++ b/backends/openfold/install/sites/delta-gh.json
@@ -6,6 +6,7 @@
   "OPENFOLD_EXAMPLE": "6KWC_1",
   "OPENFOLD_GPU_PARTITION": "ghx4-interactive",
   "OPENFOLD_GPU_RESOURCES": "--cpus-per-task=8 --mem=32G",
+  "OPENFOLD_GPU_TIME": "01:00:00",
   "OPENFOLD_PARTITION": "ghx4",
   "OPENFOLD_PREFIX": "$OPENFOLD_BASE/vizfold-gh"
 }

--- a/backends/openfold/install/sites/delta.json
+++ b/backends/openfold/install/sites/delta.json
@@ -6,6 +6,7 @@
   "OPENFOLD_GPU_ACCOUNT": "$ALLOC-delta-gpu",
   "OPENFOLD_GPU_PARTITION": "gpuA100x4-interactive",
   "OPENFOLD_GPU_RESOURCES": "--cpus-per-task=8 --mem=32G",
+  "OPENFOLD_GPU_TIME": "01:00:00",
   "OPENFOLD_MAX_CUDA": "12.8",
   "OPENFOLD_PARTITION": "cpu",
   "OPENFOLD_PREFIX": "$OPENFOLD_BASE/vizfold"

--- a/backends/openfold/setup.py
+++ b/backends/openfold/setup.py
@@ -62,7 +62,15 @@ _, bare_metal_major, _ = get_cuda_bare_metal_version(CUDA_HOME)
 if int(bare_metal_major) >= 11:
     compute_capabilities.add((8, 0))
 
-cc_flag = ['-gencode', 'arch=compute_120,code=sm_120']
+# The install exports TORCH_CUDA_ARCH_LIST for the deployment GPUs (e.g. "7.0;8.0;8.6;9.0" for
+# A100/GH200); honor it so the kernel image matches the target device. Falls back to the set above.
+arch_list = re.findall(r'\b(\d+)\.(\d+)\b', os.environ.get('TORCH_CUDA_ARCH_LIST', ''))
+if arch_list:
+    compute_capabilities = {(int(major), int(minor)) for major, minor in arch_list}
+
+cc_flag = []
+for major, minor in sorted(compute_capabilities):
+    cc_flag.extend(['-gencode', f'arch=compute_{major}{minor},code=sm_{major}{minor}'])
 extra_cuda_flags += cc_flag
 
 if bare_metal_major != -1:

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "executor"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "async-trait",
  "chrono",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "executor"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2024"
 default-run = "vizfold"
 

--- a/scripts/openfold/run_pretrained_openfold.py
+++ b/scripts/openfold/run_pretrained_openfold.py
@@ -540,8 +540,12 @@ if __name__ == "__main__":
     print(args)
 
     if args.jax_param_path is None and args.openfold_checkpoint_path is None:
+        # Resolve params via the installed openfold package, not cwd: the entrypoint runs from the
+        # checkout root (for examples/) while the package + its symlinked resources live under
+        # backends/openfold/openfold/.
+        import openfold
         args.jax_param_path = os.path.join(
-            "openfold", "resources", "params",
+            os.path.dirname(openfold.__file__), "resources", "params",
             "params_" + args.config_preset + ".npz"
         )
 


### PR DESCRIPTION
Four pre-existing bugs surfaced by testing the full `vizfold` OpenFold install→fold cycle from a **truly cold start** on NCSA Delta (none from the #102 reorg — its paths all worked):

| # | Bug | Fix |
|---|-----|-----|
| 1 | `link_mirror`'s `ln -sfn "$d" "$DATA/"` errors "cannot overwrite directory" on the empty `data/` dir preflight creates (GNU coreutils) | Explicit link names `$DATA/${d##*/}`; same for the uniclust30 glob |
| 2 | Fold srun defaulted `-t 02:00:00`, exceeding the interactive partitions' `MaxTime=01:00:00` | Pin `OPENFOLD_GPU_TIME=01:00:00` in `delta.json` + `delta-gh.json` |
| 3 | `run_pretrained_openfold.py` default `jax_param_path` was cwd-relative `openfold/resources/params/…`, stale since openfold moved under `backends/openfold/` | Resolve via the installed package (`os.path.dirname(openfold.__file__)`) |
| 4 | CUDA extension hardcoded to `sm_120` (Blackwell) → "no kernel image" on A100 (sm_80) / GH200 (sm_90) | Honor the install's `TORCH_CUDA_ARCH_LIST` (fallback to the built-in set) |

**Verified end-to-end on Delta**: cold install → seed → queue-run → execute-run → register-artifacts, producing the canonical **2839-atom** relaxed 6KWC structure + 96 attention traces (status `completed`, ~78s on A100).

Bumps to v0.2.3 to ship these to the release channel (Delta/Delta-AI have no Rust toolchain to build from source). A final clean cold-start re-test on both clusters will run against the v0.2.3 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)