### PR TITLE
One env base directory, one fixed name per environment

### DIFF
--- a/DEMO.md
+++ b/DEMO.md
@@ -35,8 +35,8 @@ Config: /u/yjayawardana/.config/vizfold/vizfold.json
 Backends:
 BACKEND   STATUS         ENV PREFIX
 --------  -------------  --------------------------------------------------------
-openfold  installed      /work/nvme/bbol/yjayawardana/vizfold/mamba/envs/openfold-env
-esmfold   not installed  /work/nvme/bbol/yjayawardana/vizfold/esmfold-venv
+openfold  installed      /work/nvme/bbol/yjayawardana/vizfold/mamba/envs/vizfold-openfold
+esmfold   not installed  /work/nvme/bbol/yjayawardana/vizfold/vizfold-esmfold
 ```
 
 The paths above (`OPENFOLD_PREFIX`, `OPENFOLD_DATA_DIR`, the account, partition) are resolved live

--- a/DEMO.md
+++ b/DEMO.md
@@ -35,8 +35,8 @@ Config: /u/yjayawardana/.config/vizfold/vizfold.json
 Backends:
 BACKEND   STATUS         ENV PREFIX
 --------  -------------  --------------------------------------------------------
-openfold  installed      /work/nvme/bbol/yjayawardana/vizfold/mamba/envs/vizfold-openfold
-esmfold   not installed  /work/nvme/bbol/yjayawardana/vizfold/vizfold-esmfold
+openfold  installed      /work/nvme/bbol/yjayawardana/vizfold/envs/vizfold-openfold
+esmfold   not installed  /work/nvme/bbol/yjayawardana/vizfold/envs/vizfold-esmfold
 ```
 
 The paths above (`OPENFOLD_PREFIX`, `OPENFOLD_DATA_DIR`, the account, partition) are resolved live

--- a/README.md
+++ b/README.md
@@ -117,6 +117,13 @@ exactly what you care about and nothing else:
 | 2 | `~/.config/vizfold/vizfold.json` | written by the install; edit to make a choice stick |
 | 3 | `backends/openfold/install/sites/<site>.json` | the site's defaults, in the repo — edit to change them for everyone |
 
+Every environment the install creates is named `vizfold-<backend>` — `vizfold-openfold` and
+`vizfold-workbench` as conda envs under `<prefix>/mamba/envs`, `vizfold-esmfold` as a venv beside
+them. `lib/config.sh`'s `vizfold::env` and `conda_env()` in `cli/src/core/config.rs` are the two
+definitions. Override any of them with `OPENFOLD_ENV_NAME` / `OPENFOLD_ENV_PREFIX` /
+`ESMFOLD_ENV_PREFIX`; an install predating this naming keeps its own paths, because the config it
+wrote outranks these defaults.
+
 A `<site>.json` carries every variable and templates paths off `$VAR` references, resolved
 recursively (`$VAR` against the environment first, then other keys in the same file). The site's
 `<site>.sh` discovers only the one login-specific atom the templates need — the allocation, the

--- a/README.md
+++ b/README.md
@@ -117,12 +117,15 @@ exactly what you care about and nothing else:
 | 2 | `~/.config/vizfold/vizfold.json` | written by the install; edit to make a choice stick |
 | 3 | `backends/openfold/install/sites/<site>.json` | the site's defaults, in the repo — edit to change them for everyone |
 
-Every environment the install creates is named `vizfold-<backend>` — `vizfold-openfold` and
-`vizfold-workbench` as conda envs under `<prefix>/mamba/envs`, `vizfold-esmfold` as a venv beside
-them. `lib/config.sh`'s `vizfold::env` and `conda_env()` in `cli/src/core/config.rs` are the two
-definitions. Override any of them with `OPENFOLD_ENV_NAME` / `OPENFOLD_ENV_PREFIX` /
-`ESMFOLD_ENV_PREFIX`; an install predating this naming keeps its own paths, because the config it
-wrote outranks these defaults.
+Every environment the install creates lives in one base directory under a fixed name:
+`$VIZFOLD_ENV_BASE/vizfold-<backend>`, defaulting to `<prefix>/envs`. That is
+`vizfold-openfold` and `vizfold-workbench` (conda) and `vizfold-esmfold` (a venv) — same directory,
+same shape, so nothing has to be told where any of them is. `vizfold::env` in `lib/config.sh` and
+`env_dir()` in `cli/src/core/config.rs` are the two definitions, and each names the other.
+
+Move them all with `VIZFOLD_ENV_BASE`. An install predating the env base keeps working untouched:
+it recorded absolute `OPENFOLD_ENV_PREFIX`/`ESMFOLD_ENV_PREFIX` values, and those still outrank the
+derived paths.
 
 A `<site>.json` carries every variable and templates paths off `$VAR` references, resolved
 recursively (`$VAR` against the environment first, then other keys in the same file). The site's

