### PR TITLE
Detect the cluster without the Slurm controller, and use one vocabulary for config names

### DIFF
--- a/.github/workflows/install_tests.yml
+++ b/.github/workflows/install_tests.yml
@@ -10,3 +10,4 @@ jobs:
       - uses: actions/checkout@v7
       - run: bash install/tests/launch_args.sh
       - run: bash install/tests/site_config.sh
+      - run: bash install/tests/vocabulary.sh

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Lists everything the install generated — the conda environment (and any ESMFol
 rest of the install prefix, the package caches beside it, the symlinks and build droppings it left in the checkout,
 the run database, the checkout it cloned into `$HOME/vizfold-src`, and
 `~/.config/vizfold/vizfold.json` — then removes it once you confirm (`--yes` skips the prompt).
-Fold outputs under the prefix, a checkout you pointed it at yourself, and the `vizfold` binary
+Fold outputs under the prefix, a checkout you pointed it at yourself with `OPENFOLD_HOME`, and the `vizfold` binary
 are left alone; drop the binary with `rm ~/.local/bin/vizfold`.
 
 ### Supported clusters

--- a/README.md
+++ b/README.md
@@ -183,7 +183,15 @@ ended up instead of guessing.
 
 That file has a fixed shape. The same binary reads it on every cluster, so it holds the same keys
 on every cluster: the schema is `VIZFOLD_CONFIG_KEYS` in `lib/config.sh`, and a name the install
-did not settle is written empty rather than left out. Empty means unset everywhere that reads it —
+did not settle is written empty rather than left out.
+
+A name belongs in the schema when the install **settles** it and something **later** needs it —
+those two conditions, and no others. So the build partition is in it (the install chose one) while
+`OPENFOLD_BUILD_MEM` is not (a re-install re-reads the same `<site>.json`); the fold's output
+directory is not (it belongs to one run, not to the install); and `VIZFOLD_CONFIG`, which selects
+*which* config to read, cannot be. Nothing the binary resolves may sit outside the schema, and
+nothing a `<site>.json` sets may go unconsumed — `install/tests/vocabulary.sh` enforces both, and
+that every `$VAR` in a site value is provided by something rather than expanding to empty. Empty means unset everywhere that reads it —
 `${VAR:-default}` in bash, `non_empty` in `cli/src/core/config.rs` — so an unsettled key falls
 through to the same default a missing one would, and never masks a `<site>.json` value beneath it.
 Both backends save the whole schema, so installing one after the other rewrites the shared keys
@@ -291,8 +299,8 @@ see [DEMO.md](DEMO.md).
 
 #### Database
 
-The executor uses SQLite. `config::database_url()` resolves the file in order: `DATABASE_URL`,
-then `VIZFOLD_DB` (env or install config), then `<OPENFOLD_PREFIX>/vizfold.db`, then
+The executor uses SQLite. `config::database_url()` resolves the file in order: `VIZFOLD_DB`
+(env or install config, and it takes a full `sqlite:` URL), then `<OPENFOLD_PREFIX>/vizfold.db`, then
 `$XDG_DATA_HOME/vizfold/vizfold.db` (`~/.local/share/vizfold/vizfold.db` by default). Parent
 directories are created automatically. The migration history was collapsed into a single baseline
 on 2026-07-23; an older executor database fails with an actionable error naming the file to

--- a/backends/esmfold/install/install.sh
+++ b/backends/esmfold/install/install.sh
@@ -52,6 +52,7 @@ PY
 esmfold::config_save() {
     log config
     export OPENFOLD_HOME=$REPO OPENFOLD_PREFIX=$PREFIX ESMFOLD_ENV_PREFIX=$ENV
+    export VIZFOLD_ENV_BASE=$(vizfold::env_base)
     export VIZFOLD_DB=${VIZFOLD_DB:-$PREFIX/vizfold.db}
     config::save
 }

--- a/backends/openfold/install/install.sh
+++ b/backends/openfold/install/install.sh
@@ -18,8 +18,8 @@ init::libs() {
 
 init::pick_site() {
     local cluster
-    cluster=$(scontrol show config 2>/dev/null | awk '$1 == "ClusterName" { print $3 }') || true
-    [ -n "${cluster:-}" ] && [ -f "$SITES/$cluster.sh" ] || cluster=local
+    cluster=$(slurm::cluster)
+    [ -n "$cluster" ] && [ -f "$SITES/$cluster.sh" ] || cluster=local
     SITE=$(interactive::resolve OPENFOLD_SITE "site" "$cluster")
     test -f "$SITES/$SITE.sh" ||
         die "no site script for $SITE; have: $(cd "$SITES" && echo *.sh | sed 's/\.sh//g')"

--- a/backends/openfold/install/setup.sh
+++ b/backends/openfold/install/setup.sh
@@ -32,7 +32,7 @@ setup::config() {
     STEREO=$OF/openfold/resources/stereo_chemical_props.txt
     sentinel=$PREFIX/.done
 
-    export CONDA_PKGS_DIRS=${OPENFOLD_PKGS_DIR:-$PREFIX/../.openfold-pkgs}
+    export CONDA_PKGS_DIRS=$PREFIX/../.openfold-pkgs
     export MAMBA_ROOT_PREFIX=$PREFIX/mamba TMPDIR=$PREFIX/tmp
     export PIP_CACHE_DIR=$PREFIX/../.openfold-pip
     export MAX_JOBS="${MAX_JOBS:-${SLURM_CPUS_PER_TASK:-4}}"
@@ -90,7 +90,7 @@ v = ctypes.c_int()
 ctypes.CDLL('libcuda.so.1').cuDriverGetVersion(ctypes.byref(v))
 print(f'{v.value // 1000}.{v.value % 1000 // 10}')" 2>/dev/null)} || true
     # CPU build node can't probe the GPU driver; assume old (12.2 PTX loads on any >=12.2).
-    : "${DRIVER_CUDA:=${OPENFOLD_FALLBACK_CUDA:-12.2}}"
+    : "${DRIVER_CUDA:=12.2}"
     ENV_CUDA=$(ls "$CONDA_PREFIX"/lib/libnvrtc.so.*.*.* 2>/dev/null |
         sed 's/.*so\.//; s/\.[0-9]*$//' | head -1) || true
     export OPENFOLD_DRIVER_CUDA=$DRIVER_CUDA

--- a/backends/openfold/install/sites/delta-gh.json
+++ b/backends/openfold/install/sites/delta-gh.json
@@ -1,6 +1,6 @@
 {
   "OPENFOLD_AF2_ROOT": "/work/hdd/data/alphafold2/database",
-  "OPENFOLD_BASE": "/work/nvme/$ALLOC/$USER",
+  "OPENFOLD_BASE": "/work/nvme/$OPENFOLD_ALLOCATION/$USER",
   "OPENFOLD_BUILD_GRES": "gpu:1",
   "OPENFOLD_GPU_PARTITION": "ghx4-interactive",
   "OPENFOLD_GPU_TIME": "01:00:00",

--- a/backends/openfold/install/sites/delta.json
+++ b/backends/openfold/install/sites/delta.json
@@ -1,6 +1,6 @@
 {
   "OPENFOLD_AF2_ROOT": "/work/hdd/data/alphafold2/database",
-  "OPENFOLD_BASE": "/work/nvme/$ALLOC/$USER",
+  "OPENFOLD_BASE": "/work/nvme/$OPENFOLD_ALLOCATION/$USER",
   "OPENFOLD_GPU_PARTITION": "gpuA100x4-interactive",
   "OPENFOLD_GPU_TIME": "01:00:00",
   "OPENFOLD_PARTITION": "cpu"

--- a/backends/openfold/install/sites/expanse.json
+++ b/backends/openfold/install/sites/expanse.json
@@ -1,5 +1,5 @@
 {
-  "OPENFOLD_BASE": "/expanse/lustre/projects/$ALLOC/$USER",
+  "OPENFOLD_BASE": "/expanse/lustre/projects/$OPENFOLD_ALLOCATION/$USER",
   "OPENFOLD_GPU_GRES": "gpu:v100:1",
   "OPENFOLD_GPU_PARTITION": "gpu-shared",
   "OPENFOLD_PARTITION": "shared"

--- a/backends/openfold/install/sites/expanse.sh
+++ b/backends/openfold/install/sites/expanse.sh
@@ -2,4 +2,4 @@
 
 # SDSC Expanse ("expanse"). No mirror; no default account, so the first association is the atom -- it doubles as the slurm account and as the /expanse project dir expanse.json templates.
 
-slurm::discover() { ALLOC=$(interactive::resolve OPENFOLD_ALLOCATION allocation "${ALLOC:-$(sacctmgr -nP show assoc user="$USER" format=Account 2>/dev/null | grep . | head -1)}"); [ -n "$ALLOC" ] || die "no usable allocation; set OPENFOLD_ALLOCATION"; export ALLOC OPENFOLD_ACCOUNT=${OPENFOLD_ACCOUNT:-$ALLOC}; }
+slurm::discover() { OPENFOLD_ALLOCATION=$(interactive::resolve OPENFOLD_ALLOCATION allocation "${OPENFOLD_ALLOCATION:-$(sacctmgr -nP show assoc user="$USER" format=Account 2>/dev/null | grep . | head -1)}"); [ -n "$OPENFOLD_ALLOCATION" ] || die "no usable allocation; set OPENFOLD_ALLOCATION"; export OPENFOLD_ALLOCATION OPENFOLD_ACCOUNT=${OPENFOLD_ACCOUNT:-$OPENFOLD_ALLOCATION}; }

--- a/backends/openfold/install/slurm.sh
+++ b/backends/openfold/install/slurm.sh
@@ -10,7 +10,7 @@ LIB=${OPENFOLD_HOME:+$OPENFOLD_HOME/lib}
 . "$(dirname "${BASH_SOURCE[0]}")/interactive.sh"
 
 # A site overrides this to export the account-specific vars its <site>.json templates reference
-# ($ALLOC, OPENFOLD_ACCOUNT, OPENFOLD_SCRATCH, ...). No-op by default; runs before <site>.json is filled.
+# (OPENFOLD_ALLOCATION, OPENFOLD_ACCOUNT, OPENFOLD_BASE). No-op by default; runs before <site>.json is filled.
 slurm::discover() { :; }
 
 # Delta-family: pick an allocation under $1 whose accounts (suffixes $2..) all exist, preferring one that holds an install.
@@ -31,16 +31,16 @@ slurm::allocation() {
     echo "${found[0]}"
 }
 
-# Resolve, prompt for, and memoize (in ALLOC) the /work/nvme allocation whose accounts (suffixes $@)
+# Resolve, prompt for, and memoize (in OPENFOLD_ALLOCATION) the /work/nvme allocation whose accounts (suffixes $@)
 # all exist -- and name those accounts here, off the same suffixes, so they cannot drift from them.
 slurm::nvme_alloc() {
-    if [ -z "${ALLOC:-}" ]; then
-        ALLOC=$(interactive::resolve OPENFOLD_ALLOCATION allocation "$(slurm::allocation /work/nvme "$@" || true)")
-        [ -n "$ALLOC" ] || die "no usable allocation: need /work/nvme space and an <alloc> with account suffix(es): $*"
+    if [ -z "${OPENFOLD_ALLOCATION:-}" ]; then
+        OPENFOLD_ALLOCATION=$(interactive::resolve OPENFOLD_ALLOCATION allocation "$(slurm::allocation /work/nvme "$@" || true)")
+        [ -n "$OPENFOLD_ALLOCATION" ] || die "no usable allocation: need /work/nvme space and an <alloc> with account suffix(es): $*"
     fi
-    export ALLOC
-    export OPENFOLD_ACCOUNT=${OPENFOLD_ACCOUNT:-$ALLOC$1}
-    [ -n "${2:-}" ] && export OPENFOLD_GPU_ACCOUNT=${OPENFOLD_GPU_ACCOUNT:-$ALLOC$2}
+    export OPENFOLD_ALLOCATION
+    export OPENFOLD_ACCOUNT=${OPENFOLD_ACCOUNT:-$OPENFOLD_ALLOCATION$1}
+    [ -n "${2:-}" ] && export OPENFOLD_GPU_ACCOUNT=${OPENFOLD_GPU_ACCOUNT:-$OPENFOLD_ALLOCATION$2}
     return 0
 }
 
@@ -99,7 +99,7 @@ slurm::run() {
     [ -n "$PREFIX" ] || die "no install prefix; set OPENFOLD_PREFIX or its <site>.json"
     ACCOUNT=$(interactive::resolve OPENFOLD_ACCOUNT "slurm account" "${OPENFOLD_ACCOUNT:-$(slurm::default_account)}")
     export OPENFOLD_GPU_ACCOUNT=${OPENFOLD_GPU_ACCOUNT:-${ACCOUNT:+$ACCOUNT${OPENFOLD_GPU_ACCOUNT_SUFFIX:-}}}
-    export OPENFOLD_PREFIX=$PREFIX OPENFOLD_HOME=$REPO
+    export OPENFOLD_PREFIX=$PREFIX OPENFOLD_HOME=$REPO OPENFOLD_ACCOUNT=$ACCOUNT
     SETUP=$OF/install/setup.sh
     mkdir -p "$PREFIX"
 
@@ -107,6 +107,7 @@ slurm::run() {
         [ -n "$ACCOUNT" ] || die "no slurm account; set OPENFOLD_ACCOUNT"
         PARTITION=$(interactive::resolve OPENFOLD_PARTITION "slurm partition" "${OPENFOLD_PARTITION:-}")
         [ -n "$PARTITION" ] || die "no build partition; set OPENFOLD_PARTITION or its <site>.json"
+        export OPENFOLD_PARTITION=$PARTITION
     fi
 
     # -t 1 must be tested here, not inside launch_args: command substitution makes stdout a pipe.

--- a/backends/openfold/install/slurm.sh
+++ b/backends/openfold/install/slurm.sh
@@ -47,6 +47,18 @@ slurm::nvme_alloc() {
 # The user's Slurm default account, overridable inline.
 slurm::default_account() { echo "${OPENFOLD_ACCOUNT:-$(sacctmgr -nP show user "$USER" format=DefaultAccount 2>/dev/null)}"; }
 
+# The cluster this node belongs to, by whichever source answers: a job carries the name, the
+# controller knows it, and slurm.conf has it with no daemon at all -- Delta's login nodes cannot
+# always reach slurmctld, and scontrol then exits 1 with nothing on stdout. Slurm lower-cases the
+# name for accounting and the sites/ files follow it, so slurm.conf's raw spelling is normalised.
+slurm::cluster() {
+    local name=${SLURM_CLUSTER_NAME:-}
+    [ -n "$name" ] || name=$(scontrol show config 2>/dev/null | awk '$1 == "ClusterName" { print $3 }')
+    [ -n "$name" ] || name=$(awk -F= '/^[ \t]*ClusterName[ \t]*=/ { gsub(/[ \t]/, "", $2); print $2 }' \
+        "${SLURM_CONF:-/etc/slurm/slurm.conf}" 2>/dev/null)
+    echo "$name" | tr '[:upper:]' '[:lower:]'
+}
+
 # Only delta-gh overrides this: it shares /work/nvme with x86 Delta and must not share the env.
 slurm::default_prefix() { echo "${OPENFOLD_BASE:+$OPENFOLD_BASE/vizfold}"; }
 

--- a/backends/openfold/install/tests/launch_args.sh
+++ b/backends/openfold/install/tests/launch_args.sh
@@ -36,6 +36,32 @@ got=$( (unset SLURM_STEP_ID SLURM_JOB_ID; slurm::launch_args acct part "") | tr 
 want=$(printf "$base" "")
 check "$want" "$got" "no tty means no pty"
 
+# slurm::cluster: each source in turn, because no single one works everywhere. Delta's login nodes
+# cannot reach slurmctld (scontrol exits 1, empty), DeltaAI has no readable slurm.conf.
+conf=${TMPDIR:-/tmp}/vizfold-slurm-conf.$$
+printf 'ControlMachine=x\nClusterName=Delta\nSelectType=cray\n' > "$conf"
+trap 'rm -f "$conf"' EXIT
+scontrol() { return 1; }                                  # controller unreachable, as on dt-login02
+
+got=$(SLURM_CLUSTER_NAME=delta-gh SLURM_CONF=$conf slurm::cluster)
+check "delta-gh" "$got" "a job's own cluster name wins"
+
+got=$(SLURM_CONF=$conf slurm::cluster)
+check "delta" "$got" "slurm.conf answers when the controller does not, lower-cased"
+
+scontrol() { echo "ClusterName             = delta-gh"; }
+got=$(SLURM_CONF=$conf slurm::cluster)
+check "delta-gh" "$got" "the controller outranks slurm.conf"
+
+scontrol() { return 1; }
+got=$(SLURM_CONF=/nonexistent slurm::cluster)
+check "" "$got" "no source means no site, so install.sh falls back to local"
+
+# Every name slurm::cluster can resolve must have a site file, or detection finds nothing to load.
+for c in delta delta-gh; do
+    [ -f "sites/$c.sh" ] && echo "ok   sites/$c.sh exists" || { echo "FAIL no sites/$c.sh"; fail=1; }
+done
+
 # sbatch must be gone entirely.
 grep -q sbatch ./slurm.sh && { echo "FAIL sbatch still referenced"; fail=1; } || echo "ok   no sbatch"
 

--- a/backends/openfold/install/tests/site_config.expected
+++ b/backends/openfold/install/tests/site_config.expected
@@ -5,6 +5,7 @@ env=/anvil/projects/x-test/x-test/vizfold/envs/vizfold-openfold arch=x86_64 max_
 launch=srun -A bbka-gpu -p gpu --gres=gpu:1 --cpus-per-task=8 --mem=32G -t 02:00:00 
 {
   "ESMFOLD_ENV_PREFIX": "",
+  "OPENFOLD_ACCOUNT": "bbka",
   "OPENFOLD_AF2_ROOT": "",
   "OPENFOLD_DATA_DIR": "/anvil/projects/x-test/x-test/vizfold/data",
   "OPENFOLD_DRIVER_CUDA": "",
@@ -18,6 +19,7 @@ launch=srun -A bbka-gpu -p gpu --gres=gpu:1 --cpus-per-task=8 --mem=32G -t 02:00
   "OPENFOLD_GPU_TIME": "02:00:00",
   "OPENFOLD_HOME": "{REPO}",
   "OPENFOLD_MAX_CUDA": "12.8",
+  "OPENFOLD_PARTITION": "shared",
   "OPENFOLD_PREFIX": "/anvil/projects/x-test/x-test/vizfold",
   "OPENFOLD_SITE": "anvil",
   "VIZFOLD_DB": "/anvil/projects/x-test/x-test/vizfold/vizfold.db",
@@ -30,6 +32,7 @@ env=/ocean/projects/bbka/x-test/vizfold/envs/vizfold-openfold arch=x86_64 max_cu
 launch=srun -A bbka -p GPU-shared --gres=gpu:v100-32:1 --cpus-per-task=5 --mem=32G -t 02:00:00 
 {
   "ESMFOLD_ENV_PREFIX": "",
+  "OPENFOLD_ACCOUNT": "bbka",
   "OPENFOLD_AF2_ROOT": "/ocean/datasets/community/alphafold/v2.3.2",
   "OPENFOLD_DATA_DIR": "/ocean/projects/bbka/x-test/vizfold/data",
   "OPENFOLD_DRIVER_CUDA": "",
@@ -43,6 +46,7 @@ launch=srun -A bbka -p GPU-shared --gres=gpu:v100-32:1 --cpus-per-task=5 --mem=3
   "OPENFOLD_GPU_TIME": "02:00:00",
   "OPENFOLD_HOME": "{REPO}",
   "OPENFOLD_MAX_CUDA": "12.8",
+  "OPENFOLD_PARTITION": "RM-shared",
   "OPENFOLD_PREFIX": "/ocean/projects/bbka/x-test/vizfold",
   "OPENFOLD_SITE": "bridges2",
   "VIZFOLD_DB": "/ocean/projects/bbka/x-test/vizfold/vizfold.db",
@@ -55,6 +59,7 @@ env=/work/nvme/bbka/x-test/vizfold-gh/envs/vizfold-openfold arch=aarch64 max_cud
 launch=srun -A bbka-dtai-gh -p ghx4-interactive --gres=gpu:1 --cpus-per-task=8 --mem=32G -t 01:00:00 
 {
   "ESMFOLD_ENV_PREFIX": "",
+  "OPENFOLD_ACCOUNT": "bbka-dtai-gh",
   "OPENFOLD_AF2_ROOT": "/work/hdd/data/alphafold2/database",
   "OPENFOLD_DATA_DIR": "/work/nvme/bbka/x-test/vizfold-gh/data",
   "OPENFOLD_DRIVER_CUDA": "",
@@ -68,6 +73,7 @@ launch=srun -A bbka-dtai-gh -p ghx4-interactive --gres=gpu:1 --cpus-per-task=8 -
   "OPENFOLD_GPU_TIME": "01:00:00",
   "OPENFOLD_HOME": "{REPO}",
   "OPENFOLD_MAX_CUDA": "12.9",
+  "OPENFOLD_PARTITION": "ghx4",
   "OPENFOLD_PREFIX": "/work/nvme/bbka/x-test/vizfold-gh",
   "OPENFOLD_SITE": "delta-gh",
   "VIZFOLD_DB": "/work/nvme/bbka/x-test/vizfold-gh/vizfold.db",
@@ -80,6 +86,7 @@ env=/work/nvme/bbka/x-test/vizfold/envs/vizfold-openfold arch=x86_64 max_cuda=12
 launch=srun -A bbka-delta-gpu -p gpuA100x4-interactive --gres=gpu:1 --cpus-per-task=8 --mem=32G -t 01:00:00 
 {
   "ESMFOLD_ENV_PREFIX": "",
+  "OPENFOLD_ACCOUNT": "bbka-delta-cpu",
   "OPENFOLD_AF2_ROOT": "/work/hdd/data/alphafold2/database",
   "OPENFOLD_DATA_DIR": "/work/nvme/bbka/x-test/vizfold/data",
   "OPENFOLD_DRIVER_CUDA": "",
@@ -93,6 +100,7 @@ launch=srun -A bbka-delta-gpu -p gpuA100x4-interactive --gres=gpu:1 --cpus-per-t
   "OPENFOLD_GPU_TIME": "01:00:00",
   "OPENFOLD_HOME": "{REPO}",
   "OPENFOLD_MAX_CUDA": "12.8",
+  "OPENFOLD_PARTITION": "cpu",
   "OPENFOLD_PREFIX": "/work/nvme/bbka/x-test/vizfold",
   "OPENFOLD_SITE": "delta",
   "VIZFOLD_DB": "/work/nvme/bbka/x-test/vizfold/vizfold.db",
@@ -105,6 +113,7 @@ env=/expanse/lustre/projects/abc123/x-test/vizfold/envs/vizfold-openfold arch=x8
 launch=srun -A abc123 -p gpu-shared --gres=gpu:v100:1 --cpus-per-task=8 --mem=32G -t 02:00:00 
 {
   "ESMFOLD_ENV_PREFIX": "",
+  "OPENFOLD_ACCOUNT": "abc123",
   "OPENFOLD_AF2_ROOT": "",
   "OPENFOLD_DATA_DIR": "/expanse/lustre/projects/abc123/x-test/vizfold/data",
   "OPENFOLD_DRIVER_CUDA": "",
@@ -118,6 +127,7 @@ launch=srun -A abc123 -p gpu-shared --gres=gpu:v100:1 --cpus-per-task=8 --mem=32
   "OPENFOLD_GPU_TIME": "02:00:00",
   "OPENFOLD_HOME": "{REPO}",
   "OPENFOLD_MAX_CUDA": "12.8",
+  "OPENFOLD_PARTITION": "shared",
   "OPENFOLD_PREFIX": "/expanse/lustre/projects/abc123/x-test/vizfold",
   "OPENFOLD_SITE": "expanse",
   "VIZFOLD_DB": "/expanse/lustre/projects/abc123/x-test/vizfold/vizfold.db",
@@ -130,6 +140,7 @@ env=/storage/ice1/x-test/vizfold/envs/vizfold-openfold arch=x86_64 max_cuda=12.8
 launch=srun -A bbka -p ice-gpu --gres=gpu:a100:1 --cpus-per-task=8 --mem=32G -t 02:00:00 
 {
   "ESMFOLD_ENV_PREFIX": "",
+  "OPENFOLD_ACCOUNT": "bbka",
   "OPENFOLD_AF2_ROOT": "/storage/ice1/shared/d-pace_community/alphafold/alphafold_2.3.2_data",
   "OPENFOLD_DATA_DIR": "/storage/ice1/x-test/vizfold/data",
   "OPENFOLD_DRIVER_CUDA": "",
@@ -143,6 +154,7 @@ launch=srun -A bbka -p ice-gpu --gres=gpu:a100:1 --cpus-per-task=8 --mem=32G -t 
   "OPENFOLD_GPU_TIME": "02:00:00",
   "OPENFOLD_HOME": "{REPO}",
   "OPENFOLD_MAX_CUDA": "12.8",
+  "OPENFOLD_PARTITION": "ice-cpu",
   "OPENFOLD_PREFIX": "/storage/ice1/x-test/vizfold",
   "OPENFOLD_SITE": "ice-slurm",
   "VIZFOLD_DB": "/storage/ice1/x-test/vizfold/vizfold.db",
@@ -155,6 +167,7 @@ env=/projects/x-test/vizfold/envs/vizfold-openfold arch=x86_64 max_cuda=12.8 ove
 launch=srun -A bbka -p gpu --gres=gpu:1 --cpus-per-task=8 --mem=24G -t 02:00:00 
 {
   "ESMFOLD_ENV_PREFIX": "",
+  "OPENFOLD_ACCOUNT": "bbka",
   "OPENFOLD_AF2_ROOT": "/media/volume/nexus-staging-slurm-data/database",
   "OPENFOLD_DATA_DIR": "/projects/x-test/vizfold/data",
   "OPENFOLD_DRIVER_CUDA": "",
@@ -168,6 +181,7 @@ launch=srun -A bbka -p gpu --gres=gpu:1 --cpus-per-task=8 --mem=24G -t 02:00:00
   "OPENFOLD_GPU_TIME": "02:00:00",
   "OPENFOLD_HOME": "{REPO}",
   "OPENFOLD_MAX_CUDA": "12.8",
+  "OPENFOLD_PARTITION": "gpu",
   "OPENFOLD_PREFIX": "/projects/x-test/vizfold",
   "OPENFOLD_SITE": "nexus-dev",
   "VIZFOLD_DB": "/projects/x-test/vizfold/vizfold.db",
@@ -180,6 +194,7 @@ env=/storage/scratch1/x-test/vizfold/envs/vizfold-openfold arch=x86_64 max_cuda=
 launch=srun -A bbka -p gpu-a100 --gres=gpu:a100:1 --cpus-per-task=8 --mem=32G -t 02:00:00 
 {
   "ESMFOLD_ENV_PREFIX": "",
+  "OPENFOLD_ACCOUNT": "bbka",
   "OPENFOLD_AF2_ROOT": "/storage/coda1/ice1/shared/d-pace_community/alphafold/alphafold_2.3.2_data",
   "OPENFOLD_DATA_DIR": "/storage/scratch1/x-test/vizfold/data",
   "OPENFOLD_DRIVER_CUDA": "",
@@ -193,6 +208,7 @@ launch=srun -A bbka -p gpu-a100 --gres=gpu:a100:1 --cpus-per-task=8 --mem=32G -t
   "OPENFOLD_GPU_TIME": "02:00:00",
   "OPENFOLD_HOME": "{REPO}",
   "OPENFOLD_MAX_CUDA": "12.8",
+  "OPENFOLD_PARTITION": "cpu-small",
   "OPENFOLD_PREFIX": "/storage/scratch1/x-test/vizfold",
   "OPENFOLD_SITE": "phoenix-slurm",
   "VIZFOLD_DB": "/storage/scratch1/x-test/vizfold/vizfold.db",

--- a/backends/openfold/install/tests/site_config.sh
+++ b/backends/openfold/install/tests/site_config.sh
@@ -17,7 +17,7 @@ trap 'rm -rf "$SANDBOX"' EXIT
 site_env() {
     case $1 in
         anvil)          echo 'export PROJECT=/anvil/projects/x-test' ;;
-        delta|delta-gh) echo 'export ALLOC=bbka' ;;
+        delta|delta-gh) echo 'export OPENFOLD_ALLOCATION=bbka' ;;
         expanse)        echo 'export OPENFOLD_ALLOCATION=abc123' ;;
         ice-slurm)      echo 'SCRATCH=/storage/ice1/x-test' ;;
         phoenix-slurm)  echo 'SCRATCH=/storage/scratch1/x-test' ;;

--- a/backends/openfold/install/tests/vocabulary.sh
+++ b/backends/openfold/install/tests/vocabulary.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# One vocabulary: the binary must not resolve a name the config never carries, and a <site>.json
+# must not set a name nothing consumes. Run: bash install/tests/vocabulary.sh
+set -uo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+REPO=$(cd ../../.. && pwd)
+VIZFOLD_CONFIG=/nonexistent/vocabulary-test.json; export VIZFOLD_CONFIG
+. "$REPO/lib/config.sh"
+
+fail=0
+schema=$(printf '%s\n' $VIZFOLD_CONFIG_KEYS | sort)
+
+# Names a <site>.json may set that the install consumes and deliberately does not persist: a
+# re-install re-reads the same file, so saving them would record an answer nobody asks for again.
+install_only="OPENFOLD_ALLOCATION OPENFOLD_BASE OPENFOLD_BUILD_CPUS OPENFOLD_BUILD_GRES
+OPENFOLD_BUILD_MEM OPENFOLD_BUILD_TIME OPENFOLD_GPU_ACCOUNT_SUFFIX"
+
+report() { # $1 label, $2 newline-separated offenders, $3 remedy
+    if [ -z "$2" ]; then echo "ok   $1"; else
+        echo "FAIL $1"; printf '       %s\n' $2; echo "       -> $3"; fail=1
+    fi
+}
+
+# Every resolved("X") in the CLI must be a schema key, or the binary expects what no install writes.
+cli=$(grep -oE 'resolved\("[A-Z_]+"\)' "$REPO/cli/src/core/config.rs" |
+    sed 's/resolved("//; s/")//' | sort -u)
+report "every name the CLI resolves is in the config schema" \
+    "$(comm -23 <(printf '%s\n' $cli) <(printf '%s\n' $schema))" \
+    "add it to VIZFOLD_CONFIG_KEYS, or read a name the install already settles"
+
+# Every <site>.json key must be persisted or knowingly install-only -- nothing set and forgotten.
+known=$(printf '%s\n' $schema $install_only | sort -u)
+site_keys=$(python3 -c '
+import json, pathlib
+print(*sorted({k for f in pathlib.Path("sites").glob("*.json") for k in json.loads(f.read_text())}))')
+report "every site key is persisted or knowingly install-only" \
+    "$(comm -23 <(printf '%s\n' $site_keys) <(printf '%s\n' $known))" \
+    "add it to VIZFOLD_CONFIG_KEYS, or to install_only here if the install consumes it and stops"
+
+# Every $VAR in a site value must be provided by something, or it expands to empty and the install
+# proceeds with a mangled value -- how "$ALLOC-delta-cpu" once became the account "-delta-cpu".
+templated=$(grep -ohE '\$\{?[A-Z_]+\}?' sites/*.json | tr -d '${}' | sort -u)
+provided=$(printf '%s\n' $schema $install_only USER HOME \
+    $(grep -ohE 'export [A-Z_]+|[A-Z_]+=' sites/*.sh slurm.sh | tr -d '=' | sed 's/export //') |
+    sort -u)
+report "every site template atom is provided by a discover hook or the schema" \
+    "$(comm -23 <(printf '%s\n' $templated) <(printf '%s\n' $provided))" \
+    "export it from the site's slurm::discover, or it silently expands to empty"
+
+exit $fail

--- a/cli/src/adapters/cli.rs
+++ b/cli/src/adapters/cli.rs
@@ -410,7 +410,7 @@ fn run_install(backend: Backend) -> Result<(), DbErr> {
     }
     if !installer.is_file() {
         return Err(DbErr::Custom(format!(
-            "no {} installer at {}; set VIZFOLD_SRC to a checkout",
+            "no {} installer at {}; set OPENFOLD_HOME to a checkout",
             backend.slug(),
             installer.display()
         )));
@@ -531,13 +531,13 @@ fn run_status() -> Result<(), DbErr> {
 
 /// Clone the vizfold checkout `vizfold install` runs its scripts (and serves the dashboard)
 /// from -- the release binary ships only itself. Pins the binary's own version tag
-/// (`VIZFOLD_REF` overrides), falling back to the repo default branch.
+/// (`VIZFOLD_VERSION` overrides, same name install.sh uses), falling back to the repo default branch.
 fn clone_checkout(src: &std::path::Path) -> Result<(), DbErr> {
     let repo =
         std::env::var("VIZFOLD_REPO").unwrap_or_else(|_| "AI2Science/vizfold-foundation".into());
     let url = format!("https://github.com/{repo}.git");
     let dest = src.to_string_lossy().into_owned();
-    let pinned = match std::env::var("VIZFOLD_REF") {
+    let pinned = match std::env::var("VIZFOLD_VERSION") {
         Ok(r) if !r.is_empty() => Some(r),
         _ => Some(format!("v{}", env!("CARGO_PKG_VERSION"))),
     };
@@ -552,7 +552,7 @@ fn clone_checkout(src: &std::path::Path) -> Result<(), DbErr> {
     match clone(&["clone", "--depth", "1", &url, &dest]) {
         Ok(s) if s.success() => Ok(()),
         _ => Err(DbErr::Custom(format!(
-            "failed to clone {url} into {dest}; set VIZFOLD_SRC to an existing checkout"
+            "failed to clone {url} into {dest}; set OPENFOLD_HOME to an existing checkout"
         ))),
     }
 }

--- a/cli/src/core/config.rs
+++ b/cli/src/core/config.rs
@@ -60,13 +60,8 @@ pub fn openfold_home() -> PathBuf {
 }
 
 /// Repo checkout holding `backends/openfold/install/install.sh` (what `vizfold install` runs, cloning it if absent).
-/// `VIZFOLD_SRC` env > vizfold.json `OPENFOLD_HOME` > the default clone location (`$HOME/vizfold-src`).
+/// `OPENFOLD_HOME` -- the config's own name for it -- else the default clone location (`$HOME/vizfold-src`).
 pub fn vizfold_src() -> PathBuf {
-    if let Ok(v) = std::env::var("VIZFOLD_SRC")
-        && !v.is_empty()
-    {
-        return PathBuf::from(v);
-    }
     resolved("OPENFOLD_HOME")
         .map(PathBuf::from)
         .unwrap_or_else(default_src)
@@ -207,10 +202,11 @@ pub fn gpu_partition() -> Option<String> {
 }
 
 pub fn database_url() -> String {
-    if let Ok(u) = std::env::var("DATABASE_URL")
-        && !u.is_empty()
-    {
-        return u;
+    // DATABASE_URL used to win here. It names nothing the install writes, so it is no longer a
+    // source -- but README shipped it, and silently moving someone's database is the worst way to
+    // say so. VIZFOLD_DB takes a full sqlite: URL, so it covers every use.
+    if std::env::var("DATABASE_URL").is_ok_and(|u| !u.is_empty()) {
+        eprintln!("warning: DATABASE_URL is ignored; set VIZFOLD_DB instead");
     }
     if let Some(db) = resolved("VIZFOLD_DB") {
         return if db.starts_with("sqlite:") {

--- a/cli/src/core/config.rs
+++ b/cli/src/core/config.rs
@@ -1,5 +1,5 @@
 use serde_json::{Map, Value};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
 /// Path to the install-time config written by `lib/config.sh` (`config::save`).
@@ -236,20 +236,31 @@ pub fn database_path() -> Option<PathBuf> {
     (!path.is_empty() && path != ":memory:").then(|| PathBuf::from(path))
 }
 
-/// Repository root for the local development layout. DEV FALLBACK ONLY: relies on
-/// the executor crate being nested under the repository root, not suitable for an
-/// installed binary (where `openfold_home()` resolves from config instead).
+/// Repository root for the local development layout: this crate is `<root>/cli`, so the root is one
+/// level up. Baked in at build time, so for a released binary it names the machine that built it --
+/// use it only when it is actually present, else the checkout `vizfold install` clones.
 fn repository_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .ancestors()
-        .nth(3)
-        .expect("executor manifest should be nested under the repository root")
-        .to_path_buf()
+        .parent()
+        .filter(|root| root.join("backends/openfold/install/install.sh").is_file())
+        .map_or_else(default_src, Path::to_path_buf)
 }
 
 #[cfg(test)]
 mod tests {
     use super::{SlurmContext, env_base, env_dir, gpu_launch, non_empty};
+
+    /// Compiled in from the build machine, so it has to name a checkout that is actually here --
+    /// a released binary otherwise reports its CI workspace as the install root.
+    #[test]
+    fn repository_root_names_a_real_checkout() {
+        let root = super::repository_root();
+        assert!(
+            root.join("backends/openfold/install/install.sh").is_file(),
+            "repository_root() must be a checkout, got {}",
+            root.display()
+        );
+    }
 
     /// The fixed key set writes "" for every name the install did not settle, so a consumer must
     /// not tell those apart from a missing key.

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -10,7 +10,7 @@ CONFIG_SH=1
 REPO=${OPENFOLD_HOME:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}
 # The OpenFold backend subtree, for OpenFold's own scripts (esmfold never reads OF). Backend-local
 # files (setup.py, environment.yml, install/) live here; shared demo assets (examples/) at the root.
-OF=${OPENFOLD_DIR:-$REPO/backends/openfold}
+OF=$REPO/backends/openfold
 die() { echo "FATAL: $*" >&2; exit 1; }
 
 # Every environment the install creates lives in one base directory under a fixed vizfold-<backend>
@@ -66,8 +66,9 @@ config::site_defaults() { config::fill "${1%.sh}.json" "site defaults"; }
 # one fixed set, whatever the cluster settled and whichever backend was installed last.
 VIZFOLD_CONFIG_KEYS="OPENFOLD_HOME OPENFOLD_PREFIX OPENFOLD_SITE OPENFOLD_DATA_DIR OPENFOLD_AF2_ROOT
 VIZFOLD_ENV_BASE OPENFOLD_ENV_PREFIX ESMFOLD_ENV_PREFIX OPENFOLD_MAX_CUDA OPENFOLD_DRIVER_CUDA
-OPENFOLD_GPU_ACCOUNT OPENFOLD_GPU_PARTITION OPENFOLD_GPU_RESOURCES OPENFOLD_GPU_GRES
-OPENFOLD_GPU_TIME OPENFOLD_EXAMPLE OPENFOLD_FOLD_ARGS VIZFOLD_DB"
+OPENFOLD_ACCOUNT OPENFOLD_PARTITION OPENFOLD_GPU_ACCOUNT OPENFOLD_GPU_PARTITION
+OPENFOLD_GPU_RESOURCES OPENFOLD_GPU_GRES OPENFOLD_GPU_TIME OPENFOLD_EXAMPLE
+OPENFOLD_FOLD_ARGS VIZFOLD_DB"
 
 # Every key, every time -- empty for what this install did not settle. config::load has already put
 # the previous install's values in the environment, so a second backend rewrites them rather than

--- a/scripts/esmfold/run_esmf_ice.slurm
+++ b/scripts/esmfold/run_esmf_ice.slurm
@@ -36,7 +36,7 @@ mkdir -p "$OUTDIR"
 # eval "$(conda shell.bash hook)"
 # conda activate vizfold
 
-cd "${VIZFOLD_REPO:-.}"
+cd "${OPENFOLD_HOME:-.}"
 
 # Sanity check: fail fast if the environment is not set up
 python -c "import torch; import transformers" 2>/dev/null || {

--- a/scripts/openfold/fold.sh
+++ b/scripts/openfold/fold.sh
@@ -21,7 +21,7 @@ fold::reexec() {
     clean=(HOME="$HOME" PATH="$env_prefix/bin:/usr/bin:/bin" OPENFOLD_CLEAN_ENV=1)
     [ -n "${TMPDIR:-}" ] && clean+=("TMPDIR=$TMPDIR")
     # JIT autotune cache: node-local, not NFS $HOME (79 s vs 8 s inference).
-    clean+=("TRITON_CACHE_DIR=${TRITON_CACHE_DIR:-/tmp/openfold-triton-$(id -u)}")
+    clean+=("TRITON_CACHE_DIR=${TRITON_CACHE_DIR:-/tmp/vizfold-triton-$(id -u)}")
     while IFS= read -r kv; do clean+=("$kv"); done < <(
         env | grep -E '^(OPENFOLD_[A-Z0-9_]*|SLURM_[A-Z0-9_]*|CUDA_VISIBLE_DEVICES|GPU_DEVICE_ORDINAL|NVIDIA_VISIBLE_DEVICES)=')
     exec env -i "${clean[@]}" bash "$0" "$@"


### PR DESCRIPTION
Two changes. The first unblocks a reported install failure; the second is the follow-on that the failure exposed — the two halves of the system did not use the same names.

---

# 1. Site detection without a live controller

Reported from a Delta GPU node: `vizfold install openfold` printed `site [local]`, then died with `no install prefix`.

Detection had one source, and it needs a daemon:

```
$ scontrol show config; echo $?
slurm_load_ctl_conf error:Unable to contact slurm controller (connect failure)
1
```

That is `dt-login02` right now. With `ClusterName` empty the site falls back to `local`, which contributes no `slurm::discover`, so `OPENFOLD_BASE` is never set and the prefix cannot be derived. The reported symptom is two steps downstream of the fault; `delta.json` was never read at all.

`slurm::cluster` now asks each source that can answer, most authoritative first: `SLURM_CLUSTER_NAME` (a job carries its own name — the compute-node case in the report), then `scontrol`, then `ClusterName` in `slurm.conf`, which needs no daemon. Slurm lower-cases the name for accounting and the `sites/` files follow it, so `slurm.conf`'s raw spelling is normalised — Delta's file says `Delta`.

**Verified live.** The two clusters fail in opposite ways, so between them they exercise every fallback:

| | `scontrol` | `slurm.conf` | resolves |
| --- | --- | --- | --- |
| Delta (`dt-login02`) | ✗ unreachable | ✓ world-readable, `Delta` | `delta` |
| Delta-AI (`gh-login02`) | ✓ `delta-gh` | ✗ not readable | `delta-gh` |

Also fixes `repository_root()`, which produced `/home/runner/work/envs/vizfold-openfold` in `vizfold status` on Delta — the **GitHub Actions workspace**, baked in via `CARGO_MANIFEST_DIR`. The crate is `<root>/cli`, so the root is `.nth(1)`, not `.nth(3)`; it was wrong everywhere and a released binary just made it visible. It now uses that path only when the checkout is really present, else where `vizfold install` clones.

---

# 2. One vocabulary

The binary resolved names no config file writes, and the site files set names the install discards.

**The CLI expected what no config provides**

| Name | Resolution |
| --- | --- |
| `VIZFOLD_SRC` | Duplicated `OPENFOLD_HOME`, and was read *ahead* of it. Deleted; errors now name `OPENFOLD_HOME`. |
| `DATABASE_URL` | Duplicated `VIZFOLD_DB`, which already takes a full `sqlite:` URL. No longer a source — but it shipped in v0.4.0's README, so it **warns** rather than silently relocating a database. |
| `VIZFOLD_REF` | Renamed `VIZFOLD_VERSION`, the name `install.sh` already uses, so bootstrap and self-clone agree. |
| `VIZFOLD_REPO` | Meant a GitHub slug in the CLI and a **directory** in `run_esmf_ice.slurm`. The latter is `OPENFOLD_HOME`. |

**The install settled names and dropped them.** `OPENFOLD_ACCOUNT` and `OPENFOLD_PARTITION` are set by all eight sites, chosen once, then lost — nothing afterwards could say which account an install charged. Both are schema keys now. ESMFold's installer never exported `VIZFOLD_ENV_BASE`, so an esmfold-first install wrote that key empty.

**Knobs nothing ever wrote:** `OPENFOLD_DIR`, `OPENFOLD_FALLBACK_CUDA`, `OPENFOLD_PKGS_DIR` — read but set by no site, no installer, no doc. `OPENFOLD_SCRATCH` was a pure phantom, appearing only in a comment describing a contract it was not part of.

`ALLOC` was the only name without a prefix and `OPENFOLD_ALLOCATION` already existed as its own inline override; they are one name. `TRITON_CACHE_DIR` had two different defaults for the same cache. `cli.rs:485` set `OPENFOLD_HOME` on the downloader child, which no downloader reads.

**Deliberately left alone.** `OPENFOLD_FOLD_ARGS` was proposed for deletion as "read, never written" — no *site* writes it, but users do, and that is how `--skip_relaxation` persists. The eight per-run names in `fold.sh` (`OPENFOLD_INPUT_ID`, `OPENFOLD_OUTPUT_DIR`, `OPENFOLD_MODEL_DEVICE`, …) stay out of the schema: persisting an output directory would be wrong on the next fold. `OPENFOLD_BUILD_*` stay out too — a re-install re-reads the same `<site>.json`.

## Keeping it aligned

`install/tests/vocabulary.sh` enforces the invariant across the language boundary, in CI:

1. Every `resolved()` in the CLI is a schema key.
2. Every site key is persisted or knowingly install-time-only.
3. Every `$VAR` in a site value is provided by something — this is how `"$ALLOC-delta-cpu"` once expanded to the account `"-delta-cpu"`.

Check 3 is verified to fail on a planted bad atom. README now states the membership rule: a name belongs in the schema when the install **settles** it and something **later** needs it, and nothing else.

The resolver snapshot moves by exactly 16 lines — two new keys on each of eight sites — with no existing value changed.