### PR TITLE
Fold from the dashboard, and provision the Node it needs

### DIFF
--- a/DEMO.md
+++ b/DEMO.md
@@ -143,8 +143,9 @@ unrelaxed PDBs, `timings.json`) and, with `--demo-attn`, `attention/`.
 
 ## 4. Register artifacts
 
-Record the produced directories against the run so the workbench and other tools can find them.
-The first call registers; a second call is idempotent and reports them as already present.
+`execute-run` already did this — a completed run whose outputs were never registered is invisible
+to the workbench, so registration rides along with execution. The command remains for re-running it
+against a run whose outputs appeared later; it is idempotent and reports what is already present.
 
 ```bash
 vizfold register-artifacts 1

--- a/README.md
+++ b/README.md
@@ -175,23 +175,40 @@ init` (via `backends/openfold/install/install.sh`) dispatches on `ClusterName`, 
 
 ## Commands
 
-`vizfold <command>`. After a backend is installed, the fold lifecycle is: `seed` the executor
-records once, then `queue-run` → `execute-run` → `register-artifacts` → `show run` for each
-fold; `serve` opens the dashboard over the results. `vizfold <command> --help` details any one.
+`vizfold <command>`. After a backend is installed, folding a bundled example is one command —
+`execute-run <example-id>` queues it, runs it, and registers its outputs. For a sequence of your
+own, `queue-run` first and hand `execute-run` the run id it prints. `serve` opens the dashboard
+over the results. `vizfold <command> --help` details any one.
 
 ```text
 install                  Install a model backend (openfold or esmfold) on this machine
 download                 Download a backend's data (OpenFold AlphaFold2 databases/params)
 status                   Show resolved config and which backends are installed
 uninstall                Remove everything the install generated
-seed                     Seed the default executor records
+seed                     Seed the default executor records (the submit path does this for you)
 queue-run                Queue a run for a backend (queue-run openfold|esmfold ...)
-execute-run <id>         Execute a queued run
-register-artifacts <id>  Register known artifacts for a completed run
-list                     List executor records (list models|targets|profiles|runs)
+execute-run <target>     Fold a bundled example, or execute a queued run by id
+register-artifacts <id>  Re-register a run's artifacts (execute-run already does)
+list                     List records (list examples|models|targets|profiles|runs)
 show                     Show one executor record (show run <id>)
 serve                    Start the workbench dashboard
 ```
+
+`vizfold list examples` shows what folds without an MSA search — the bundled monomers whose
+alignments are precomputed:
+
+```text
+ID      RESIDUES  DESCRIPTION
+------  --------  -------------------------------------
+1G1J_1  43        NON-STRUCTURAL GLYCOPROTEIN NSP4
+1UBQ_1  76        UBIQUITIN
+1STM_1  157       SATELLITE PANICUM MOSAIC VIRUS
+6KWC_1  191
+2OMF_1  340       MATRIX PORIN OUTER MEMBRANE PROTEIN F
+```
+
+The dashboard drives the same path: pick one of these in **Fold a protein** and it queues,
+executes, and registers the run for you.
 
 For a full end-to-end walkthrough on a cluster — queue a sequence, fold it on a GPU, register
 and view the outputs, with real commands and results — see [DEMO.md](DEMO.md).

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ accounts you can charge); the values below are what a fresh install settles on.
 | --- | --- | --- | --- | --- | --- |
 | `delta` (NCSA Delta) | ✅ install + fold | x86-64 | mirror¹ | `cpu` → `gpuA100x4-interactive` (A100) | `/work/nvme/<alloc>/<user>/vizfold` |
 | `delta-gh` (NCSA Delta-AI) | ✅ install + fold³ | aarch64 (GH200) | mirror¹ | `ghx4` → `ghx4-interactive` (GH200) | `/work/nvme/<alloc>/<user>/vizfold-gh`² |
-| `nexus-dev` (Nexus) | ◐ install⁵ | x86-64 | downloaded | `gpu` → `gpu` (A100 10 GB vGPU)⁴ | `/projects/<user>/vizfold` |
+| `nexus-dev` (Nexus) | ◐ install⁵ | x86-64 | mirror¹ | `gpu` → `gpu` (A100 10 GB vGPU)⁴ | `/projects/<user>/vizfold` |
 | `anvil` (Purdue Anvil) | ◐ install⁵ | x86-64 | downloaded | `shared` → `gpu` (A100) | `$PROJECT/<user>/vizfold` |
 | `bridges2` (PSC Bridges-2) | ◐ install⁵ | x86-64 | mirror¹ | `RM-shared` → `GPU-shared` (V100-32) | `/ocean/projects/<acct>/<user>/vizfold` |
 | `expanse` (SDSC Expanse) | ⚙️ profile | x86-64 | downloaded | `shared` → `gpu-shared` (V100) | `/expanse/lustre/projects/<acct>/<user>/vizfold` |
@@ -88,7 +88,8 @@ in this pass⁵; ⚙️ site profile written and its paths probed live, full ins
 
 1. AF2 mirrors: Delta & Delta-AI (shared `/work/hdd`) `/work/hdd/data/alphafold2/database`,
    Phoenix `/storage/coda1/ice1/shared/d-pace_community/alphafold/alphafold_2.3.2_data`, ICE
-   `/storage/ice1/shared/d-pace_community/…`, Bridges-2 `/ocean/datasets/community/alphafold/v2.3.2`.
+   `/storage/ice1/shared/d-pace_community/…`, Bridges-2 `/ocean/datasets/community/alphafold/v2.3.2`,
+   Nexus `/media/volume/nexus-staging-slurm-data/database`.
    Each mirror lays out `uniclust30` differently (real single- or double-nested set, or none), so
    the install stages it into a canonical dir — real set if present, else aliased from uniref30.
    Where there is no mirror the install downloads the ~4 GB parameters + the example's templates.
@@ -100,7 +101,8 @@ in this pass⁵; ⚙️ site profile written and its paths probed live, full ins
    `LD_PRELOAD`; the 10 GB vGPU gets the smaller `1UBQ_1` example. CUDA is capped at 12.8 on every
    x86 site and 12.9 on aarch64 (the 13.x build won't compile OpenFold's extension).
 5. `◐` detail — nexus: cold-start install completed this session, NVRTC-pinned relaxation confirmed
-   in earlier runs; anvil: install reached the dataset stage (fixed a conda-libcurl mmCIF bug),
+   in earlier runs, though that run predates the mirror and no install has yet been run against
+   `OPENFOLD_AF2_ROOT` there; anvil: install reached the dataset stage (fixed a conda-libcurl mmCIF bug),
    A100 fold queue-bound; bridges2: build + fold ran through to relaxation (memory / gcc / CUDA-arch
    / NVRTC fixes applied).
 