--- a/backends/esmfold/install/install.sh
+++ b/backends/esmfold/install/install.sh
@@ -17,7 +17,7 @@ log() { echo "== $* (+$((SECONDS))s)"; }
 REPO=${OPENFOLD_HOME:-$REPO}
 ESM=$REPO/backends/esmfold
 PREFIX=${OPENFOLD_PREFIX:-$HOME/openfold}
-ENV=${ESMFOLD_ENV_PREFIX:-$PREFIX/$(vizfold::env esmfold)}
+ENV=${ESMFOLD_ENV_PREFIX:-$(vizfold::env esmfold)}
 test -f "$ESM/pyproject.toml" || die "no esmfold project at $ESM; is $REPO a vizfold checkout?"
 command -v python3 >/dev/null || die "python3 is required to create the ESMFold venv"
 

--- a/backends/esmfold/install/install.sh
+++ b/backends/esmfold/install/install.sh
@@ -17,7 +17,7 @@ log() { echo "== $* (+$((SECONDS))s)"; }
 REPO=${OPENFOLD_HOME:-$REPO}
 ESM=$REPO/backends/esmfold
 PREFIX=${OPENFOLD_PREFIX:-$HOME/openfold}
-ENV=${ESMFOLD_ENV_PREFIX:-$PREFIX/esmfold-venv}
+ENV=${ESMFOLD_ENV_PREFIX:-$PREFIX/$(vizfold::env esmfold)}
 test -f "$ESM/pyproject.toml" || die "no esmfold project at $ESM; is $REPO a vizfold checkout?"
 command -v python3 >/dev/null || die "python3 is required to create the ESMFold venv"
 

--- a/backends/openfold/environment-aarch64.yml
+++ b/backends/openfold/environment-aarch64.yml
@@ -5,7 +5,7 @@
 #   py3.13     the aarch64 flash-attn/openmm/pytorch generation is py3.13, not the x86 py3.11
 #   cuda<=12.9 setup.sh caps it (aarch64 MAX_CUDA=12.9); the 13.x pytorch build won't compile OpenFold's CUDA extension
 #   gcc<15     gcc 15's -Wtemplate-body strictness rejects torch's ATen headers (List_inl.h needs 'typename')
-name: openfold-env
+name: vizfold-openfold
 channels:
   - conda-forge
   - bioconda

--- a/backends/openfold/environment.yml
+++ b/backends/openfold/environment.yml
@@ -22,9 +22,9 @@
 # if `nvidia-smi` reports a lower version than the solver picks. Note that
 # `env create` takes no extra specs, so this needs plain `create`:
 #
-#   mamba create -n openfold-env -f environment.yml 'cuda-version<=12.8'
+#   mamba create -n vizfold-openfold -f environment.yml 'cuda-version<=12.8'
 
-name: openfold-env
+name: vizfold-openfold
 channels:
   - conda-forge
   - bioconda

