### PR TITLE
Bump version to 0.4.0

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "executor"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "executor"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 default-run = "vizfold"
 


### PR DESCRIPTION
Cuts a release for #111.

Minor rather than patch: the install config changed shape on disk. It now carries a fixed 18-key schema (`VIZFOLD_CONFIG_KEYS`), writing `""` for whatever an install did not settle, where before it omitted those names. A 0.4.0 binary reads an older config unchanged, but a 0.3.0 binary reading a 0.4.0-written config would take `Some("")` for `ESMFOLD_ENV_PREFIX` — it lacks the `non_empty` filter added in #111.

A release is also what delivers the installer changes at all: `clone_checkout` pins the checkout to `v{CARGO_PKG_VERSION}` (`cli/src/adapters/cli.rs:542`), so the trimmed `sites/*.json`, `slurm::default_prefix`, the account derivation in `slurm::nvme_alloc`, and the `config::save` schema only reach users once a tag exists.