### PR TITLE
Bump version to 0.3.0

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "executor"
-version = "0.2.3"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "executor"
-version = "0.2.3"
+version = "0.3.0"
 edition = "2024"
 default-run = "vizfold"
 


### PR DESCRIPTION
Cuts 0.3.0. Everything merged since v0.2.3:

- **Fold from the dashboard** (#108) — `POST /api/runs` + a Fold card; `vizfold` stays the only writer to the executor database.
- **`serve` provisions its own Node** (#108) — clusters ship none, and the workbench needs ≥22.13 for `node:sqlite`.
- **`execute-run <example>`** (#108) — folding an example *is* executing a run, so it is one verb, and it registers artifacts on the way out. Plus `list examples`.
- **Nexus AF2 mirror** (#108) — `OPENFOLD_AF2_ROOT` on the staging volume.
- **One env base directory** (#109) — `$VIZFOLD_ENV_BASE/vizfold-<backend>`, defaulting to `<prefix>/envs`.

This release is what actually delivers the bash-side work. `install.sh` clones the install scripts at the binary's own version tag, so the `setup.sh`, `fold.sh`, and `lib/config.sh` changes reach users only once this is tagged.

Verified on NCSA Delta A100 hardware before merge: folds from the CLI, from the dashboard, and inside a batch allocation; `serve` cold start provisioning Node from scratch; the 3D viewer over an SSH tunnel.

`cargo test` 120 pass, `clippy` and `fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AdhiyVf49e86fLAA8pisFu