--- a/backends/openfold/install/setup.sh
+++ b/backends/openfold/install/setup.sh
@@ -19,14 +19,13 @@ step()   { log "$1"; sealed "$1" && { echo "  cached"; return; }; "$2"; seal "$1
 setup::config() {
     PREFIX=${OPENFOLD_PREFIX:-$HOME/openfold}
     AF2=${OPENFOLD_AF2_ROOT:-}                       # set by a site with a database mirror
-    ENV_NAME=${OPENFOLD_ENV_NAME:-$(vizfold::env openfold)}
     # aarch64 (Grace-Hopper) needs its own env: py3.13, GH200-only sm_90, cuda<=12.9 -- the 13.x aarch64 pytorch build won't compile OpenFold's extension.
     case $(uname -m) in
         aarch64|arm64) ENV_YML=$OF/environment-aarch64.yml; ARCH_DEFAULT=9.0; MAX_CUDA=${OPENFOLD_MAX_CUDA:-12.9} ;;
         *)             ENV_YML=$OF/environment.yml; ARCH_DEFAULT="7.0;8.0;8.6;9.0"; MAX_CUDA=${OPENFOLD_MAX_CUDA:-12.8} ;;
     esac
     DATA=$PREFIX/data
-    ENV_DIR=$PREFIX/mamba/envs/$ENV_NAME
+    ENV_DIR=${OPENFOLD_ENV_PREFIX:-$(vizfold::env openfold)}
     MM=$PREFIX/bin/micromamba
     CUTLASS=$PREFIX/cutlass
     UNICLUST=$DATA/uniclust30/uniclust30_2018_08
@@ -49,7 +48,7 @@ setup::preflight() {
     mkdir -p "$PREFIX/bin" "$TMPDIR" "$DATA" "$OF/openfold/resources"
     hostname
     nvidia-smi --query-gpu=name,compute_cap --format=csv,noheader 2>/dev/null || echo "no GPU on this node"
-    echo "prefix=$PREFIX repo=$REPO env=$ENV_NAME max_cuda=$MAX_CUDA mirror=$MIRROR${AF2:+ ($AF2)}"
+    echo "prefix=$PREFIX repo=$REPO env=$ENV_DIR max_cuda=$MAX_CUDA mirror=$MIRROR${AF2:+ ($AF2)}"
     test -f "$OF/setup.py" || die "$REPO is not an OpenFold checkout"
 }
 
