### PR TITLE
docs: command reference + Delta fold walkthrough

### DIFF
--- a/DEMO.md
+++ b/DEMO.md
@@ -1,250 +1,249 @@
-# Running the OpenFold executor demo
+# Folding a protein with the vizfold CLI
 
-This demo runs the OpenFold workflow through the `vizfold` CLI. It uses repo-aware defaults for the OpenFold script, FASTA input, precomputed alignments, and output directory.
+This is the full OpenFold lifecycle through the `vizfold` CLI on a cluster: seed the executor,
+queue a sequence, fold it on a GPU, register the outputs, and view them. The commands below are
+from a clean run on **NCSA Delta** (A100); the outputs shown are that run's actual results. Every
+`vizfold` call is the installed binary on your `PATH` — nothing is run from a source checkout.
 
-The only required external path is the OpenFold data directory.
+## Prerequisites
 
-## 1. Expected directory layout
+The `vizfold` binary and an installed OpenFold backend. If you have neither, do the two-command
+bootstrap from the [README](README.md#install):
 
-Place the `vizfold_data` directory one level above the `vizfold-foundation` repository:
+```bash
+curl -sL https://raw.githubusercontent.com/AI2Science/vizfold-foundation/main/install.sh | bash
+vizfold install openfold
+```
+
+On Delta the install is dispatched by SLURM `ClusterName`, so it needs no site arguments and takes
+~8 min. When it finishes, `vizfold status` shows OpenFold `installed` and a populated config:
 
 ```text
-<workspace>/
-  vizfold-foundation/
-  vizfold_data/
-````
+$ vizfold status
+VizFold status
 
-For example:
+Config: /u/yjayawardana/.config/vizfold/vizfold.json
+  OPENFOLD_HOME = /u/yjayawardana/vizfold-src
+  OPENFOLD_PREFIX = /work/nvme/bbol/yjayawardana/vizfold
+  OPENFOLD_DATA_DIR = /work/nvme/bbol/yjayawardana/vizfold/data
+  OPENFOLD_SITE = delta
+  OPENFOLD_GPU_PARTITION = gpuA100x4-interactive
+  OPENFOLD_GPU_TIME = 01:00:00
+  ...
+  database = /work/nvme/bbol/yjayawardana/vizfold/vizfold.db (present)
+
+Backends:
+BACKEND   STATUS         ENV PREFIX
+--------  -------------  --------------------------------------------------------
+openfold  installed      /work/nvme/bbol/yjayawardana/vizfold/mamba/envs/openfold-env
+esmfold   not installed  /work/nvme/bbol/yjayawardana/vizfold/esmfold-venv
+```
+
+The paths above (`OPENFOLD_PREFIX`, `OPENFOLD_DATA_DIR`, the account, partition) are resolved live
+during install and written to `vizfold.json`; on Delta they land under your `/work/nvme`
+allocation. Everything after this point reads them from there.
+
+## 1. Seed the executor records
+
+Once per install, create the catalog the runs reference — the OpenFold backend, the local
+execution target, and the invocation profile that ties them together. It is existence-guarded, so
+re-running is harmless.
+
+```bash
+vizfold seed
+```
 
 ```text
-/home/<user>/
-  vizfold-foundation/
-  vizfold_data/
+Seeded default executor records.
 ```
 
-If you received `vizfold_data.zip`, extract it next to the repository:
+You can inspect what it created:
 
 ```bash
-cd /home/<user>
-unzip vizfold_data.zip
+vizfold list models
+vizfold list targets
+vizfold list profiles
 ```
 
-After extraction, you should have:
+## 2. Queue a run
 
-```text
-/home/<user>/vizfold_data
-/home/<user>/vizfold-foundation
-```
-
-## 2. Activate the Python/OpenFold environment
-
-Run the demo from an environment where OpenFold dependencies are installed.
-
-For example:
+Queue the bundled example, 6KWC (a ~190-residue monomer). On a cluster install the input paths all
+default off the config and the checkout examples, so the only flags you need are the sequence and
+its id — plus `--demo-attn` to also dump attention maps:
 
 ```bash
-conda activate vizfold
-```
-
-or, if using micromamba:
-
-```bash
-micromamba activate vizfold
-```
-
-You can quickly verify that PyTorch and CUDA are visible:
-
-```bash
-python3 -c "import torch; print(torch.__version__); print(torch.cuda.is_available())"
-```
-
-Expected on a GPU machine:
-
-```text
-True
-```
-
-## 3. Useful queue-run flags
-
-Every OpenFold-specific input is a `queue-run openfold` flag, not an environment variable -- see the full command in section 4. The one environment override most users need is the data directory, consulted when `--data-dir` is omitted:
-
-```bash
-export OPENFOLD_DATA_DIR="/path/to/vizfold_data"
-```
-
-If you pass `--input-id`, make sure the FASTA header and precomputed alignment directory match. For example, with `--input-id 1UBQ_1`, the FASTA header should resolve to `1UBQ_1`, and precomputed alignments should exist at:
-
-```text
-alignment_dir/1UBQ_1
-```
-
-The output location is not a per-run flag: it comes from the seeded `local-openfold` invocation profile. The workflow resolves the run workspace as `<output_location>/<run.id>`, passes it to OpenFold as `--output_dir`, and derives attention output under `<output_location>/<run.id>/attention`.
-
-## 4. CLI workflow
-
-The `vizfold` CLI is the development path for testing the full persisted workflow: seeded model/target/profile records, queued runs, execution status, and registered output artifacts.
-
-Run these commands from the CLI crate:
-
-```bash
-cd vizfold-foundation/cli
-```
-
-### Set up the local output workspace
-
-The seeded `local-openfold` profile uses the repository root as its working directory and writes runs below:
-
-```text
-<repo-root>/openfold-demo-output/<run-id>
-```
-
-Create the output parent before executing a run:
-
-```bash
-mkdir -p ../openfold-demo-output
-```
-
-In PowerShell:
-
-```powershell
-New-Item -ItemType Directory -Force -Path ../openfold-demo-output
-```
-
-### Seed and inspect the local records
-
-Seed is safe to repeat. It creates (or refreshes) the development OpenFold backend, `local-openfold` target, and matching `local_subprocess` invocation profile.
-
-```bash
-cargo run --bin vizfold -- seed
-cargo run --bin vizfold -- list models
-cargo run --bin vizfold -- list targets
-cargo run --bin vizfold -- list profiles
-```
-
-Verify that the output includes:
-
-* model backend `openfold`;
-* execution target `local-openfold` with type `local`;
-* an invocation profile that references those two IDs and has invocation kind `local_subprocess`.
-
-The CLI uses `DATABASE_URL` when present; otherwise it uses the executor's local SQLite default. Set `DATABASE_URL` if you want a separate development database.
-
-### Queue an OpenFold run
-
-Unlike shell-relative paths, relative local paths supplied to `queue-run` are resolved from the seeded profile's repository-root `working_dir`. The following paths are therefore relative to `vizfold-foundation`, even though the command is executed from the executor crate.
-
-```bash
-cargo run --bin vizfold -- queue-run openfold \
+vizfold queue-run openfold \
   --input-id 6KWC_1 \
   --input-sequence GSTIQPGTGYNNGYFYSYWNDGHGGVTYTNGPGGQFSVNWSNSGEFVGGKGWQPGTKNKVINFSGSYNPNGNSYLSVYGWSRNPLIEYYIVENFGTYNPSTGATKLGEVTSDGSVYDIYRTQRVNQPSIIGTATFYQYWSVRRNHRSSGSVNTANHFNAWAQQGLTLGTMDYQIVAVQGYFSSGSASITVS \
-  --fasta-dir examples/monomer/fasta_dir_6KWC \
-  --data-dir ../vizfold_data \
-  --alignment-dir examples/monomer/alignments \
-  --model-device cuda:0 \
-  --residue-idx 1 \
-  --demo-attn \
-  --use-precomputed-alignments
+  --demo-attn
 ```
-
-`--data-dir ../vizfold_data` matches the directory layout in this guide. All local FASTA, data, and alignment paths must exist when queuing; the CLI stores their canonical absolute paths in the run record.
-
-The command prints a run ID. Inspect it before execution:
-
-```bash
-cargo run --bin vizfold -- list runs
-cargo run --bin vizfold -- show run <run-id>
-```
-
-Confirm its status is `submitted`, its input ID is correct, and its backend/target/profile IDs point to the seeded OpenFold records.
-
-### Execute, register artifacts, and inspect the result
-
-Activate the Python/OpenFold environment first, as described above, then execute the queued run:
-
-```bash
-cargo run --bin vizfold -- execute-run <run-id>
-```
-
-The command prints every preflight check and either launches the configured OpenFold command or reports why execution was skipped. On a successful run, the output workspace is `<repo-root>/openfold-demo-output/<run-id>`.
-
-Register the known output directories after execution:
-
-```bash
-cargo run --bin vizfold -- register-artifacts <run-id>
-cargo run --bin vizfold -- register-artifacts <run-id>
-cargo run --bin vizfold -- show run <run-id>
-```
-
-The first registration records the workspace as `run_output_directory` and, if present, its `attention` child as `attention_output_directory`. The second call is idempotent and reports those artifacts as already present. `show run` lists the resulting artifact IDs, types, formats, and storage paths.
-
-Artifact registration does not block failed or incomplete runs: it prints a warning because available output may be partial, then registers only directories that actually exist.
-
-## 5. Common failure modes
-
-### `ModuleNotFoundError: No module named 'torch'`
-
-The executor successfully launched Python, but it used a Python environment without PyTorch/OpenFold dependencies.
-
-Activate the correct environment first:
-
-```bash
-micromamba activate vizfold
-# or
-conda activate vizfold
-```
-
-Then verify:
-
-```bash
-python3 -c "import torch; print(torch.cuda.is_available())"
-```
-
-### Missing `data_dir`
-
-Set:
-
-```bash
-export OPENFOLD_DATA_DIR="$(realpath ../../vizfold_data)"
-```
-
-from:
 
 ```text
-vizfold-foundation/cli
+Queued OpenFold run 1
+status: submitted
+input_id: 6KWC_1
+
+Next:
+  vizfold execute-run 1
 ```
 
-### FASTA/input ID mismatch
+What the omitted flags default to (all overridable — see `vizfold queue-run openfold --help`):
 
-The executor validates that the FASTA header-derived OpenFold tag matches the run `input_id`.
+| Flag | Default on a cluster install |
+| --- | --- |
+| `--fasta-dir` | `$OPENFOLD_HOME/examples/monomer/fasta_dir_6KWC` |
+| `--alignment-dir` | `$OPENFOLD_HOME/examples/monomer/alignments` |
+| `--data-dir` | `$OPENFOLD_DATA_DIR` (the staged AlphaFold2 databases) |
+| `--model-device` | `cuda:0` — a GPU partition is configured, so the fold will `srun` onto a GPU node |
+| `--use-precomputed-alignments` | `true` — reuse `alignment-dir/6KWC_1`, skipping the MSA search |
 
-For the default demo:
+The FASTA file in `fasta-dir` must have a header matching `--input-id` (here `>6KWC_1`);
+`--input-sequence` is that sequence, recorded with the run. With precomputed alignments enabled the
+directory `alignment-dir/<input-id>` (here `examples/monomer/alignments/6KWC_1`) must exist. The
+queue step canonicalizes and stores absolute paths in the run record, so all inputs must be present
+when you queue.
+
+## 3. Execute the run
+
+```bash
+vizfold execute-run 1
+```
+
+`execute-run` prints each preflight check, then — because a GPU partition is configured but no
+allocation is held — wraps the OpenFold command in `srun -p gpuA100x4-interactive --gres=gpu:1`,
+streams its logs, and reports the final status. On Delta the fold itself took ~78 s on one A100
+(a queue wait shows first as `srun: job N queued and waiting for resources`).
 
 ```text
-input_id = 1UBQ_1
+Executing run 1
+
+Preflight: passed
+[passed] program configured: program 'python3' is configured
+[passed] working directory: '/u/yjayawardana/vizfold-src' exists
+[passed] script file: '/u/yjayawardana/vizfold-src/scripts/openfold/run_pretrained_openfold.py' exists
+[passed] input_id: run input_id '6KWC_1' is configured
+[passed] fasta_dir: '/u/yjayawardana/vizfold-src/examples/monomer/fasta_dir_6KWC' exists
+...
+
+Final status: completed
 ```
 
-So the FASTA header must resolve to:
+Verify the structure directly — a relaxed 6KWC prediction is 2839 atoms, and `--demo-attn` wrote
+one text trace per layer/head:
+
+```bash
+$ grep -c '^ATOM' /work/nvme/bbol/yjayawardana/vizfold/runs/1/predictions/6KWC_1_model_1_ptm_relaxed.pdb
+2839
+$ ls /work/nvme/bbol/yjayawardana/vizfold/runs/1/attention | wc -l
+96
+```
+
+Outputs land in the run workspace `$OPENFOLD_PREFIX/runs/<run-id>`: `predictions/` (relaxed and
+unrelaxed PDBs, `timings.json`) and, with `--demo-attn`, `attention/`.
+
+## 4. Register artifacts
+
+Record the produced directories against the run so the workbench and other tools can find them.
+The first call registers; a second call is idempotent and reports them as already present.
+
+```bash
+vizfold register-artifacts 1
+```
 
 ```text
-1UBQ_1
+Registered artifacts for run 1
+
+Output workspace:
+  /work/nvme/bbol/yjayawardana/vizfold/runs/1
+
+Artifacts:
+  [registered] run_output_directory -> /work/nvme/bbol/yjayawardana/vizfold/runs/1
+  [registered] attention_output_directory -> /work/nvme/bbol/yjayawardana/vizfold/runs/1/attention
 ```
 
-### Missing precomputed alignment key
+Registration never blocks a partial run — if a run failed it warns and registers only the
+directories that actually exist.
 
-If precomputed alignments are enabled, the executor expects:
+## 5. Inspect the run
+
+```bash
+vizfold show run 1
+```
 
 ```text
-alignment_dir/input_id
+Run 1
+status: completed
+input_id: 6KWC_1
+model_backend_id: 1
+execution_target_id: 1
+invocation_profile_id: 1
+submitted_at: 2026-07-24T16:22:35+00:00
+started_at: 2026-07-24T16:41:14+00:00
+completed_at: 2026-07-24T16:42:32+00:00
+artifacts:
+ID  TYPE ID  FORMAT     STORAGE URI
+--  -------  ---------  -----------------------------------------------------
+1   12       directory  /work/nvme/bbol/yjayawardana/vizfold/runs/1
+2   13       directory  /work/nvme/bbol/yjayawardana/vizfold/runs/1/attention
 ```
 
-For the default demo:
+`vizfold list runs` (optionally `--status completed`) lists all runs.
 
-```text
-examples/monomer/alignments/1UBQ_1
+## 6. View it in the dashboard
+
+```bash
+vizfold serve
 ```
 
-## 6. Notes
+This stages and starts the Next.js workbench (installing its dependencies on first run) at
+`http://localhost:3000`, linking `$OPENFOLD_PREFIX/runs` under the app's `public/` so the browser
+can load each run's outputs. The dashboard renders the predicted structure in an interactive 3D
+viewer and shows the attention maps. From a laptop, forward the port over SSH:
 
-This demo does not automatically register newly generated alignments as reusable artifacts.
+```bash
+ssh -L 3000:localhost:3000 <you>@delta.ncsa.illinois.edu
+```
 
-Precomputed alignment reuse currently requires that the expected alignment directory already exists on disk. Future work should index generated alignments as artifacts so later runs can select and reuse them through the executor/workbench flow.
+## A quicker smoke test
+
+To confirm the install without the executor at all, `vizfold install openfold` prints a one-liner
+that folds the bundled example straight through `fold.sh` and counts the atoms:
+
+```bash
+srun -A bbol-delta-gpu -p gpuA100x4-interactive --gres=gpu:1 --cpus-per-task=8 --mem=32G -t 00:30:00 \
+  env OPENFOLD_PREFIX=$OPENFOLD_PREFIX $OPENFOLD_HOME/scripts/openfold/fold.sh 6KWC_1
+grep -c '^ATOM' $OPENFOLD_PREFIX/outputs/6KWC_1/predictions/6KWC_1_model_1_ptm_relaxed.pdb
+```
+
+The account, partition, and resources here are Delta's; `vizfold install openfold` prints the
+command already filled in for whatever cluster it ran on.
+
+A few thousand atoms means it worked. The executor lifecycle above is the fuller path — it
+persists the run, its provenance, and its artifacts, and feeds the dashboard.
+
+## Common failure modes
+
+### `run vizfold install openfold first`
+
+The config isn't initialized — the install didn't finish, or on a shared filesystem the freshly
+written `vizfold.json` hasn't propagated to the login node yet. Check with `vizfold status`; if the
+install did complete, wait a few seconds and retry.
+
+### FASTA / input-id mismatch
+
+The executor checks that the FASTA header-derived tag matches the run `input_id`. With
+`--input-id 6KWC_1`, the header in the FASTA must resolve to `6KWC_1`.
+
+### Missing precomputed alignment
+
+With `--use-precomputed-alignments=true` (the default), the directory `alignment-dir/<input-id>`
+must exist — for the example, `examples/monomer/alignments/6KWC_1`. Pass
+`--use-precomputed-alignments=false` to run the full MSA search instead (much slower; needs the
+full databases).
+
+### `srun: Requested time limit is invalid` / `Invalid account or account/partition combination`
+
+The GPU partition, account, and time cap come from the site profile
+(`backends/openfold/install/sites/<ClusterName>.json`) and are written to `vizfold.json`. If you
+override any `OPENFOLD_GPU_*` value, keep it within the partition's limits (on Delta,
+`gpuA100x4-interactive` caps at `01:00:00`).

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ SLURM account, or `OPENFOLD_BASE` (the install directory). `backends/openfold/in
   "OPENFOLD_GPU_ACCOUNT": "$ALLOC-delta-gpu",
   "OPENFOLD_GPU_PARTITION": "gpuA100x4-interactive",
   "OPENFOLD_GPU_RESOURCES": "--cpus-per-task=8 --mem=32G",
+  "OPENFOLD_GPU_TIME": "01:00:00",
   "OPENFOLD_MAX_CUDA": "12.8",
   "OPENFOLD_PARTITION": "cpu",
   "OPENFOLD_PREFIX": "$OPENFOLD_BASE/vizfold"
@@ -169,6 +170,31 @@ Two files in `backends/openfold/install/sites/`, named after the cluster's SLURM
 single `slurm::discover` that exports the one login-specific atom — and `<name>.json`, which
 declares everything else and templates paths/accounts off that atom (and `$USER`). `vizfold
 init` (via `backends/openfold/install/install.sh`) dispatches on `ClusterName`, so nothing else needs to change.
+
+---
+
+## Commands
+
+`vizfold <command>`. After a backend is installed, the fold lifecycle is: `seed` the executor
+records once, then `queue-run` → `execute-run` → `register-artifacts` → `show run` for each
+fold; `serve` opens the dashboard over the results. `vizfold <command> --help` details any one.
+
+```text
+install                  Install a model backend (openfold or esmfold) on this machine
+download                 Download a backend's data (OpenFold AlphaFold2 databases/params)
+status                   Show resolved config and which backends are installed
+uninstall                Remove everything the install generated
+seed                     Seed the default executor records
+queue-run                Queue a run for a backend (queue-run openfold|esmfold ...)
+execute-run <id>         Execute a queued run
+register-artifacts <id>  Register known artifacts for a completed run
+list                     List executor records (list models|targets|profiles|runs)
+show                     Show one executor record (show run <id>)
+serve                    Start the workbench dashboard
+```
+
+For a full end-to-end walkthrough on a cluster — queue a sequence, fold it on a GPU, register
+and view the outputs, with real commands and results — see [DEMO.md](DEMO.md).
 
 ---
 


### PR DESCRIPTION
Documentation-only. Makes the `vizfold` usage pattern clear and replaces the stale demo with the real end-to-end lifecycle on a cluster.

## README
- New **Commands** section: the `vizfold` subcommand surface (captured from the built binary's `--help`), ordered by the actual lifecycle — `install` → `seed` → `queue-run` → `execute-run` → `register-artifacts` → `show run` / `serve` — plus a pointer to `vizfold <command> --help` and to DEMO.
- Fixed the `delta.json` example: added `OPENFOLD_GPU_TIME: "01:00:00"` to match the shipped site profile (the v0.2.3 fix for the A100 interactive 1-hour cap).

## DEMO
- Rewrote the stale `cargo run` / `vizfold_data.zip` / `openfold-demo-output` dev walkthrough into the **cluster walkthrough on NCSA Delta** using the installed binary.
- Numbered lifecycle (`status` → `seed` → `queue-run openfold` → `execute-run` → `register-artifacts` → `show run` → `serve`), with a table of what each omitted `queue-run` flag defaults to on a cluster install.
- Real commands and outputs from the certified v0.2.3 run: 6KWC, 2839-atom relaxed structure, 96 attention traces, actual storage URIs.
- Corrected output paths to `$OPENFOLD_PREFIX/runs/<id>` and refreshed the failure-modes section.

## Verification
- `--help` text taken from a local `cargo build` of the CLI, not hand-transcribed.
- Numbers/URIs/timestamps are from the certified Delta run; the `execute-run` preflight block is trimmed to check names/wording confirmed in source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)