@@ -139,12 +141,13 @@ SLURM account, or `OPENFOLD_BASE` (the install directory). `backends/openfold/in
 Here `delta.sh` discovers just `$ALLOC` (the `/work/nvme` allocation, via `sacctmgr`); the
 account, base, and prefix all template off it.
 
-`backends/openfold/install/sites/nexus-dev.json` — no database mirror, so `OPENFOLD_AF2_ROOT` is absent and the
-install fetches the parameters itself. Its GPU is a 10 GB vGPU, hence the smaller example and
-memory:
+`backends/openfold/install/sites/nexus-dev.json` — its GPU is a 10 GB vGPU, hence the smaller
+example and memory. Setting `OPENFOLD_AF2_ROOT` is what makes the install link the staged databases
+instead of downloading the parameters itself:
 
 ```json
 {
+  "OPENFOLD_AF2_ROOT": "/media/volume/nexus-staging-slurm-data/database",
   "OPENFOLD_EXAMPLE": "1UBQ_1",
   "OPENFOLD_GPU_PARTITION": "gpu",
   "OPENFOLD_GPU_RESOURCES": "--cpus-per-task=8 --mem=24G",
@@ -152,6 +155,10 @@ memory:
   "OPENFOLD_PARTITION": "gpu"
 }
 ```
+
+A mirror is all-or-nothing: with `OPENFOLD_AF2_ROOT` set the install stops fetching parameters and
+templates, so the root must also carry `params/` and `pdb_mmcif/mmcif_files` alongside the search
+databases, or the install fails its verify step.
 
 To override for one run, put the variable inline — it wins over both files:
 

--- a/backends/openfold/install/sites/nexus-dev.json
+++ b/backends/openfold/install/sites/nexus-dev.json
@@ -1,4 +1,5 @@
 {
+  "OPENFOLD_AF2_ROOT": "/media/volume/nexus-staging-slurm-data/database",
   "OPENFOLD_BUILD_TIME": "01:00:00",
   "OPENFOLD_EXAMPLE": "1UBQ_1",
   "OPENFOLD_GPU_PARTITION": "gpu",

--- a/backends/openfold/install/sites/nexus-dev.sh
+++ b/backends/openfold/install/sites/nexus-dev.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Nexus ("nexus-dev"). No mirror; 10 GB A100 vGPU on a 535 driver (setup.sh pins NVRTC); prefix templates off OPENFOLD_BASE = a writable /projects dir, not $HOME.
+# Nexus ("nexus-dev"). AF2 mirror on the staging volume; 10 GB A100 vGPU on a 535 driver (setup.sh pins NVRTC); prefix templates off OPENFOLD_BASE = a writable /projects dir, not $HOME.
 
 slurm::discover() {
     local c

--- a/cli/src/adapters/cli.rs
+++ b/cli/src/adapters/cli.rs
@@ -772,15 +772,50 @@ fn copy_tree(src: &Path, dst: &Path, skip: &[&str]) -> std::io::Result<()> {
     Ok(())
 }
 
-/// Node for the dashboard, in a micromamba env of its own. Clusters ship none -- Delta has no
-/// `node`, no `npm`, and no nodejs module -- and the workbench needs >=22.13 for `node:sqlite`.
-/// Kept out of every backend env so the dashboard works before a backend is installed. Returns the
-/// bin directory to put in front of PATH.
+/// The workbench needs Node >=22.13 for `node:sqlite`.
+const MIN_NODE: (u32, u32) = (22, 13);
+
+/// Whether a `process.versions.node` string clears `MIN_NODE`. Unparseable reads as too old:
+/// provisioning a known-good Node is cheaper than a confusing failure deep in `next dev`.
+fn node_is_new_enough(version: &str) -> bool {
+    let mut parts = version.trim().trim_start_matches('v').split('.');
+    let (Some(Ok(major)), Some(Ok(minor))) = (
+        parts.next().map(str::parse::<u32>),
+        parts.next().map(str::parse::<u32>),
+    ) else {
+        return false;
+    };
+    (major, minor) >= MIN_NODE
+}
+
+/// The bin directory of a usable Node already on PATH, if there is one.
+fn system_node_bin() -> Option<PathBuf> {
+    let output = std::process::Command::new("node")
+        .args([
+            "-e",
+            "process.stdout.write(process.versions.node + '\\n' + process.execPath)",
+        ])
+        .output()
+        .ok()?;
+    let text = String::from_utf8(output.stdout).ok()?;
+    let (version, path) = text.split_once('\n')?;
+    node_is_new_enough(version)
+        .then(|| PathBuf::from(path).parent().map(Path::to_path_buf))
+        .flatten()
+}
+
+/// Node for the dashboard: whatever is already on PATH when it is new enough, otherwise a
+/// micromamba env of its own. Clusters ship none -- Delta has no `node`, no `npm`, and no nodejs
+/// module -- and the env is kept out of every backend so the dashboard works before a backend is
+/// installed. Returns the bin directory to put in front of PATH.
 fn ensure_node() -> Result<PathBuf, DbErr> {
     let env_dir = config::prefix().join("mamba/envs/vizfold-web");
     let bin = env_dir.join("bin");
     if bin.join("node").is_file() {
         return Ok(bin);
+    }
+    if let Some(system) = system_node_bin() {
+        return Ok(system);
     }
     let micromamba = ensure_micromamba()?;
     println!("Provisioning Node (first run only)...");
@@ -805,8 +840,10 @@ fn ensure_micromamba() -> Result<PathBuf, DbErr> {
     if micromamba.is_file() {
         return Ok(micromamba);
     }
-    let arch = match std::env::consts::ARCH {
-        "aarch64" | "arm64" => "linux-aarch64",
+    let arch = match (std::env::consts::OS, std::env::consts::ARCH) {
+        ("macos", "aarch64" | "arm64") => "osx-arm64",
+        ("macos", _) => "osx-64",
+        (_, "aarch64" | "arm64") => "linux-aarch64",
         _ => "linux-64",
     };
     std::fs::create_dir_all(prefix.join("bin")).map_err(|error| {
@@ -1819,6 +1856,19 @@ mod tests {
             cli.command,
             Command::Serve(ServeArgs { port: Some(3001) })
         ));
+    }
+
+    #[test]
+    fn node_version_gate_is_major_then_minor() {
+        assert!(node_is_new_enough("22.13.0"));
+        assert!(node_is_new_enough("v26.5.0"));
+        assert!(node_is_new_enough("23.0.1"));
+        assert!(!node_is_new_enough("22.12.9"), "minor below the floor");
+        assert!(!node_is_new_enough("20.19.0"), "major below the floor");
+        // 22.9 must not beat 22.13 -- the reason this compares numbers, not strings.
+        assert!(!node_is_new_enough("22.9.0"));
+        assert!(!node_is_new_enough(""), "unparseable reads as too old");
+        assert!(!node_is_new_enough("garbage"));
     }
 
     #[test]

--- a/cli/src/adapters/cli.rs
+++ b/cli/src/adapters/cli.rs
@@ -436,7 +436,8 @@ fn run_to_completion(what: &str, command: &mut std::process::Command) -> Result<
     status
         .success()
         .then_some(())
-        .ok_or_else(|| DbErr::Custom(format!("{what} exited with status {status}")))
+        // ExitStatus already renders as "exit status: N", so no "exited with status" prefix.
+        .ok_or_else(|| DbErr::Custom(format!("{what}: {status}")))
 }
 
 /// Download a backend's data by running the checkout's downloader for the requested dataset into

--- a/cli/src/adapters/cli.rs
+++ b/cli/src/adapters/cli.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 
 use crate::core::{
     commands::LocalCommandRunner,
-    config, db,
+    config, db, examples,
     entities::{
         execution_targets as execution_target_entity, model_backends as model_backend_entity,
         model_invocation_profiles as model_invocation_profile_entity,
@@ -47,8 +47,8 @@ enum Command {
     Show(ShowArgs),
     /// Queue a run for a supported model backend.
     QueueRun(QueueRunArgs),
-    /// Execute a queued run.
-    ExecuteRun { run_id: i32 },
+    /// Execute a queued run, or fold a bundled example in one step.
+    ExecuteRun(ExecuteRunArgs),
     /// Register known artifacts for a completed run.
     RegisterArtifacts { run_id: i32 },
 }
@@ -139,8 +139,28 @@ struct ListArgs {
     resource: ListResource,
 }
 
+#[derive(Debug, Args)]
+struct ExecuteRunArgs {
+    /// A queued run's id, or a bundled example to queue and fold in one step
+    /// (`vizfold list examples`).
+    target: String,
+    /// Dump per-layer, per-head attention maps. Applies when queueing an example; an
+    /// already-queued run keeps whatever it was queued with.
+    #[arg(long, default_value_t = true, action = ArgAction::Set)]
+    attn: bool,
+    /// Print only the run as JSON, for tools driving the CLI.
+    #[arg(long)]
+    json: bool,
+}
+
 #[derive(Debug, Subcommand)]
 enum ListResource {
+    /// List the bundled examples that can fold without an MSA search.
+    Examples {
+        /// Emit JSON including each sequence, for tools driving the CLI.
+        #[arg(long)]
+        json: bool,
+    },
     /// List model backends.
     Models,
     /// List execution targets.
@@ -214,7 +234,7 @@ struct EsmfoldQueueArgs {
     structure_traces: bool,
 }
 
-#[derive(Clone, Debug, Args)]
+#[derive(Clone, Debug, PartialEq, Eq, Args)]
 struct OpenfoldQueueArgs {
     #[arg(long)]
     input_id: String,
@@ -247,6 +267,27 @@ struct OpenfoldQueueArgs {
     /// (fold.sh default). Pass `--use-precomputed-alignments=false` for the full MSA pipeline.
     #[arg(long, default_value_t = true, action = ArgAction::Set)]
     use_precomputed_alignments: bool,
+}
+
+impl OpenfoldQueueArgs {
+    /// A bundled example queued with the same defaults clap applies to `queue-run openfold`, which
+    /// `queue_run_openfold_defaults_match_for_example` pins so the two cannot drift.
+    fn for_example(example: &examples::Example, attn: bool) -> Self {
+        Self {
+            input_id: example.id.clone(),
+            input_sequence: example.sequence.clone(),
+            demo_attn: attn,
+            fasta_dir: None,
+            data_dir: None,
+            alignment_dir: None,
+            model_device: None,
+            cpus: default_cpus(),
+            residue_idx: 1,
+            save_outputs: true,
+            num_recycles_save: 1,
+            use_precomputed_alignments: true,
+        }
+    }
 }
 
 /// No allocation held but a GPU partition configured means the fold will be srun'd onto a
@@ -316,6 +357,9 @@ pub async fn run() -> Result<(), DbErr> {
         Command::Status => return run_status(),
         Command::Uninstall(args) => return run_uninstall(args),
         Command::Serve(args) => return run_serve(args),
+        Command::List(ListArgs {
+            resource: ListResource::Examples { json },
+        }) => return list_examples(json),
         _ => {}
     }
 
@@ -330,6 +374,7 @@ pub async fn run() -> Result<(), DbErr> {
             ListResource::Targets => list_targets(&database).await?,
             ListResource::Profiles => list_profiles(&database).await?,
             ListResource::Runs { status } => list_runs(&database, status.as_deref()).await?,
+            ListResource::Examples { .. } => unreachable!("handled before DB connect"),
         },
         Command::Show(show) => match show.resource {
             ShowResource::Run { run_id } => show_run(&database, run_id).await?,
@@ -338,7 +383,7 @@ pub async fn run() -> Result<(), DbErr> {
             QueueRunModel::Openfold(args) => queue_openfold_run(&database, args).await?,
             QueueRunModel::Esmfold(args) => queue_esmfold_run(&database, args).await?,
         },
-        Command::ExecuteRun { run_id } => execute(&database, run_id).await?,
+        Command::ExecuteRun(args) => run_execute(&database, args).await?,
         Command::RegisterArtifacts { run_id } => register_artifacts(&database, run_id).await?,
         Command::Install(_)
         | Command::Download(_)
@@ -661,12 +706,14 @@ fn run_serve(args: ServeArgs) -> Result<(), DbErr> {
         }
     }
 
+    let node_bin = ensure_node()?;
+
     let node_modules = workbench.join("node_modules");
     let empty =
         std::fs::read_dir(&node_modules).map_or(true, |mut entries| entries.next().is_none());
     if empty {
         println!("Installing workbench dependencies (npm install)...");
-        run_npm(&workbench, &["install"])?;
+        run_npm(&workbench, &node_bin, &["install"])?;
     }
 
     let port = args.port.unwrap_or(3000);
@@ -676,7 +723,7 @@ fn run_serve(args: ServeArgs) -> Result<(), DbErr> {
     if args.port.is_some() {
         npm_args.extend(["--", "--port", &port_arg]);
     }
-    run_npm(&workbench, &npm_args)
+    run_npm(&workbench, &node_bin, &npm_args)
 }
 
 /// Directory the dashboard runs from. A cluster home is inode-quota-capped NFS, so on a real
@@ -725,19 +772,89 @@ fn copy_tree(src: &Path, dst: &Path, skip: &[&str]) -> std::io::Result<()> {
     Ok(())
 }
 
-fn run_npm(dir: &Path, args: &[&str]) -> Result<(), DbErr> {
-    let mut command = std::process::Command::new("npm");
+/// Node for the dashboard, in a micromamba env of its own. Clusters ship none -- Delta has no
+/// `node`, no `npm`, and no nodejs module -- and the workbench needs >=22.13 for `node:sqlite`.
+/// Kept out of every backend env so the dashboard works before a backend is installed. Returns the
+/// bin directory to put in front of PATH.
+fn ensure_node() -> Result<PathBuf, DbErr> {
+    let env_dir = config::prefix().join("mamba/envs/vizfold-web");
+    let bin = env_dir.join("bin");
+    if bin.join("node").is_file() {
+        return Ok(bin);
+    }
+    let micromamba = ensure_micromamba()?;
+    println!("Provisioning Node (first run only)...");
+    // --no-rc so a user ~/.condarc envs_dirs/channels can't hijack it, as the backend installs do.
+    let status = std::process::Command::new(&micromamba)
+        .args(["create", "-y", "--no-rc", "-c", "conda-forge", "nodejs>=22.13", "-p"])
+        .arg(&env_dir)
+        .env("MAMBA_ROOT_PREFIX", config::prefix().join("mamba"))
+        .status()
+        .map_err(|error| DbErr::Custom(format!("failed to launch micromamba: {error}")))?;
+    status
+        .success()
+        .then_some(bin)
+        .ok_or_else(|| DbErr::Custom(format!("provisioning Node exited with status {status}")))
+}
+
+/// The micromamba a backend install drops at `<prefix>/bin`, fetched the same way
+/// `backends/openfold/install/setup.sh` fetches it when no backend has been installed yet.
+fn ensure_micromamba() -> Result<PathBuf, DbErr> {
+    let prefix = config::prefix();
+    let micromamba = prefix.join("bin/micromamba");
+    if micromamba.is_file() {
+        return Ok(micromamba);
+    }
+    let arch = match std::env::consts::ARCH {
+        "aarch64" | "arm64" => "linux-aarch64",
+        _ => "linux-64",
+    };
+    std::fs::create_dir_all(prefix.join("bin")).map_err(|error| {
+        DbErr::Custom(format!(
+            "failed to create '{}/bin': {error}",
+            prefix.display()
+        ))
+    })?;
+    let status = std::process::Command::new("sh")
+        .arg("-c")
+        .arg(format!(
+            "curl -Ls 'https://micro.mamba.pm/api/micromamba/{arch}/latest' | tar -xj -C '{}' bin/micromamba",
+            prefix.display()
+        ))
+        .status()
+        .map_err(|error| DbErr::Custom(format!("failed to fetch micromamba: {error}")))?;
+    status
+        .success()
+        .then_some(micromamba)
+        .ok_or_else(|| DbErr::Custom(format!("fetching micromamba exited with status {status}")))
+}
+
+fn run_npm(dir: &Path, node_bin: &Path, args: &[&str]) -> Result<(), DbErr> {
+    let mut command = std::process::Command::new(node_bin.join("npm"));
     command.current_dir(dir).args(args);
+    // npm's shebang resolves `node` off PATH, and `next` spawns node for the dev server, so the
+    // provisioned env has to lead PATH -- naming the npm binary by path is not enough on its own.
+    let path = std::env::var_os("PATH").unwrap_or_default();
+    let dirs = std::iter::once(node_bin.to_path_buf()).chain(std::env::split_paths(&path));
+    command.env(
+        "PATH",
+        std::env::join_paths(dirs)
+            .map_err(|error| DbErr::Custom(format!("failed to build PATH: {error}")))?,
+    );
+    // The dashboard shells out to this same binary to list examples and queue runs, and drops each
+    // background fold's log under the prefix.
+    if let Ok(binary) = std::env::current_exe() {
+        command.env("VIZFOLD_BIN", binary);
+    }
+    command.env("OPENFOLD_PREFIX", config::prefix());
     // The dashboard reads the sqlite file directly; hand it the plain path (database_url() carries
     // a sqlite://...?mode=rwc wrapper that node:sqlite can't open).
     if let Some(database) = config::database_path() {
         command.env("VIZFOLD_DB", database);
     }
-    let status = command.status().map_err(|error| {
-        DbErr::Custom(format!(
-            "failed to run npm (is Node.js installed and on PATH?): {error}"
-        ))
-    })?;
+    let status = command
+        .status()
+        .map_err(|error| DbErr::Custom(format!("failed to run npm: {error}")))?;
     status.success().then_some(()).ok_or_else(|| {
         DbErr::Custom(format!(
             "npm {} exited with status {status}",
@@ -807,7 +924,12 @@ async fn register_artifacts(
     Ok(())
 }
 
-async fn execute(database: &sea_orm::DatabaseConnection, run_id: i32) -> Result<(), DbErr> {
+/// The execution itself, with its preflight and command output. `run_execute` owns the queueing
+/// and the registration around it.
+async fn report_execution(
+    database: &sea_orm::DatabaseConnection,
+    run_id: i32,
+) -> Result<(), DbErr> {
     println!("Executing run {run_id}");
     let outcome = execute_run(database, run_id, &LocalCommandRunner).await?;
 
@@ -855,10 +977,149 @@ fn preflight_status_label(status: PreflightStatus) -> &'static str {
     }
 }
 
+/// The bundled examples. Filesystem-only, so it runs without a database -- the dashboard calls
+/// this on every page render and should not pay for a connect and migrate to draw a dropdown.
+fn list_examples(json: bool) -> Result<(), DbErr> {
+    let found = examples::scan_default();
+    if json {
+        println!(
+            "{}",
+            serde_json::Value::Array(
+                found
+                    .iter()
+                    .map(|example| json!({
+                        "id": example.id,
+                        "residues": example.residues,
+                        "description": example.description,
+                        "sequence": example.sequence,
+                    }))
+                    .collect()
+            )
+        );
+        return Ok(());
+    }
+    if found.is_empty() {
+        println!(
+            "No examples under {}. Re-run `vizfold install openfold`.",
+            examples::monomer_dir().display()
+        );
+        return Ok(());
+    }
+    print_table(
+        &["ID", "RESIDUES", "DESCRIPTION"],
+        found
+            .iter()
+            .map(|example| {
+                vec![
+                    example.id.clone(),
+                    example.residues.to_string(),
+                    example.description.clone(),
+                ]
+            })
+            .collect(),
+    );
+    Ok(())
+}
+
+/// Execute a run -- either one already queued, by id, or a bundled example, which is queued first.
+/// Folding an example *is* executing a run, so it is one verb rather than two. Artifacts are
+/// registered on the way out: a completed run whose outputs were never registered is invisible to
+/// the dashboard, and registration is idempotent and skips directories that do not exist.
+async fn run_execute(
+    database: &sea_orm::DatabaseConnection,
+    args: ExecuteRunArgs,
+) -> Result<(), DbErr> {
+    let run_id = match args.target.parse::<i32>() {
+        Ok(run_id) => run_id,
+        Err(_) => {
+            let example = examples::find(&args.target).ok_or_else(|| unknown_target(&args.target))?;
+            let run =
+                submit_openfold_run(database, OpenfoldQueueArgs::for_example(&example, args.attn))
+                    .await?;
+            if !args.json {
+                println!(
+                    "Queued OpenFold run {} ({}, {} residues)\n",
+                    run.id, example.id, example.residues
+                );
+            }
+            run.id
+        }
+    };
+
+    if args.json {
+        execute_run(database, run_id, &LocalCommandRunner).await?;
+    } else {
+        report_execution(database, run_id).await?;
+        println!();
+    }
+    register_known_openfold_artifacts(database, run_id).await?;
+
+    let run = runs::get_run_with_artifacts(database, run_id)
+        .await?
+        .map(|result| result.run)
+        .ok_or_else(|| DbErr::Custom(format!("run {run_id} does not exist")))?;
+    let elapsed = run
+        .started_at
+        .zip(run.completed_at)
+        .map(|(started, completed)| (completed - started).num_seconds());
+
+    if args.json {
+        println!(
+            "{}",
+            json!({ "run_id": run.id, "status": run.status, "elapsed_s": elapsed })
+        );
+    } else if run.status == "completed" {
+        let took = elapsed.map_or(String::new(), |seconds| format!(" in {seconds}s"));
+        println!("Run {} completed{took}. View it with: vizfold serve", run.id);
+    } else {
+        println!("Run {} finished with status: {}", run.id, run.status);
+        if let Some(message) = run.error_message {
+            println!("{message}");
+        }
+    }
+    Ok(())
+}
+
+/// A target that is neither a run id nor a bundled example.
+fn unknown_target(target: &str) -> DbErr {
+    let available: Vec<String> = examples::scan_default()
+        .into_iter()
+        .map(|example| example.id)
+        .collect();
+    DbErr::Custom(if available.is_empty() {
+        format!(
+            "'{target}' is not a run id, and no bundled examples were found under {}; re-run `vizfold install openfold`",
+            examples::monomer_dir().display()
+        )
+    } else {
+        format!(
+            "'{target}' is not a run id or a bundled example; available examples: {}",
+            available.join(", ")
+        )
+    })
+}
+
 async fn queue_openfold_run(
     database: &sea_orm::DatabaseConnection,
     args: OpenfoldQueueArgs,
 ) -> Result<(), DbErr> {
+    let run = submit_openfold_run(database, args).await?;
+    println!("Queued OpenFold run {}", run.id);
+    println!("status: {}", run.status);
+    println!("input_id: {}", run.input_id);
+    println!("\nNext:");
+    println!("  vizfold execute-run {}", run.id);
+    Ok(())
+}
+
+/// The queue step without its reporting, so `fold` can chain it into execute and register.
+async fn submit_openfold_run(
+    database: &sea_orm::DatabaseConnection,
+    args: OpenfoldQueueArgs,
+) -> Result<crate::core::entities::runs::Model, DbErr> {
+    // Submitting a run *needs* the catalog, so seed here rather than making every caller -- the
+    // CLI, the dashboard -- remember to. Existence-guarded, so repeating it is free.
+    seed_defaults(database).await?;
     let backend = model_backend_entity::Entity::find()
         .filter(model_backend_entity::Column::Slug.eq("openfold"))
         .one(database)
@@ -959,18 +1220,14 @@ async fn queue_openfold_run(
     )
     .await?;
 
-    println!("Queued OpenFold run {}", run.id);
-    println!("status: {}", run.status);
-    println!("input_id: {}", run.input_id);
-    println!("\nNext:");
-    println!("  vizfold execute-run {}", run.id);
-    Ok(())
+    Ok(run)
 }
 
 async fn queue_esmfold_run(
     database: &sea_orm::DatabaseConnection,
     args: EsmfoldQueueArgs,
 ) -> Result<(), DbErr> {
+    seed_defaults(database).await?;
     let backend = model_backend_entity::Entity::find()
         .filter(model_backend_entity::Column::Slug.eq("esmfold"))
         .one(database)
@@ -1569,7 +1826,62 @@ mod tests {
         let cli = Cli::try_parse_from(["vizfold", "execute-run", "1"])
             .expect("execute-run command should parse");
 
-        assert!(matches!(cli.command, Command::ExecuteRun { run_id: 1 }));
+        assert!(matches!(
+            cli.command,
+            Command::ExecuteRun(ExecuteRunArgs {
+                ref target,
+                attn: true,
+                json: false,
+            }) if target == "1"
+        ));
+    }
+
+    /// Folding an example is executing a run, so it is the same verb -- the target is a run id or
+    /// an example id, and `run_execute` tells them apart by whether it parses as an integer.
+    #[test]
+    fn execute_run_takes_an_example_id_as_its_target() {
+        let cli = Cli::try_parse_from(["vizfold", "execute-run", "6KWC_1", "--attn=false"])
+            .expect("execute-run command should parse");
+
+        assert!(matches!(
+            cli.command,
+            Command::ExecuteRun(ExecuteRunArgs {
+                ref target,
+                attn: false,
+                ..
+            }) if target == "6KWC_1"
+        ));
+    }
+
+    /// `for_example` hardcodes the defaults clap applies to `queue-run openfold`. If a default
+    /// there ever changes, this fails rather than silently queueing examples differently.
+    #[test]
+    fn queue_run_openfold_defaults_match_for_example() {
+        let cli = Cli::try_parse_from([
+            "vizfold",
+            "queue-run",
+            "openfold",
+            "--input-id",
+            "1UBQ_1",
+            "--input-sequence",
+            "MQIFVKTL",
+            "--demo-attn",
+        ])
+        .expect("queue-run command should parse");
+        let Command::QueueRun(QueueRunArgs {
+            model: QueueRunModel::Openfold(parsed),
+        }) = cli.command
+        else {
+            panic!("expected an openfold queue-run");
+        };
+
+        let example = examples::Example {
+            id: "1UBQ_1".into(),
+            residues: 8,
+            description: "UBIQUITIN".into(),
+            sequence: "MQIFVKTL".into(),
+        };
+        assert_eq!(OpenfoldQueueArgs::for_example(&example, true), parsed);
     }
 
     #[test]

--- a/cli/src/adapters/cli.rs
+++ b/cli/src/adapters/cli.rs
@@ -5,11 +5,12 @@ use std::path::{Path, PathBuf};
 
 use crate::core::{
     commands::LocalCommandRunner,
-    config, db, examples,
+    config, db,
     entities::{
         execution_targets as execution_target_entity, model_backends as model_backend_entity,
         model_invocation_profiles as model_invocation_profile_entity,
     },
+    examples,
     output_locations::resolve_output_location,
     preflight::PreflightStatus,
     seed::seed_defaults,
@@ -419,15 +420,23 @@ fn run_install(backend: Backend) -> Result<(), DbErr> {
         backend.slug(),
         installer.display()
     );
-    let status = std::process::Command::new("bash")
-        .arg(&installer)
-        .env("OPENFOLD_HOME", &src)
+    run_to_completion(
+        "model install",
+        std::process::Command::new("bash")
+            .arg(&installer)
+            .env("OPENFOLD_HOME", &src),
+    )
+}
+
+/// Run a child to completion with inherited stdio, naming it in either failure.
+fn run_to_completion(what: &str, command: &mut std::process::Command) -> Result<(), DbErr> {
+    let status = command
         .status()
-        .map_err(|error| DbErr::Custom(format!("failed to launch model install: {error}")))?;
+        .map_err(|error| DbErr::Custom(format!("failed to launch {what}: {error}")))?;
     status
         .success()
         .then_some(())
-        .ok_or_else(|| DbErr::Custom(format!("model install exited with status {status}")))
+        .ok_or_else(|| DbErr::Custom(format!("{what} exited with status {status}")))
 }
 
 /// Download a backend's data by running the checkout's downloader for the requested dataset into
@@ -467,16 +476,13 @@ fn run_download(backend: Backend, dataset: String) -> Result<(), DbErr> {
         script.display(),
         dest.display()
     );
-    let status = std::process::Command::new("bash")
-        .arg(&script)
-        .arg(&dest)
-        .env("OPENFOLD_HOME", &src)
-        .status()
-        .map_err(|error| DbErr::Custom(format!("failed to launch downloader: {error}")))?;
-    status
-        .success()
-        .then_some(())
-        .ok_or_else(|| DbErr::Custom(format!("downloader exited with status {status}")))
+    run_to_completion(
+        "downloader",
+        std::process::Command::new("bash")
+            .arg(&script)
+            .arg(&dest)
+            .env("OPENFOLD_HOME", &src),
+    )
 }
 
 /// Report resolved config plus which backends are installed. Runs before any install (so it can
@@ -517,8 +523,7 @@ fn run_status() -> Result<(), DbErr> {
                     status.to_owned(),
                     backend.env_prefix().display().to_string(),
                 ]
-            })
-            .collect(),
+            }),
     );
     Ok(())
 }
@@ -804,10 +809,9 @@ fn system_node_bin() -> Option<PathBuf> {
         .flatten()
 }
 
-/// Node for the dashboard: whatever is already on PATH when it is new enough, otherwise a
-/// micromamba env of its own. Clusters ship none -- Delta has no `node`, no `npm`, and no nodejs
-/// module -- and the env is kept out of every backend so the dashboard works before a backend is
-/// installed. Returns the bin directory to put in front of PATH.
+/// Node for the dashboard: whatever is on PATH when it is new enough, else a micromamba env of its
+/// own -- clusters ship none (Delta has no `node`, `npm`, or nodejs module). Kept out of every
+/// backend env so the dashboard works before a backend is installed. Returns the bin dir for PATH.
 fn ensure_node() -> Result<PathBuf, DbErr> {
     let env_dir = config::prefix().join("mamba/envs/vizfold-web");
     let bin = env_dir.join("bin");
@@ -820,16 +824,22 @@ fn ensure_node() -> Result<PathBuf, DbErr> {
     let micromamba = ensure_micromamba()?;
     println!("Provisioning Node (first run only)...");
     // --no-rc so a user ~/.condarc envs_dirs/channels can't hijack it, as the backend installs do.
-    let status = std::process::Command::new(&micromamba)
-        .args(["create", "-y", "--no-rc", "-c", "conda-forge", "nodejs>=22.13", "-p"])
-        .arg(&env_dir)
-        .env("MAMBA_ROOT_PREFIX", config::prefix().join("mamba"))
-        .status()
-        .map_err(|error| DbErr::Custom(format!("failed to launch micromamba: {error}")))?;
-    status
-        .success()
-        .then_some(bin)
-        .ok_or_else(|| DbErr::Custom(format!("provisioning Node exited with status {status}")))
+    run_to_completion(
+        "provisioning Node",
+        std::process::Command::new(&micromamba)
+            .args([
+                "create",
+                "-y",
+                "--no-rc",
+                "-c",
+                "conda-forge",
+                "nodejs>=22.13",
+                "-p",
+            ])
+            .arg(&env_dir)
+            .env("MAMBA_ROOT_PREFIX", config::prefix().join("mamba")),
+    )?;
+    Ok(bin)
 }
 
 /// The micromamba a backend install drops at `<prefix>/bin`, fetched the same way
@@ -852,18 +862,14 @@ fn ensure_micromamba() -> Result<PathBuf, DbErr> {
             prefix.display()
         ))
     })?;
-    let status = std::process::Command::new("sh")
-        .arg("-c")
-        .arg(format!(
+    run_to_completion(
+        "fetching micromamba",
+        std::process::Command::new("sh").arg("-c").arg(format!(
             "curl -Ls 'https://micro.mamba.pm/api/micromamba/{arch}/latest' | tar -xj -C '{}' bin/micromamba",
             prefix.display()
-        ))
-        .status()
-        .map_err(|error| DbErr::Custom(format!("failed to fetch micromamba: {error}")))?;
-    status
-        .success()
-        .then_some(micromamba)
-        .ok_or_else(|| DbErr::Custom(format!("fetching micromamba exited with status {status}")))
+        )),
+    )?;
+    Ok(micromamba)
 }
 
 fn run_npm(dir: &Path, node_bin: &Path, args: &[&str]) -> Result<(), DbErr> {
@@ -889,15 +895,7 @@ fn run_npm(dir: &Path, node_bin: &Path, args: &[&str]) -> Result<(), DbErr> {
     if let Some(database) = config::database_path() {
         command.env("VIZFOLD_DB", database);
     }
-    let status = command
-        .status()
-        .map_err(|error| DbErr::Custom(format!("failed to run npm: {error}")))?;
-    status.success().then_some(()).ok_or_else(|| {
-        DbErr::Custom(format!(
-            "npm {} exited with status {status}",
-            args.join(" ")
-        ))
-    })
+    run_to_completion(&format!("npm {}", args.join(" ")), &mut command)
 }
 
 async fn register_artifacts(
@@ -1044,16 +1042,13 @@ fn list_examples(json: bool) -> Result<(), DbErr> {
     }
     print_table(
         &["ID", "RESIDUES", "DESCRIPTION"],
-        found
-            .iter()
-            .map(|example| {
-                vec![
-                    example.id.clone(),
-                    example.residues.to_string(),
-                    example.description.clone(),
-                ]
-            })
-            .collect(),
+        found.iter().map(|example| {
+            vec![
+                example.id.clone(),
+                example.residues.to_string(),
+                example.description.clone(),
+            ]
+        }),
     );
     Ok(())
 }
@@ -1069,10 +1064,13 @@ async fn run_execute(
     let run_id = match args.target.parse::<i32>() {
         Ok(run_id) => run_id,
         Err(_) => {
-            let example = examples::find(&args.target).ok_or_else(|| unknown_target(&args.target))?;
-            let run =
-                submit_openfold_run(database, OpenfoldQueueArgs::for_example(&example, args.attn))
-                    .await?;
+            let example =
+                examples::find(&args.target).ok_or_else(|| unknown_target(&args.target))?;
+            let run = submit_openfold_run(
+                database,
+                OpenfoldQueueArgs::for_example(&example, args.attn),
+            )
+            .await?;
             if !args.json {
                 println!(
                     "Queued OpenFold run {} ({}, {} residues)\n",
@@ -1107,7 +1105,10 @@ async fn run_execute(
         );
     } else if run.status == "completed" {
         let took = elapsed.map_or(String::new(), |seconds| format!(" in {seconds}s"));
-        println!("Run {} completed{took}. View it with: vizfold serve", run.id);
+        println!(
+            "Run {} completed{took}. View it with: vizfold serve",
+            run.id
+        );
     } else {
         println!("Run {} finished with status: {}", run.id, run.status);
         if let Some(message) = run.error_message {
@@ -1141,29 +1142,36 @@ async fn queue_openfold_run(
     args: OpenfoldQueueArgs,
 ) -> Result<(), DbErr> {
     let run = submit_openfold_run(database, args).await?;
-    println!("Queued OpenFold run {}", run.id);
-    println!("status: {}", run.status);
-    println!("input_id: {}", run.input_id);
-    println!("\nNext:");
-    println!("  vizfold execute-run {}", run.id);
+    report_queued("OpenFold", &run);
     Ok(())
 }
 
 /// The queue step without its reporting, so `fold` can chain it into execute and register.
-async fn submit_openfold_run(
+/// The seeded records a local run is built from, plus what is derived from them. Both queue paths
+/// need all of it and differ only in the backend.
+struct LocalCatalog {
+    backend_id: i32,
+    target_id: i32,
+    profile_id: i32,
+    available_resources_json: String,
+    provenance: String,
+    working_dir: String,
+}
+
+async fn local_catalog(
     database: &sea_orm::DatabaseConnection,
-    args: OpenfoldQueueArgs,
-) -> Result<crate::core::entities::runs::Model, DbErr> {
+    backend: Backend,
+) -> Result<LocalCatalog, DbErr> {
     // Submitting a run *needs* the catalog, so seed here rather than making every caller -- the
     // CLI, the dashboard -- remember to. Existence-guarded, so repeating it is free.
     seed_defaults(database).await?;
-    let backend = model_backend_entity::Entity::find()
-        .filter(model_backend_entity::Column::Slug.eq("openfold"))
+    let model = model_backend_entity::Entity::find()
+        .filter(model_backend_entity::Column::Slug.eq(backend.slug()))
         .one(database)
         .await?
         .ok_or_else(seed_required_error)?;
     let target = execution_target_entity::Entity::find()
-        .filter(execution_target_entity::Column::Slug.eq("local-openfold"))
+        .filter(execution_target_entity::Column::Slug.eq(format!("local-{}", backend.slug())))
         .one(database)
         .await?
         .ok_or_else(seed_required_error)?;
@@ -1171,22 +1179,45 @@ async fn submit_openfold_run(
         .await?
         .into_iter()
         .find(|profile| {
-            profile.model_backend_id == backend.id
+            profile.model_backend_id == model.id
                 && profile.execution_target_id == target.id
                 && profile.invocation_kind == "local_subprocess"
         })
         .ok_or_else(seed_required_error)?;
-    let provenance = runs::provenance_snapshot(
-        &backend.slug,
-        backend.version.as_deref(),
-        &target.slug,
-        &profile.invocation_kind,
-        &profile.config_json,
-        &config::openfold_home(),
-        &config::prefix(),
-        &config::openfold_env_prefix(),
-    );
-    let working_dir = local_working_dir(&profile)?;
+    Ok(LocalCatalog {
+        backend_id: model.id,
+        target_id: target.id,
+        profile_id: profile.id,
+        available_resources_json: target.available_resources_json,
+        provenance: runs::provenance_snapshot(
+            &model.slug,
+            model.version.as_deref(),
+            &target.slug,
+            &profile.invocation_kind,
+            &profile.config_json,
+            &config::openfold_home(),
+            &config::prefix(),
+            &backend.env_prefix(),
+        ),
+        working_dir: local_working_dir(&profile)?,
+    })
+}
+
+/// What every queue path prints once the run exists.
+fn report_queued(label: &str, run: &crate::core::entities::runs::Model) {
+    println!("Queued {label} run {}", run.id);
+    println!("status: {}", run.status);
+    println!("input_id: {}", run.input_id);
+    println!("\nNext:");
+    println!("  vizfold execute-run {}", run.id);
+}
+
+async fn submit_openfold_run(
+    database: &sea_orm::DatabaseConnection,
+    args: OpenfoldQueueArgs,
+) -> Result<crate::core::entities::runs::Model, DbErr> {
+    let catalog = local_catalog(database, Backend::Openfold).await?;
+    let working_dir = &catalog.working_dir;
     let fasta_dir_input = args
         .fasta_dir
         .clone()
@@ -1195,8 +1226,8 @@ async fn submit_openfold_run(
         .data_dir
         .clone()
         .unwrap_or_else(|| config::data_dir().to_string_lossy().into_owned());
-    let fasta_dir = canonicalize_local_path("--fasta-dir", &fasta_dir_input, &working_dir)?;
-    let data_dir = canonicalize_local_path("--data-dir", &data_dir_input, &working_dir)?;
+    let fasta_dir = canonicalize_local_path("--fasta-dir", &fasta_dir_input, working_dir)?;
+    let data_dir = canonicalize_local_path("--data-dir", &data_dir_input, working_dir)?;
     let alignment_dir = if args.use_precomputed_alignments {
         let input = args
             .alignment_dir
@@ -1205,12 +1236,12 @@ async fn submit_openfold_run(
         Some(canonicalize_local_path(
             "--alignment-dir",
             &input,
-            &working_dir,
+            working_dir,
         )?)
     } else {
         args.alignment_dir
             .as_deref()
-            .map(|path| canonicalize_local_path("--alignment-dir", path, &working_dir))
+            .map(|path| canonicalize_local_path("--alignment-dir", path, working_dir))
             .transpose()?
     };
     let model_device = args
@@ -1229,7 +1260,7 @@ async fn submit_openfold_run(
         ("model_device".into(), json!(model_device)),
         (
             "cpus".into(),
-            json!(clamp_cpus(args.cpus, &target.available_resources_json)),
+            json!(clamp_cpus(args.cpus, &catalog.available_resources_json)),
         ),
     ]);
     if let Some(alignment_dir) = alignment_dir {
@@ -1239,9 +1270,9 @@ async fn submit_openfold_run(
     let run = runs::submit_run(
         database,
         runs::SubmitRunInput {
-            model_backend_id: backend.id,
-            execution_target_id: target.id,
-            invocation_profile_id: profile.id,
+            model_backend_id: catalog.backend_id,
+            execution_target_id: catalog.target_id,
+            invocation_profile_id: catalog.profile_id,
             status: "submitted".into(),
             input_id: args.input_id,
             input_sequence: args.input_sequence,
@@ -1252,7 +1283,7 @@ async fn submit_openfold_run(
             })
             .to_string(),
             execution_parameters_json: serde_json::Value::Object(execution_parameters).to_string(),
-            provenance_json: Some(provenance),
+            provenance_json: Some(catalog.provenance),
         },
     )
     .await?;
@@ -1264,38 +1295,9 @@ async fn queue_esmfold_run(
     database: &sea_orm::DatabaseConnection,
     args: EsmfoldQueueArgs,
 ) -> Result<(), DbErr> {
-    seed_defaults(database).await?;
-    let backend = model_backend_entity::Entity::find()
-        .filter(model_backend_entity::Column::Slug.eq("esmfold"))
-        .one(database)
-        .await?
-        .ok_or_else(seed_required_error)?;
-    let target = execution_target_entity::Entity::find()
-        .filter(execution_target_entity::Column::Slug.eq("local-esmfold"))
-        .one(database)
-        .await?
-        .ok_or_else(seed_required_error)?;
-    let profile = model_invocation_profiles::list_model_invocation_profiles(database)
-        .await?
-        .into_iter()
-        .find(|profile| {
-            profile.model_backend_id == backend.id
-                && profile.execution_target_id == target.id
-                && profile.invocation_kind == "local_subprocess"
-        })
-        .ok_or_else(seed_required_error)?;
-    let provenance = runs::provenance_snapshot(
-        &backend.slug,
-        backend.version.as_deref(),
-        &target.slug,
-        &profile.invocation_kind,
-        &profile.config_json,
-        &config::openfold_home(),
-        &config::prefix(),
-        &config::esmfold_env_prefix(),
-    );
-    let working_dir = local_working_dir(&profile)?;
-    let fasta = canonicalize_local_path("--fasta", &args.fasta, &working_dir)?;
+    let catalog = local_catalog(database, Backend::Esmfold).await?;
+    let working_dir = &catalog.working_dir;
+    let fasta = canonicalize_local_path("--fasta", &args.fasta, working_dir)?;
     let model_device = args
         .model_device
         .clone()
@@ -1304,9 +1306,9 @@ async fn queue_esmfold_run(
     let run = runs::submit_run(
         database,
         runs::SubmitRunInput {
-            model_backend_id: backend.id,
-            execution_target_id: target.id,
-            invocation_profile_id: profile.id,
+            model_backend_id: catalog.backend_id,
+            execution_target_id: catalog.target_id,
+            invocation_profile_id: catalog.profile_id,
             status: "submitted".into(),
             input_id: args.input_id,
             input_sequence: args.input_sequence,
@@ -1324,16 +1326,12 @@ async fn queue_esmfold_run(
                 "model_device": model_device,
             })
             .to_string(),
-            provenance_json: Some(provenance),
+            provenance_json: Some(catalog.provenance),
         },
     )
     .await?;
 
-    println!("Queued ESMFold run {}", run.id);
-    println!("status: {}", run.status);
-    println!("input_id: {}", run.input_id);
-    println!("\nNext:");
-    println!("  vizfold execute-run {}", run.id);
+    report_queued("ESMFold", &run);
     Ok(())
 }
 
@@ -1404,17 +1402,14 @@ async fn list_models(database: &sea_orm::DatabaseConnection) -> Result<(), DbErr
     let models = model_backends::list_model_backends(database).await?;
     print_table(
         &["ID", "SLUG", "LABEL", "VERSION"],
-        models
-            .iter()
-            .map(|model| {
-                vec![
-                    model.id.to_string(),
-                    model.slug.clone(),
-                    model.label.clone(),
-                    model.version.clone().unwrap_or_else(|| "-".into()),
-                ]
-            })
-            .collect(),
+        models.iter().map(|model| {
+            vec![
+                model.id.to_string(),
+                model.slug.clone(),
+                model.label.clone(),
+                model.version.clone().unwrap_or_else(|| "-".into()),
+            ]
+        }),
     );
     Ok(())
 }
@@ -1423,17 +1418,14 @@ async fn list_targets(database: &sea_orm::DatabaseConnection) -> Result<(), DbEr
     let targets = execution_targets::list_execution_targets(database).await?;
     print_table(
         &["ID", "SLUG", "TYPE", "DESCRIPTION"],
-        targets
-            .iter()
-            .map(|target| {
-                vec![
-                    target.id.to_string(),
-                    target.slug.clone(),
-                    target.target_type.clone(),
-                    target.description.clone().unwrap_or_else(|| "-".into()),
-                ]
-            })
-            .collect(),
+        targets.iter().map(|target| {
+            vec![
+                target.id.to_string(),
+                target.slug.clone(),
+                target.target_type.clone(),
+                target.description.clone().unwrap_or_else(|| "-".into()),
+            ]
+        }),
     );
     Ok(())
 }
@@ -1442,17 +1434,14 @@ async fn list_profiles(database: &sea_orm::DatabaseConnection) -> Result<(), DbE
     let profiles = model_invocation_profiles::list_model_invocation_profiles(database).await?;
     print_table(
         &["ID", "MODEL ID", "TARGET ID", "INVOCATION KIND"],
-        profiles
-            .iter()
-            .map(|profile| {
-                vec![
-                    profile.id.to_string(),
-                    profile.model_backend_id.to_string(),
-                    profile.execution_target_id.to_string(),
-                    profile.invocation_kind.clone(),
-                ]
-            })
-            .collect(),
+        profiles.iter().map(|profile| {
+            vec![
+                profile.id.to_string(),
+                profile.model_backend_id.to_string(),
+                profile.execution_target_id.to_string(),
+                profile.invocation_kind.clone(),
+            ]
+        }),
     );
     Ok(())
 }
@@ -1484,8 +1473,7 @@ async fn list_runs(
                     run.input_id.clone(),
                     run.submitted_at.to_rfc3339(),
                 ]
-            })
-            .collect(),
+            }),
     );
     Ok(())
 }
@@ -1512,18 +1500,14 @@ async fn show_run(database: &sea_orm::DatabaseConnection, run_id: i32) -> Result
     println!("artifacts:");
     print_table(
         &["ID", "TYPE ID", "FORMAT", "STORAGE URI"],
-        result
-            .artifacts
-            .iter()
-            .map(|artifact| {
-                vec![
-                    artifact.id.to_string(),
-                    artifact.artifact_type_id.to_string(),
-                    artifact.format.clone(),
-                    artifact.storage_uri.clone(),
-                ]
-            })
-            .collect(),
+        result.artifacts.iter().map(|artifact| {
+            vec![
+                artifact.id.to_string(),
+                artifact.artifact_type_id.to_string(),
+                artifact.format.clone(),
+                artifact.storage_uri.clone(),
+            ]
+        }),
     );
     Ok(())
 }
@@ -1534,7 +1518,8 @@ fn format_time(value: Option<chrono::DateTime<chrono::Utc>>) -> String {
         .unwrap_or_else(|| "-".into())
 }
 
-fn print_table(headers: &[&str], rows: Vec<Vec<String>>) {
+fn print_table(headers: &[&str], rows: impl IntoIterator<Item = Vec<String>>) {
+    let rows: Vec<Vec<String>> = rows.into_iter().collect();
     let mut widths: Vec<usize> = headers.iter().map(|header| header.len()).collect();
     for row in &rows {
         for (index, cell) in row.iter().enumerate() {

--- a/cli/src/core/examples.rs
+++ b/cli/src/core/examples.rs
@@ -77,9 +77,9 @@ fn parse(text: &str) -> Option<Example> {
         .flat_map(str::chars)
         .filter(|c| !c.is_whitespace())
         .collect();
-    (!id.is_empty() && !sequence.is_empty()).then(|| Example {
-        id,
+    (!id.is_empty() && !sequence.is_empty()).then_some(Example {
         residues: sequence.len(),
+        id,
         description,
         sequence,
     })

--- a/cli/src/core/examples.rs
+++ b/cli/src/core/examples.rs
@@ -1,0 +1,180 @@
+//! The bundled monomer examples -- the sequences that can fold without an MSA search.
+//!
+//! `<OPENFOLD_HOME>/examples/monomer` holds `fasta_dir_<stem>/<stem>.fasta` beside
+//! `alignments/<id>`. An example is offerable only when both exist: without the alignment
+//! directory the fold falls back to the full MSA pipeline, which needs the complete databases and
+//! runs for hours.
+
+use std::path::{Path, PathBuf};
+
+use crate::core::config;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Example {
+    pub id: String,
+    pub residues: usize,
+    /// The FASTA header's molecule-name field, empty when the header carries only an id.
+    pub description: String,
+    pub sequence: String,
+}
+
+pub fn monomer_dir() -> PathBuf {
+    config::openfold_home().join("examples/monomer")
+}
+
+pub fn scan_default() -> Vec<Example> {
+    scan(&monomer_dir())
+}
+
+pub fn find(id: &str) -> Option<Example> {
+    scan_default().into_iter().find(|example| example.id == id)
+}
+
+/// Every example in `dir` that has both a FASTA and a matching alignment directory, cheapest
+/// first -- residue count is what someone picking an example is actually choosing on.
+pub fn scan(dir: &Path) -> Vec<Example> {
+    let alignments = dir.join("alignments");
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    let mut found: Vec<Example> = entries
+        .filter_map(Result::ok)
+        .filter(|entry| entry.file_name().to_string_lossy().starts_with("fasta_dir_"))
+        .filter_map(|entry| first_fasta(&entry.path()))
+        .filter_map(|fasta| parse(&std::fs::read_to_string(fasta).ok()?))
+        .filter(|example| alignments.join(&example.id).is_dir())
+        .collect();
+    found.sort_by(|a, b| a.residues.cmp(&b.residues).then_with(|| a.id.cmp(&b.id)));
+    found
+}
+
+fn first_fasta(dir: &Path) -> Option<PathBuf> {
+    let mut fastas: Vec<PathBuf> = std::fs::read_dir(dir)
+        .ok()?
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.extension()
+                .is_some_and(|ext| ext == "fasta" || ext == "fa")
+        })
+        .collect();
+    fastas.sort();
+    fastas.into_iter().next()
+}
+
+/// Parse the first record of a FASTA. `>1UBQ_1|Chain A|UBIQUITIN|Homo sapiens (9606)` yields id
+/// `1UBQ_1` and description `UBIQUITIN`; a bare `>6KWC_1` yields an empty description.
+/// ponytail: first record only -- these directories hold one monomer each. Loop the records if a
+/// multi-chain example ever ships.
+fn parse(text: &str) -> Option<Example> {
+    let mut lines = text.lines().skip_while(|line| !line.starts_with('>'));
+    let header = lines.next()?.trim_start_matches('>');
+    let mut fields = header.split('|');
+    let id = fields.next()?.split_whitespace().next()?.to_owned();
+    let description = fields.nth(1).unwrap_or("").trim().to_owned();
+    let sequence: String = lines
+        .take_while(|line| !line.starts_with('>'))
+        .flat_map(str::chars)
+        .filter(|c| !c.is_whitespace())
+        .collect();
+    (!id.is_empty() && !sequence.is_empty()).then(|| Example {
+        id,
+        residues: sequence.len(),
+        description,
+        sequence,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Lay out a monomer tree: (fasta stem, contents, whether `alignments/<id>` exists).
+    fn tree(name: &str, entries: &[(&str, &str, bool)]) -> PathBuf {
+        let base = std::env::temp_dir().join(format!(
+            "vizfold-examples-{name}-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&base);
+        for (stem, contents, aligned) in entries {
+            let fasta_dir = base.join(format!("fasta_dir_{stem}"));
+            std::fs::create_dir_all(&fasta_dir).unwrap();
+            std::fs::write(fasta_dir.join(format!("{stem}.fasta")), contents).unwrap();
+            if *aligned {
+                let id = contents
+                    .trim_start_matches('>')
+                    .split(['|', '\n'])
+                    .next()
+                    .unwrap();
+                std::fs::create_dir_all(base.join("alignments").join(id)).unwrap();
+            }
+        }
+        base
+    }
+
+    #[test]
+    fn reads_id_description_and_sequence_from_a_piped_header() {
+        let dir = tree(
+            "piped",
+            &[(
+                "1UBQ",
+                ">1UBQ_1|Chain A|UBIQUITIN|Homo sapiens (9606)\nMQIFVKTL\nTGKTITL\n",
+                true,
+            )],
+        );
+        assert_eq!(
+            scan(&dir),
+            vec![Example {
+                id: "1UBQ_1".into(),
+                residues: 15,
+                description: "UBIQUITIN".into(),
+                sequence: "MQIFVKTLTGKTITL".into(),
+            }]
+        );
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn a_bare_header_has_no_description() {
+        let dir = tree("bare", &[("6KWC", ">6KWC_1\nGSTIQPGTGY\n", true)]);
+        let found = scan(&dir);
+        assert_eq!(found[0].id, "6KWC_1");
+        assert_eq!(found[0].description, "");
+        assert_eq!(found[0].residues, 10);
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    /// Without `alignments/<id>` the fold falls back to the full MSA pipeline, so it is not offerable.
+    #[test]
+    fn excludes_an_example_with_no_alignment_directory() {
+        let dir = tree(
+            "unaligned",
+            &[
+                ("2OMF", ">2OMF_1|Chain A|PORIN\nAEIYNKDG\n", false),
+                ("1UBQ", ">1UBQ_1|Chain A|UBIQUITIN\nMQIFVKTL\n", true),
+            ],
+        );
+        let ids: Vec<String> = scan(&dir).into_iter().map(|e| e.id).collect();
+        assert_eq!(ids, vec!["1UBQ_1"]);
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn sorts_cheapest_first() {
+        let dir = tree(
+            "order",
+            &[
+                ("2OMF", ">2OMF_1|Chain A|PORIN\nAEIYNKDGNK\n", true),
+                ("1G1J", ">1G1J_1|Chains A, B|NSP4\nIEKQ\n", true),
+            ],
+        );
+        let ids: Vec<String> = scan(&dir).into_iter().map(|e| e.id).collect();
+        assert_eq!(ids, vec!["1G1J_1", "2OMF_1"]);
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn a_missing_directory_yields_nothing() {
+        assert!(scan(Path::new("/nonexistent/examples/monomer")).is_empty());
+    }
+}

--- a/cli/src/core/examples.rs
+++ b/cli/src/core/examples.rs
@@ -1,9 +1,8 @@
-//! The bundled monomer examples -- the sequences that can fold without an MSA search.
+//! The bundled monomer examples -- the sequences that fold without an MSA search.
 //!
 //! `<OPENFOLD_HOME>/examples/monomer` holds `fasta_dir_<stem>/<stem>.fasta` beside
-//! `alignments/<id>`. An example is offerable only when both exist: without the alignment
-//! directory the fold falls back to the full MSA pipeline, which needs the complete databases and
-//! runs for hours.
+//! `alignments/<id>`. Both must exist to offer one: without the alignments the fold falls back to
+//! the full MSA pipeline, which needs the complete databases and runs for hours.
 
 use std::path::{Path, PathBuf};
 
@@ -39,7 +38,12 @@ pub fn scan(dir: &Path) -> Vec<Example> {
     };
     let mut found: Vec<Example> = entries
         .filter_map(Result::ok)
-        .filter(|entry| entry.file_name().to_string_lossy().starts_with("fasta_dir_"))
+        .filter(|entry| {
+            entry
+                .file_name()
+                .to_string_lossy()
+                .starts_with("fasta_dir_")
+        })
         .filter_map(|entry| first_fasta(&entry.path()))
         .filter_map(|fasta| parse(&std::fs::read_to_string(fasta).ok()?))
         .filter(|example| alignments.join(&example.id).is_dir())
@@ -62,9 +66,9 @@ fn first_fasta(dir: &Path) -> Option<PathBuf> {
     fastas.into_iter().next()
 }
 
-/// Parse the first record of a FASTA. `>1UBQ_1|Chain A|UBIQUITIN|Homo sapiens (9606)` yields id
-/// `1UBQ_1` and description `UBIQUITIN`; a bare `>6KWC_1` yields an empty description.
-/// ponytail: first record only -- these directories hold one monomer each. Loop the records if a
+/// `>1UBQ_1|Chain A|UBIQUITIN|Homo sapiens (9606)` yields id `1UBQ_1`, description `UBIQUITIN`;
+/// a bare `>6KWC_1` yields no description.
+/// ponytail: first record only -- these directories hold one monomer each. Loop them if a
 /// multi-chain example ever ships.
 fn parse(text: &str) -> Option<Example> {
     let mut lines = text.lines().skip_while(|line| !line.starts_with('>'));
@@ -91,10 +95,8 @@ mod tests {
 
     /// Lay out a monomer tree: (fasta stem, contents, whether `alignments/<id>` exists).
     fn tree(name: &str, entries: &[(&str, &str, bool)]) -> PathBuf {
-        let base = std::env::temp_dir().join(format!(
-            "vizfold-examples-{name}-{}",
-            std::process::id()
-        ));
+        let base =
+            std::env::temp_dir().join(format!("vizfold-examples-{name}-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&base);
         for (stem, contents, aligned) in entries {
             let fasta_dir = base.join(format!("fasta_dir_{stem}"));

--- a/cli/src/core/mod.rs
+++ b/cli/src/core/mod.rs
@@ -2,6 +2,7 @@ pub mod commands;
 pub mod config;
 pub mod db;
 pub mod entities;
+pub mod examples;
 pub mod migrations;
 pub mod model_runners;
 pub mod output_locations;

--- a/workbench/app/FoldCard.tsx
+++ b/workbench/app/FoldCard.tsx
@@ -70,13 +70,13 @@ export default function FoldCard({ examples }: { examples: Example[] }) {
         </label>
 
         <label className="field">
-          <span>
+          <span className="check">
             <input
               type="checkbox"
               checked={attn}
               onChange={(event) => setAttn(event.target.checked)}
               disabled={folding}
-            />{" "}
+            />
             Dump attention maps
           </span>
           <p className="field-note">

--- a/workbench/app/FoldCard.tsx
+++ b/workbench/app/FoldCard.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import type { Example } from "@/lib/vizfold";
+
+export default function FoldCard({ examples }: { examples: Example[] }) {
+  const router = useRouter();
+  const [inputId, setInputId] = useState(examples[0]?.id ?? "");
+  const [attn, setAttn] = useState(true);
+  const [folding, setFolding] = useState(false);
+  const [error, setError] = useState("");
+
+  if (examples.length === 0) {
+    return (
+      <section className="panel">
+        <div className="panel-header">
+          <h2>Fold a protein</h2>
+        </div>
+        <p className="field-note">
+          No examples found. They come from <code>examples/monomer</code> in the VizFold checkout —
+          run <code>vizfold install openfold</code>, then reload.
+        </p>
+      </section>
+    );
+  }
+
+  async function fold(event: React.FormEvent) {
+    event.preventDefault();
+    setFolding(true);
+    setError("");
+    try {
+      const response = await fetch("/api/runs", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ inputId, attn }),
+      });
+      const body = await response.json();
+      if (!response.ok) throw new Error(body.error ?? "Could not start the fold.");
+      router.push(`/runs/${body.runId}`);
+    } catch (problem) {
+      setError(problem instanceof Error ? problem.message : String(problem));
+      setFolding(false);
+    }
+  }
+
+  return (
+    <section className="panel">
+      <div className="panel-header">
+        <h2>Fold a protein</h2>
+        <p>Bundled examples fold in about a minute — their alignments are precomputed.</p>
+      </div>
+
+      <form className="run-form" onSubmit={fold}>
+        <label className="field">
+          <span>Protein</span>
+          <select
+            value={inputId}
+            onChange={(event) => setInputId(event.target.value)}
+            disabled={folding}
+          >
+            {examples.map((example) => (
+              <option key={example.id} value={example.id}>
+                {example.id}
+                {example.description ? ` — ${example.description}` : ""} ({example.residues}{" "}
+                residues)
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="field">
+          <span>
+            <input
+              type="checkbox"
+              checked={attn}
+              onChange={(event) => setAttn(event.target.checked)}
+              disabled={folding}
+            />{" "}
+            Dump attention maps
+          </span>
+          <p className="field-note">
+            Writes one trace per layer and head, which the run page renders alongside the structure.
+          </p>
+        </label>
+
+        {error ? <p className="field-note">{error}</p> : null}
+
+        <button className="primary-button" type="submit" disabled={folding}>
+          {folding ? "Starting…" : "Fold"}
+        </button>
+      </form>
+    </section>
+  );
+}

--- a/workbench/app/Poller.tsx
+++ b/workbench/app/Poller.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+
+const TERMINAL = new Set(["completed", "failed"]);
+
+/**
+ * Re-render the server component while any run is still going. Both pages are `force-dynamic`, so
+ * a refresh re-reads the executor's database — no client-side run state to keep in sync.
+ */
+export default function Poller({ statuses }: { statuses: string[] }) {
+  const router = useRouter();
+  const active = statuses.some((status) => !TERMINAL.has(status));
+
+  useEffect(() => {
+    if (!active) return;
+    const timer = setInterval(() => router.refresh(), 3000);
+    return () => clearInterval(timer);
+  }, [active, router]);
+
+  return null;
+}

--- a/workbench/app/api/runs/route.ts
+++ b/workbench/app/api/runs/route.ts
@@ -4,8 +4,7 @@ import { foldInBackground, listExamples, queueRun } from "@/lib/vizfold";
 export async function POST(request: Request) {
   const { inputId, attn = true } = await request.json();
 
-  // The trust boundary: only an id the CLI itself listed reaches the CLI, so nothing a caller
-  // typed is ever passed through as a sequence or a path.
+  // Trust boundary: only an id the CLI itself listed is ever handed back to it.
   const example = (await listExamples()).find((one) => one.id === inputId);
   if (!example) {
     return NextResponse.json(
@@ -19,8 +18,7 @@ export async function POST(request: Request) {
     foldInBackground(runId);
     return NextResponse.json({ runId }, { status: 201 });
   } catch (error) {
-    // A fold that fails later is not an error here — the run row carries its own status and
-    // error_message, and the run page shows them. This is only "the run could not be created".
+    // Only "could not create the run" — a later fold failure lands on the run row instead.
     const detail = error instanceof Error ? error.message : String(error);
     return NextResponse.json({ error: detail }, { status: 500 });
   }

--- a/workbench/app/api/runs/route.ts
+++ b/workbench/app/api/runs/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+import { foldInBackground, listExamples, queueRun } from "@/lib/vizfold";
+
+export async function POST(request: Request) {
+  const { inputId, attn = true } = await request.json();
+
+  // The trust boundary: only an id the CLI itself listed reaches the CLI, so nothing a caller
+  // typed is ever passed through as a sequence or a path.
+  const example = (await listExamples()).find((one) => one.id === inputId);
+  if (!example) {
+    return NextResponse.json(
+      { error: `Unknown example "${inputId}".` },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const runId = await queueRun(example, Boolean(attn));
+    foldInBackground(runId);
+    return NextResponse.json({ runId }, { status: 201 });
+  } catch (error) {
+    // A fold that fails later is not an error here — the run row carries its own status and
+    // error_message, and the run page shows them. This is only "the run could not be created".
+    const detail = error instanceof Error ? error.message : String(error);
+    return NextResponse.json({ error: detail }, { status: 500 });
+  }
+}

--- a/workbench/app/globals.css
+++ b/workbench/app/globals.css
@@ -81,16 +81,6 @@ textarea {
   line-height: 1.6;
 }
 
-.workspace-grid {
-  display: grid;
-  grid-template-columns: minmax(0, 1.3fr) minmax(320px, 0.9fr);
-  gap: 24px;
-}
-
-.result-panel {
-  grid-column: 1 / -1;
-}
-
 .panel {
   padding: 24px;
 }
@@ -158,14 +148,6 @@ textarea {
   background: var(--accent-strong);
 }
 
-.capability-list {
-  margin: 0;
-  padding-left: 20px;
-  color: var(--text-soft);
-  display: grid;
-  gap: 10px;
-}
-
 .result-card,
 .empty-state {
   border: 1px dashed var(--border);
@@ -191,12 +173,10 @@ textarea {
 }
 
 .result-row span,
-.empty-state p:last-child,
-.result-note {
+.empty-state p:last-child {
   color: var(--text-soft);
 }
 
-.result-note,
 .empty-state p {
   margin: 14px 0 0;
   line-height: 1.5;
@@ -339,14 +319,6 @@ textarea {
 }
 
 @media (max-width: 900px) {
-  .workspace-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .result-panel {
-    grid-column: auto;
-  }
-
   .page-shell {
     padding-inline: 16px;
   }

--- a/workbench/app/globals.css
+++ b/workbench/app/globals.css
@@ -110,6 +110,12 @@ textarea {
   font-weight: 600;
 }
 
+.field .check {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
 .field-note {
   margin: 0;
   color: var(--text-soft);
@@ -117,7 +123,8 @@ textarea {
   font-size: 0.95rem;
 }
 
-.field input,
+/* Checkboxes keep their intrinsic box; the full-width treatment is for text-ish controls. */
+.field input:not([type="checkbox"]),
 .field select,
 .field textarea {
   width: 100%;

--- a/workbench/app/page.tsx
+++ b/workbench/app/page.tsx
@@ -1,25 +1,33 @@
 import Link from "next/link";
 import { listRuns } from "@/lib/db";
+import { listExamples } from "@/lib/vizfold";
+import FoldCard from "@/app/FoldCard";
+import Poller from "@/app/Poller";
 
 // Read the executor db per request; never prerender a stale run list at build time.
 export const dynamic = "force-dynamic";
 
-export default function HomePage() {
+export default async function HomePage() {
   const runs = listRuns();
+  // The dashboard is still useful for browsing past runs when the CLI is unreachable, so a failed
+  // lookup degrades to an empty picker (which explains itself) rather than a 500.
+  const examples = await listExamples().catch(() => []);
 
   return (
     <main className="page-shell">
+      <Poller statuses={runs.map((run) => run.status)} />
       <section className="hero-card">
         <div className="hero-copy">
           <p className="eyebrow">VizFold v2</p>
           <h1 className="brand-title">VizFold</h1>
           <p className="subtitle">
-            Runs recorded by the VizFold executor. Queue new runs with{" "}
-            <code>vizfold queue-run</code> and execute them with{" "}
-            <code>vizfold execute-run</code>.
+            Fold a protein and inspect what the model computed — the predicted structure and the
+            attention behind it.
           </p>
         </div>
       </section>
+
+      <FoldCard examples={examples} />
 
       <section className="panel">
         <div className="panel-header">
@@ -32,10 +40,7 @@ export default function HomePage() {
         {runs.length === 0 ? (
           <div className="empty-state">
             <p>No runs yet.</p>
-            <p>
-              Queue one with <code>vizfold queue-run openfold …</code>, then{" "}
-              <code>vizfold execute-run &lt;id&gt;</code>.
-            </p>
+            <p>Pick a protein above and hit Fold.</p>
           </div>
         ) : (
           <table className="runs-table">

--- a/workbench/app/runs/[runId]/page.tsx
+++ b/workbench/app/runs/[runId]/page.tsx
@@ -27,23 +27,23 @@ function runRoot(artifacts: ArtifactRow[], id: number): string | null {
   return null;
 }
 
+const entry = (file: string, runsRoot: string, name = path.basename(file)): FileEntry => ({
+  name,
+  url: `/runs/${path.relative(runsRoot, file)}`,
+  isImage: IS_IMAGE.test(file),
+  isStructure: IS_STRUCTURE.test(file),
+});
+
 function browse(dir: string, runsRoot: string): FileEntry[] {
-  let abs: string[];
   try {
-    abs = readdirSync(dir, { recursive: true, withFileTypes: true })
+    return readdirSync(dir, { recursive: true, withFileTypes: true })
       .filter((e) => e.isFile())
-      .map((e) => path.join(e.parentPath, e.name));
+      .map((e) => path.join(e.parentPath, e.name))
+      .map((file) => entry(file, runsRoot, path.relative(dir, file)))
+      .sort((a, b) => a.name.localeCompare(b.name));
   } catch {
     return [];
   }
-  return abs
-    .map((file) => ({
-      name: path.relative(dir, file),
-      url: `/runs/${path.relative(runsRoot, file)}`,
-      isImage: IS_IMAGE.test(file),
-      isStructure: IS_STRUCTURE.test(file),
-    }))
-    .sort((a, b) => a.name.localeCompare(b.name));
 }
 
 export default async function RunPage({
@@ -104,14 +104,12 @@ export default async function RunPage({
           </div>
         ) : (
           artifacts.map((artifact) => {
-            const files =
-              artifact.format === "directory" && runsRoot
+            // A file artifact is just a one-entry listing, so both kinds render the same way.
+            const files = !runsRoot
+              ? []
+              : artifact.format === "directory"
                 ? browse(artifact.storage_uri, runsRoot)
-                : [];
-            const directLink =
-              artifact.format !== "directory" && runsRoot
-                ? `/runs/${path.relative(runsRoot, artifact.storage_uri)}`
-                : null;
+                : [entry(artifact.storage_uri, runsRoot)];
             return (
               <div key={artifact.id} className="artifact-block">
                 <h3>
@@ -122,16 +120,7 @@ export default async function RunPage({
                       : `(${artifact.format})`}
                   </span>
                 </h3>
-                {directLink ? (
-                  <ul className="file-list">
-                    <li>
-                      <a href={directLink}>{path.basename(artifact.storage_uri)}</a>
-                      {IS_STRUCTURE.test(artifact.storage_uri) ? (
-                        <StructureViewer url={directLink} name={path.basename(artifact.storage_uri)} />
-                      ) : null}
-                    </li>
-                  </ul>
-                ) : files.length === 0 ? (
+                {files.length === 0 ? (
                   <p className="field-note">Empty.</p>
                 ) : (
                   <ul className="file-list">

--- a/workbench/app/runs/[runId]/page.tsx
+++ b/workbench/app/runs/[runId]/page.tsx
@@ -5,6 +5,7 @@ import path from "node:path";
 import { readdirSync } from "node:fs";
 import { getRun, listArtifacts, type ArtifactRow } from "@/lib/db";
 import StructureViewer from "@/app/StructureViewer";
+import Poller from "@/app/Poller";
 
 export const dynamic = "force-dynamic";
 
@@ -61,6 +62,7 @@ export default async function RunPage({
 
   return (
     <main className="page-shell">
+      <Poller statuses={[run.status]} />
       <section className="hero-card">
         <div className="hero-copy">
           <p className="eyebrow">

--- a/workbench/lib/db.ts
+++ b/workbench/lib/db.ts
@@ -30,8 +30,14 @@ export type ArtifactRow = {
 };
 
 // A fresh install has no db until the first run; treat "not created yet" as "nothing to show".
-function open(): DatabaseSync | null {
-  return existsSync(dbPath) ? new DatabaseSync(dbPath, { readOnly: true }) : null;
+function query<T>(read: (db: DatabaseSync) => T, whenAbsent: T): T {
+  if (!existsSync(dbPath)) return whenAbsent;
+  const db = new DatabaseSync(dbPath, { readOnly: true });
+  try {
+    return read(db);
+  } finally {
+    db.close();
+  }
 }
 
 // Join the FK tables here so pages never see bare model_backend_id/execution_target_id.
@@ -42,40 +48,17 @@ const RUN_SELECT = `SELECT r.id, r.status, r.input_id, r.input_sequence, r.submi
   JOIN model_backends b ON b.id = r.model_backend_id
   JOIN execution_targets t ON t.id = r.execution_target_id`;
 
-export function listRuns(): RunRow[] {
-  const db = open();
-  if (!db) return [];
-  try {
-    return db.prepare(`${RUN_SELECT} ORDER BY r.submitted_at DESC`).all() as RunRow[];
-  } finally {
-    db.close();
-  }
-}
+const ARTIFACT_SELECT = `SELECT a.id, a.format, a.storage_uri,
+    at.slug AS type_slug, at.label AS type_label, at.viewer_kind, at.display_mode
+  FROM artifacts a
+  JOIN artifact_types at ON at.id = a.artifact_type_id
+  WHERE a.run_id = ? ORDER BY a.id`;
 
-export function getRun(id: number): RunRow | null {
-  const db = open();
-  if (!db) return null;
-  try {
-    return (db.prepare(`${RUN_SELECT} WHERE r.id = ?`).get(id) as RunRow) ?? null;
-  } finally {
-    db.close();
-  }
-}
+export const listRuns = (): RunRow[] =>
+  query((db) => db.prepare(`${RUN_SELECT} ORDER BY r.submitted_at DESC`).all() as RunRow[], []);
 
-export function listArtifacts(runId: number): ArtifactRow[] {
-  const db = open();
-  if (!db) return [];
-  try {
-    return db
-      .prepare(
-        `SELECT a.id, a.format, a.storage_uri,
-            at.slug AS type_slug, at.label AS type_label, at.viewer_kind, at.display_mode
-          FROM artifacts a
-          JOIN artifact_types at ON at.id = a.artifact_type_id
-          WHERE a.run_id = ? ORDER BY a.id`,
-      )
-      .all(runId) as ArtifactRow[];
-  } finally {
-    db.close();
-  }
-}
+export const getRun = (id: number): RunRow | null =>
+  query((db) => (db.prepare(`${RUN_SELECT} WHERE r.id = ?`).get(id) as RunRow) ?? null, null);
+
+export const listArtifacts = (runId: number): ArtifactRow[] =>
+  query((db) => db.prepare(ARTIFACT_SELECT).all(runId) as ArtifactRow[], []);

--- a/workbench/lib/vizfold.ts
+++ b/workbench/lib/vizfold.ts
@@ -1,0 +1,55 @@
+import { execFile, spawn } from "node:child_process";
+import { mkdirSync, openSync } from "node:fs";
+import { promisify } from "node:util";
+
+// The CLI owns the executor; the dashboard never parses FASTA or writes the database itself.
+// `vizfold serve` exports VIZFOLD_BIN so this resolves without depending on ~/.local/bin.
+const BIN = process.env.VIZFOLD_BIN ?? "vizfold";
+const PREFIX = process.env.OPENFOLD_PREFIX ?? "";
+
+const run = promisify(execFile);
+
+export type Example = {
+  id: string;
+  residues: number;
+  description: string;
+  sequence: string;
+};
+
+export async function listExamples(): Promise<Example[]> {
+  const { stdout } = await run(BIN, ["list", "examples", "--json"]);
+  return JSON.parse(stdout);
+}
+
+/** Record the run and return its id. Queueing only writes the row, so this is near-instant. */
+export async function queueRun(example: Example, attn: boolean): Promise<number> {
+  const args = [
+    "queue-run",
+    "openfold",
+    "--input-id",
+    example.id,
+    "--input-sequence",
+    example.sequence,
+    ...(attn ? ["--demo-attn"] : []),
+  ];
+  const { stdout } = await run(BIN, args);
+  const id = stdout.match(/Queued OpenFold run (\d+)/)?.[1];
+  if (!id) throw new Error(`no run id in queue-run output: ${stdout.trim()}`);
+  return Number(id);
+}
+
+/**
+ * Fold in the background. A fold runs for minutes, far longer than a request should be held open,
+ * so the response returns as soon as the run exists and the page polls the status from there.
+ * `execute-run` registers the artifacts itself once the fold lands.
+ */
+export function foldInBackground(runId: number): void {
+  const logs = `${PREFIX}/runs`;
+  mkdirSync(logs, { recursive: true });
+  const log = openSync(`${logs}/${runId}.submit.log`, "a");
+  const child = spawn(BIN, ["execute-run", String(runId)], {
+    detached: true,
+    stdio: ["ignore", log, log],
+  });
+  child.unref();
+}

--- a/workbench/lib/vizfold.ts
+++ b/workbench/lib/vizfold.ts
@@ -2,8 +2,8 @@ import { execFile, spawn } from "node:child_process";
 import { mkdirSync, openSync } from "node:fs";
 import { promisify } from "node:util";
 
-// The CLI owns the executor; the dashboard never parses FASTA or writes the database itself.
-// `vizfold serve` exports VIZFOLD_BIN so this resolves without depending on ~/.local/bin.
+// The CLI owns the executor; the dashboard never parses FASTA or writes the database.
+// `vizfold serve` exports VIZFOLD_BIN so this resolves without relying on ~/.local/bin.
 const BIN = process.env.VIZFOLD_BIN ?? "vizfold";
 const PREFIX = process.env.OPENFOLD_PREFIX ?? "";
 
@@ -38,11 +38,8 @@ export async function queueRun(example: Example, attn: boolean): Promise<number>
   return Number(id);
 }
 
-/**
- * Fold in the background. A fold runs for minutes, far longer than a request should be held open,
- * so the response returns as soon as the run exists and the page polls the status from there.
- * `execute-run` registers the artifacts itself once the fold lands.
- */
+/** Detached: a fold runs for minutes, far longer than a request may be held open. The page polls
+ *  from there, and `execute-run` registers the artifacts itself once it lands. */
 export function foldInBackground(runId: number): void {
   const logs = `${PREFIX}/runs`;
   mkdirSync(logs, { recursive: true });


### PR DESCRIPTION
Closes the three gaps between what `PEARC26_TUTORIAL.md` describes and what shipped: the dashboard could not submit a run, `vizfold serve` could not start on a cluster, and folding an example took four commands and a 191-character sequence paste.

## What changed

**`vizfold serve` provisions its own Node.** Clusters ship none — Delta has no `node`, no `npm`, and no `nodejs` Lmod module — and the workbench needs ≥22.13 for `node:sqlite`. `ensure_node()` uses whatever is already on `PATH` when it clears the floor, otherwise creates a `vizfold-web` micromamba env, bootstrapping micromamba the way `setup.sh:57` does when no backend is installed yet. Kept out of every backend env so the dashboard works before a backend exists. `run_npm` leads `PATH` with that bin dir — npm's shebang resolves `node` off `PATH`, so naming the binary by path is not enough on its own.

**Folding an example is executing a run, so it is one verb.** `execute-run <target>` now takes a run id *or* a bundled example id, queueing the example first, and registers artifacts on the way out — a completed run whose outputs were never registered is invisible to the dashboard. `list examples` enumerates what folds without an MSA search: the monomers with both a FASTA and a precomputed alignment directory, so the list can never offer something that fails. Both take `--json`. The four lifecycle subcommands are unchanged and still documented.

**Seeding moved into the submit path.** `submit_openfold_run` and `queue_esmfold_run` call `seed_defaults` themselves. Submitting a run requires the catalog, so the requirement is met where it lives rather than at each call site. Found by hitting `run vizfold seed` from the dashboard against a fresh database.

**The dashboard can fold.** `POST /api/runs` validates the id against the CLI's own list, queues synchronously for the redirect, then detaches the fold to `$OPENFOLD_PREFIX/runs/<id>.submit.log`. Plus a Fold card and a 3 s poller. `lib/db.ts` stays read-only and `vizfold` stays the only writer — the workbench never parses FASTA and never writes SQLite.

**Nexus points at its staged AF2 mirror.** Setting `OPENFOLD_AF2_ROOT` is all-or-nothing: it flips `MIRROR=yes`, which skips `fetch_params`/`fetch_templates`, so the root must also carry `params/` and `pdb_mmcif/mmcif_files`. Documented, since that is the failure mode a new mirror hits.

## Verified on Delta (`dt-login02`, A100 40GB)

| Path | Result |
| --- | --- |
| `execute-run <example>` from a login node | 776 atoms, 96 attention traces |
| **Dashboard Fold card** | 1231 atoms (1UBQ) / 776 atoms (1G1J), `srun` onto a GPU node |
| **Inside an allocation** (the CS Bridge path) | `CUDA available: True`, A100, 53 s |
| `serve` cold start with the env deleted | `Provisioning Node (first run only)…` → v26.5.0 → `npm install` → HTTP 200 |
| `npm` without / with the `PATH` prepend | `env: 'node': No such file` / `11.17.0` |
| 3D viewer over an SSH tunnel | Structure renders, residue coloring applies per-viewer |

`SlurmContext::detect()` needed **no change**: in a real batch allocation (`SLURM_JOB_ID` set, `SLURM_STEP_ID` unset) the `srun --ntasks=1` step was not blocked by the batch step and did inherit the GPU.

## Also in here

A ponytail pass over both trees: `run_to_completion()` for five copies of the spawn-and-check ceremony, `local_catalog()` for a 30-line preamble duplicated across both queue paths, `query()` for `lib/db.ts`'s threefold open/try/finally, `print_table` taking an iterator, one render path for file and directory artifacts, and four dead CSS rules. Net −74 lines.

## Test plan

- `cargo test` — 119 pass; `cargo clippy --all-targets` and `cargo fmt --check` clean
- New coverage: the example scanner (piped vs bare FASTA headers, missing alignment dir, ordering), the Node version gate, and a drift test pinning `OpenfoldQueueArgs::for_example` to clap's `queue-run openfold` defaults
- `tsc --noEmit` and `eslint` clean in `workbench/`
- End-to-end on Delta as above, including a fold submitted from the browser

## Not verified

Simple Browser rendering inside an actual CS Bridge window; DeltaAI (aarch64); and the Nexus mirror contents — no install has run against `OPENFOLD_AF2_ROOT` there yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AdhiyVf49e86fLAA8pisFu