@@ -225,11 +224,11 @@ setup::fold_vars() {
 # Record resolved values, not the caller's -- a consumer shouldn't know our fallbacks.
 setup::config_save() {
     log config
-    export OPENFOLD_HOME=$REPO OPENFOLD_PREFIX=$PREFIX OPENFOLD_ENV_NAME=$ENV_NAME
+    export OPENFOLD_HOME=$REPO OPENFOLD_PREFIX=$PREFIX VIZFOLD_ENV_BASE=$(vizfold::env_base)
     export OPENFOLD_ENV_PREFIX=$CONDA_PREFIX OPENFOLD_DATA_DIR=$DATA OPENFOLD_MAX_CUDA=$MAX_CUDA
     export OPENFOLD_GPU_RESOURCES=$GPU_RES OPENFOLD_EXAMPLE=$EXAMPLE OPENFOLD_GPU_GRES=$GPU_GRES
     export VIZFOLD_DB=$PREFIX/vizfold.db
-    config::save OPENFOLD_HOME OPENFOLD_PREFIX OPENFOLD_ENV_NAME OPENFOLD_ENV_PREFIX \
+    config::save OPENFOLD_HOME OPENFOLD_PREFIX VIZFOLD_ENV_BASE OPENFOLD_ENV_PREFIX \
         OPENFOLD_DATA_DIR OPENFOLD_SITE OPENFOLD_AF2_ROOT OPENFOLD_MAX_CUDA \
         OPENFOLD_DRIVER_CUDA OPENFOLD_GPU_ACCOUNT OPENFOLD_GPU_PARTITION \
         OPENFOLD_GPU_RESOURCES OPENFOLD_GPU_GRES OPENFOLD_GPU_TIME \

--- a/backends/openfold/install/setup.sh
+++ b/backends/openfold/install/setup.sh
@@ -19,7 +19,7 @@ step()   { log "$1"; sealed "$1" && { echo "  cached"; return; }; "$2"; seal "$1
 setup::config() {
     PREFIX=${OPENFOLD_PREFIX:-$HOME/openfold}
     AF2=${OPENFOLD_AF2_ROOT:-}                       # set by a site with a database mirror
-    ENV_NAME=${OPENFOLD_ENV_NAME:-openfold-env}
+    ENV_NAME=${OPENFOLD_ENV_NAME:-$(vizfold::env openfold)}
     # aarch64 (Grace-Hopper) needs its own env: py3.13, GH200-only sm_90, cuda<=12.9 -- the 13.x aarch64 pytorch build won't compile OpenFold's extension.
     case $(uname -m) in
         aarch64|arm64) ENV_YML=$OF/environment-aarch64.yml; ARCH_DEFAULT=9.0; MAX_CUDA=${OPENFOLD_MAX_CUDA:-12.9} ;;

--- a/cli/src/adapters/cli.rs
+++ b/cli/src/adapters/cli.rs
@@ -626,7 +626,8 @@ fn install_paths(prefix: &Path, home: &Path) -> Vec<PathBuf> {
         ".done",
         "params",
         "workbench",
-        "esmfold-venv",
+        "vizfold-esmfold",
+        "esmfold-venv", // pre-rename installs; uninstall must still find one
         "vizfold.db",
     ]
     .iter()
@@ -814,7 +815,7 @@ fn system_node_bin() -> Option<PathBuf> {
 /// own -- clusters ship none (Delta has no `node`, `npm`, or nodejs module). Kept out of every
 /// backend env so the dashboard works before a backend is installed. Returns the bin dir for PATH.
 fn ensure_node() -> Result<PathBuf, DbErr> {
-    let env_dir = config::prefix().join("mamba/envs/vizfold-web");
+    let env_dir = config::conda_env("workbench");
     let bin = env_dir.join("bin");
     if bin.join("node").is_file() {
         return Ok(bin);
@@ -1761,6 +1762,7 @@ mod tests {
             prefix.join("data"),
             prefix.join(".done"),
             prefix.join("nvrtc-12.2"),
+            prefix.join("vizfold-esmfold"),
             prefix.join("esmfold-venv"),
             base.join(".openfold-pkgs"),
             home.join("openfold/resources/params"),

--- a/cli/src/adapters/cli.rs
+++ b/cli/src/adapters/cli.rs
@@ -626,8 +626,10 @@ fn install_paths(prefix: &Path, home: &Path) -> Vec<PathBuf> {
         ".done",
         "params",
         "workbench",
+        "envs",
+        // Layouts predating the env base; uninstall must still find their environments.
         "vizfold-esmfold",
-        "esmfold-venv", // pre-rename installs; uninstall must still find one
+        "esmfold-venv",
         "vizfold.db",
     ]
     .iter()
@@ -815,7 +817,7 @@ fn system_node_bin() -> Option<PathBuf> {
 /// own -- clusters ship none (Delta has no `node`, `npm`, or nodejs module). Kept out of every
 /// backend env so the dashboard works before a backend is installed. Returns the bin dir for PATH.
 fn ensure_node() -> Result<PathBuf, DbErr> {
-    let env_dir = config::conda_env("workbench");
+    let env_dir = config::env_dir("workbench");
     let bin = env_dir.join("bin");
     if bin.join("node").is_file() {
         return Ok(bin);
@@ -1762,6 +1764,7 @@ mod tests {
             prefix.join("data"),
             prefix.join(".done"),
             prefix.join("nvrtc-12.2"),
+            prefix.join("envs"),
             prefix.join("vizfold-esmfold"),
             prefix.join("esmfold-venv"),
             base.join(".openfold-pkgs"),

--- a/cli/src/core/config.rs
+++ b/cli/src/core/config.rs
@@ -80,25 +80,33 @@ pub fn data_dir() -> PathBuf {
         .unwrap_or_else(|| openfold_home().join("data"))
 }
 
-/// Every environment the install creates is named `vizfold-<backend>`. Mirrors `vizfold::env` in
-/// `lib/config.sh`; a conda env lives under `<prefix>/mamba/envs`, a venv beside it.
-pub fn conda_env(name: &str) -> PathBuf {
-    prefix().join("mamba/envs").join(format!("vizfold-{name}"))
+/// The one directory holding every environment the install creates. Mirrors `vizfold::env_base`
+/// in `lib/config.sh`.
+pub fn env_base() -> PathBuf {
+    resolved("VIZFOLD_ENV_BASE")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| prefix().join("envs"))
 }
 
-/// micromamba env prefix for local OpenFold execution (matches fold.sh's `$OPENFOLD_ENV_PREFIX`).
+/// `<env base>/vizfold-<backend>` — a fixed name per backend, conda env and venv alike, so nothing
+/// has to be told where any of them is.
+pub fn env_dir(name: &str) -> PathBuf {
+    env_base().join(format!("vizfold-{name}"))
+}
+
+/// micromamba env prefix for local OpenFold execution. `OPENFOLD_ENV_PREFIX` is honoured because
+/// installs predating the env base recorded one; fresh installs derive it.
 pub fn openfold_env_prefix() -> PathBuf {
     resolved("OPENFOLD_ENV_PREFIX")
         .map(PathBuf::from)
-        .unwrap_or_else(|| conda_env("openfold"))
+        .unwrap_or_else(|| env_dir("openfold"))
 }
 
-/// venv prefix for the ESMFold backend (matches `backends/esmfold/install/install.sh`'s
-/// `$ESMFOLD_ENV_PREFIX`). A venv, so it sits beside the conda envs rather than under them.
+/// venv prefix for the ESMFold backend, same story as `openfold_env_prefix`.
 pub fn esmfold_env_prefix() -> PathBuf {
     resolved("ESMFOLD_ENV_PREFIX")
         .map(PathBuf::from)
-        .unwrap_or_else(|| prefix().join("vizfold-esmfold"))
+        .unwrap_or_else(|| env_dir("esmfold"))
 }
 
 /// The install-resolved config map as sorted (key, value) string pairs, for `vizfold status`.
@@ -237,7 +245,20 @@ fn repository_root() -> PathBuf {
 
 #[cfg(test)]
 mod tests {
-    use super::{SlurmContext, gpu_launch};
+    use super::{SlurmContext, env_base, env_dir, gpu_launch};
+
+    /// Every environment is `<base>/vizfold-<backend>` — one directory, a fixed name each. Keeps
+    /// the Rust side in step with `vizfold::env` in lib/config.sh.
+    #[test]
+    fn every_env_is_a_fixed_name_under_one_base() {
+        for backend in ["openfold", "esmfold", "workbench"] {
+            assert_eq!(
+                env_dir(backend),
+                env_base().join(format!("vizfold-{backend}"))
+            );
+        }
+        assert_eq!(env_base().file_name().unwrap(), "envs");
+    }
 
     // (name, context, partition, account, gres, resources, time, expected args)
     #[test]

--- a/cli/src/core/config.rs
+++ b/cli/src/core/config.rs
@@ -80,20 +80,25 @@ pub fn data_dir() -> PathBuf {
         .unwrap_or_else(|| openfold_home().join("data"))
 }
 
-/// micromamba env prefix for local OpenFold execution (matches fold.sh's
-/// `${OPENFOLD_ENV_PREFIX:-$PREFIX/mamba/envs/openfold-env}`).
+/// Every environment the install creates is named `vizfold-<backend>`. Mirrors `vizfold::env` in
+/// `lib/config.sh`; a conda env lives under `<prefix>/mamba/envs`, a venv beside it.
+pub fn conda_env(name: &str) -> PathBuf {
+    prefix().join("mamba/envs").join(format!("vizfold-{name}"))
+}
+
+/// micromamba env prefix for local OpenFold execution (matches fold.sh's `$OPENFOLD_ENV_PREFIX`).
 pub fn openfold_env_prefix() -> PathBuf {
     resolved("OPENFOLD_ENV_PREFIX")
         .map(PathBuf::from)
-        .unwrap_or_else(|| prefix().join("mamba/envs/openfold-env"))
+        .unwrap_or_else(|| conda_env("openfold"))
 }
 
 /// venv prefix for the ESMFold backend (matches `backends/esmfold/install/install.sh`'s
-/// `${ESMFOLD_ENV_PREFIX:-$PREFIX/esmfold-venv}`).
+/// `$ESMFOLD_ENV_PREFIX`). A venv, so it sits beside the conda envs rather than under them.
 pub fn esmfold_env_prefix() -> PathBuf {
     resolved("ESMFOLD_ENV_PREFIX")
         .map(PathBuf::from)
-        .unwrap_or_else(|| prefix().join("esmfold-venv"))
+        .unwrap_or_else(|| prefix().join("vizfold-esmfold"))
 }
 
 /// The install-resolved config map as sorted (key, value) string pairs, for `vizfold status`.

--- a/cli/src/core/services/openfold_execution.rs
+++ b/cli/src/core/services/openfold_execution.rs
@@ -388,14 +388,14 @@ mod tests {
         let wrapped = activate_env_command(
             &command,
             &PathBuf::from("/work/of"),
-            &PathBuf::from("/work/of/mamba/envs/openfold-env"),
+            &PathBuf::from("/work/of/mamba/envs/vizfold-openfold"),
         );
 
         assert_eq!(wrapped.program, "bash");
         assert_eq!(wrapped.args[0], "-c");
         let script = &wrapped.args[1];
         assert!(script.contains("'/work/of/bin/micromamba' shell hook -s bash"));
-        assert!(script.contains("micromamba activate '/work/of/mamba/envs/openfold-env'"));
+        assert!(script.contains("micromamba activate '/work/of/mamba/envs/vizfold-openfold'"));
         assert!(script.contains("activate.d/openfold.sh"));
         assert!(script.contains("TRITON_CACHE_DIR"));
         assert!(script.trim_end().ends_with("exec \"$@\""));
@@ -424,7 +424,7 @@ mod tests {
         let composed = compose_exec_command(
             &command,
             &PathBuf::from("/work/of"),
-            &PathBuf::from("/work/of/mamba/envs/openfold-env"),
+            &PathBuf::from("/work/of/mamba/envs/vizfold-openfold"),
             &["srun".to_owned(), "-p".to_owned(), "gpu".to_owned()],
             true,
         );

--- a/cli/src/core/services/openfold_execution.rs
+++ b/cli/src/core/services/openfold_execution.rs
@@ -388,14 +388,14 @@ mod tests {
         let wrapped = activate_env_command(
             &command,
             &PathBuf::from("/work/of"),
-            &PathBuf::from("/work/of/mamba/envs/vizfold-openfold"),
+            &PathBuf::from("/work/of/envs/vizfold-openfold"),
         );
 
         assert_eq!(wrapped.program, "bash");
         assert_eq!(wrapped.args[0], "-c");
         let script = &wrapped.args[1];
         assert!(script.contains("'/work/of/bin/micromamba' shell hook -s bash"));
-        assert!(script.contains("micromamba activate '/work/of/mamba/envs/vizfold-openfold'"));
+        assert!(script.contains("micromamba activate '/work/of/envs/vizfold-openfold'"));
         assert!(script.contains("activate.d/openfold.sh"));
         assert!(script.contains("TRITON_CACHE_DIR"));
         assert!(script.trim_end().ends_with("exec \"$@\""));
@@ -424,7 +424,7 @@ mod tests {
         let composed = compose_exec_command(
             &command,
             &PathBuf::from("/work/of"),
-            &PathBuf::from("/work/of/mamba/envs/vizfold-openfold"),
+            &PathBuf::from("/work/of/envs/vizfold-openfold"),
             &["srun".to_owned(), "-p".to_owned(), "gpu".to_owned()],
             true,
         );

--- a/cli/src/core/services/runs.rs
+++ b/cli/src/core/services/runs.rs
@@ -318,7 +318,7 @@ mod tests {
             r#"{"output_location":"/work/runs"}"#,
             Path::new("/opt/openfold"),
             Path::new("/opt/prefix"),
-            Path::new("/opt/prefix/mamba/envs/vizfold-openfold"),
+            Path::new("/opt/prefix/envs/vizfold-openfold"),
         );
         let value: serde_json::Value = serde_json::from_str(&snapshot).expect("valid json");
 
@@ -331,7 +331,7 @@ mod tests {
         assert_eq!(value["resolved"]["prefix"], "/opt/prefix");
         assert_eq!(
             value["resolved"]["env_prefix"],
-            "/opt/prefix/mamba/envs/vizfold-openfold"
+            "/opt/prefix/envs/vizfold-openfold"
         );
     }
 }

--- a/cli/src/core/services/runs.rs
+++ b/cli/src/core/services/runs.rs
@@ -318,7 +318,7 @@ mod tests {
             r#"{"output_location":"/work/runs"}"#,
             Path::new("/opt/openfold"),
             Path::new("/opt/prefix"),
-            Path::new("/opt/prefix/mamba/envs/openfold-env"),
+            Path::new("/opt/prefix/mamba/envs/vizfold-openfold"),
         );
         let value: serde_json::Value = serde_json::from_str(&snapshot).expect("valid json");
 
@@ -331,7 +331,7 @@ mod tests {
         assert_eq!(value["resolved"]["prefix"], "/opt/prefix");
         assert_eq!(
             value["resolved"]["env_prefix"],
-            "/opt/prefix/mamba/envs/openfold-env"
+            "/opt/prefix/mamba/envs/vizfold-openfold"
         );
     }
 }

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -13,6 +13,11 @@ REPO=${OPENFOLD_HOME:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}
 OF=${OPENFOLD_DIR:-$REPO/backends/openfold}
 die() { echo "FATAL: $*" >&2; exit 1; }
 
+# Every environment the install creates is named vizfold-<backend>: conda envs under
+# <prefix>/mamba/envs, the ESMFold venv beside them, the workbench's node env. Defined once here so
+# the installers and fold.sh cannot drift apart. Mirrored by conda_env() in cli/src/core/config.rs.
+vizfold::env() { echo "vizfold-$1"; }
+
 config::file() {
     echo "${VIZFOLD_CONFIG:-${XDG_CONFIG_HOME:-$HOME/.config}/vizfold/vizfold.json}"
 }

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -13,10 +13,11 @@ REPO=${OPENFOLD_HOME:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}
 OF=${OPENFOLD_DIR:-$REPO/backends/openfold}
 die() { echo "FATAL: $*" >&2; exit 1; }
 
-# Every environment the install creates is named vizfold-<backend>: conda envs under
-# <prefix>/mamba/envs, the ESMFold venv beside them, the workbench's node env. Defined once here so
-# the installers and fold.sh cannot drift apart. Mirrored by conda_env() in cli/src/core/config.rs.
-vizfold::env() { echo "vizfold-$1"; }
+# Every environment the install creates lives in one base directory under a fixed vizfold-<backend>
+# name -- conda envs and the ESMFold venv alike, so one directory holds them all and nothing has to
+# be told where any of them is. Mirrored by env_base()/env_dir() in cli/src/core/config.rs.
+vizfold::env_base() { echo "${VIZFOLD_ENV_BASE:-${OPENFOLD_PREFIX:-$HOME/openfold}/envs}"; }
+vizfold::env() { echo "$(vizfold::env_base)/vizfold-$1"; }
 
 config::file() {
     echo "${VIZFOLD_CONFIG:-${XDG_CONFIG_HOME:-$HOME/.config}/vizfold/vizfold.json}"

--- a/scripts/openfold/fold.sh
+++ b/scripts/openfold/fold.sh
@@ -11,13 +11,13 @@ LIB=${OPENFOLD_HOME:+$OPENFOLD_HOME/lib}
 
 fold::config() {
     PREFIX=${OPENFOLD_PREFIX:-$HOME/openfold}
-    ENV_NAME=${OPENFOLD_ENV_NAME:-$(vizfold::env openfold)}
+    ENV_DIR=${OPENFOLD_ENV_PREFIX:-$(vizfold::env openfold)}
 }
 
 # torch/DeepSpeed JIT-compile at import; a site's leaked toolchain env breaks it. Re-exec in a curated env (HOME, clean PATH, SLURM/CUDA binding, OPENFOLD_*).
 fold::reexec() {
     [ -n "${OPENFOLD_CLEAN_ENV:-}" ] && return
-    local env_prefix=${OPENFOLD_ENV_PREFIX:-$PREFIX/mamba/envs/$ENV_NAME} clean kv
+    local env_prefix=$ENV_DIR clean kv
     clean=(HOME="$HOME" PATH="$env_prefix/bin:/usr/bin:/bin" OPENFOLD_CLEAN_ENV=1)
     [ -n "${TMPDIR:-}" ] && clean+=("TMPDIR=$TMPDIR")
     # JIT autotune cache: node-local, not NFS $HOME (79 s vs 8 s inference).
@@ -41,7 +41,8 @@ fold::activate() {
     local mm=$PREFIX/bin/micromamba
     [ -x "$mm" ] || die "nothing installed at $PREFIX; run install.sh first"
     export MAMBA_ROOT_PREFIX=$PREFIX/mamba
-    mamba::activate "$mm" "$ENV_NAME"
+    # By path, not name: the env lives under VIZFOLD_ENV_BASE, not $MAMBA_ROOT_PREFIX/envs.
+    mamba::activate "$mm" "$ENV_DIR"
 }
 
 fold::preflight() {

--- a/scripts/openfold/fold.sh
+++ b/scripts/openfold/fold.sh
@@ -11,7 +11,7 @@ LIB=${OPENFOLD_HOME:+$OPENFOLD_HOME/lib}
 
 fold::config() {
     PREFIX=${OPENFOLD_PREFIX:-$HOME/openfold}
-    ENV_NAME=${OPENFOLD_ENV_NAME:-openfold-env}
+    ENV_NAME=${OPENFOLD_ENV_NAME:-$(vizfold::env openfold)}
 }
 
 # torch/DeepSpeed JIT-compile at import; a site's leaked toolchain env breaks it. Re-exec in a curated env (HOME, clean PATH, SLURM/CUDA binding, OPENFOLD_*).


### PR DESCRIPTION
The three environments the install and `serve` create were named three different ways and lived in two different places: `openfold-env` under `mamba/envs`, `esmfold-venv` at the prefix root, and `vizfold-web` back under `mamba/envs`. Nothing derived any of them from anything else.

## Now

```
$VIZFOLD_ENV_BASE/vizfold-<backend>          default: <prefix>/envs
  ├── vizfold-openfold     (conda)
  ├── vizfold-esmfold      (venv)
  └── vizfold-workbench    (conda, node for the dashboard)
```

One directory, one fixed name each, conda env and venv alike — so nothing has to be told where any of them is.

**The openfold default used to be written out three times** — `setup.sh`, `fold.sh`, and `config.rs` — which is what let the naming drift to begin with. All four bash entry points already source `lib/config.sh`, so those collapse into `vizfold::env` there; `env_dir()` in `cli/src/core/config.rs` is the one remaining counterpart, and each comment names the other. Renaming without that would have rebuilt the same trap.

**`OPENFOLD_ENV_NAME` is gone.** A name that is always `vizfold-<backend>` is not a setting. `VIZFOLD_ENV_BASE` moves all of them at once.

**`fold.sh` activated the env by name**, which only worked while it sat under `$MAMBA_ROOT_PREFIX/envs`. It activates by path now — micromamba takes either, and the base is deliberately no longer inside the mamba root.

## Existing installs keep working

`OPENFOLD_ENV_PREFIX`/`ESMFOLD_ENV_PREFIX` are still read: an install predating this recorded absolute paths there, and those have to keep resolving to the environments that actually exist. Verified against a config pinning the old layout — still reports `installed` at `mamba/envs/openfold-env`. `uninstall` also lists `envs/` plus both older layouts, so upgrading does not strand an environment it can no longer name.

| Case | openfold resolves to |
| --- | --- |
| Fresh install | `<prefix>/envs/vizfold-openfold` |
| `VIZFOLD_ENV_BASE=/shared/envs` | `/shared/envs/vizfold-openfold` |
| Pre-existing config | `<prefix>/mamba/envs/openfold-env` (unchanged, still `installed`) |

Bash and Rust were checked to resolve byte-identical paths in all three cases.

## Test plan

- `cargo test` — 120 pass (new: every env is `<base>/vizfold-<backend>`, pinning the Rust side to `vizfold::env`); `clippy --all-targets` and `fmt --check` clean
- Every tracked `.sh` parses; `vizfold::env` resolution and `VIZFOLD_ENV_BASE` override exercised directly
- `vizfold status` compared against the bash helper for fresh, overridden, and legacy configs

Not exercised by a real cluster install — the paths are verified, the install that builds into them is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AdhiyVf49e86fLAA8pisFu