### PR TITLE
Bump version to 0.5.0

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "executor"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "executor"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 default-run = "vizfold"
 


### PR DESCRIPTION
Cuts a release for #113.

Minor rather than patch because names were removed from the environment interface:

- `DATABASE_URL` is no longer a database source. It was documented in v0.4.0's README, so the binary warns rather than silently relocating a database, but the behaviour did change.
- `VIZFOLD_SRC` is gone; `OPENFOLD_HOME` is the only spelling.
- `VIZFOLD_REF` is now `VIZFOLD_VERSION`, matching what `install.sh` already called it.
- `ALLOC` is now `OPENFOLD_ALLOCATION`; anyone passing `ALLOC=` inline needs the new name.
- The saved config gains `OPENFOLD_ACCOUNT` and `OPENFOLD_PARTITION`.

A release is also how the installer changes reach anyone: `clone_checkout` pins the checkout to `v{CARGO_PKG_VERSION}` (`cli/src/adapters/cli.rs`), so the cluster-detection fix in `slurm.sh` — the thing that unblocks `vizfold install` on Delta — is only delivered by a tag.