### PR TITLE
Print the fold check for the shell that will run it

### DIFF
--- a/DEMO.md
+++ b/DEMO.md
@@ -239,7 +239,8 @@ grep -c '^ATOM' /work/nvme/bbol/yjayawardana/vizfold/outputs/6KWC_1/predictions/
 ```
 
 The account, partition, and resources here are Delta's; `vizfold install openfold` prints the
-command already filled in for whatever cluster it ran on.
+command already filled in for whatever cluster it ran on — and prints it without the `srun` when
+you install from inside a GPU allocation, where the fold runs as-is.
 
 A few thousand atoms means it worked. The executor lifecycle above is the fuller path — it
 persists the run, its provenance, and its artifacts, and feeds the dashboard.

--- a/backends/openfold/install/setup.sh
+++ b/backends/openfold/install/setup.sh
@@ -215,7 +215,14 @@ setup::fold_vars() {
     GPU_RES=${OPENFOLD_GPU_RESOURCES:---cpus-per-task=8 --mem=32G}
     GPU_GRES=${OPENFOLD_GPU_GRES:-gpu:1}
     GPU_TIME=${OPENFOLD_GPU_TIME:-02:00:00}
-    LAUNCH="${OPENFOLD_GPU_PARTITION:+srun ${OPENFOLD_GPU_ACCOUNT:+-A $OPENFOLD_GPU_ACCOUNT }-p $OPENFOLD_GPU_PARTITION --gres=$GPU_GRES $GPU_RES -t $GPU_TIME }"
+    # The command below runs in the shell that invoked the install, which slurm::fold_context
+    # classified: on a GPU node it runs as printed, and asking for a partition from inside an
+    # allocation is rejected anyway.
+    case ${OPENFOLD_FOLD_CONTEXT:-none} in
+        node)       LAUNCH= ;;
+        allocation) LAUNCH="srun --ntasks=1 " ;;
+        *)          LAUNCH="${OPENFOLD_GPU_PARTITION:+srun ${OPENFOLD_GPU_ACCOUNT:+-A $OPENFOLD_GPU_ACCOUNT }-p $OPENFOLD_GPU_PARTITION --gres=$GPU_GRES $GPU_RES -t $GPU_TIME }" ;;
+    esac
     EXAMPLE=${OPENFOLD_EXAMPLE:-6KWC_1}
     FOLD_ARGS=${OPENFOLD_FOLD_ARGS:-}
     STRUCTURE=relaxed

--- a/backends/openfold/install/slurm.sh
+++ b/backends/openfold/install/slurm.sh
@@ -68,6 +68,19 @@ slurm::scratch_root() {
     case "$s" in */"$USER"/*) echo "${s%%/"$USER"/*}/$USER" ;; *) echo "$s" ;; esac
 }
 
+# Where the shell that invoked the install stands, for the fold command setup.sh prints: that
+# command runs there, not on the node setup.sh gets (delta-gh builds on a GPU while the caller waits
+# on a login node). Mirrors gpu_launch in cli/src/core/config.rs.
+slurm::fold_context() {
+    if [ -n "$(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null)" ]; then
+        echo node                                        # a GPU in hand; srun would queue a second job
+    elif [ -n "${SLURM_JOB_ID:-}" ]; then
+        echo allocation                                  # held, but the shell may be off the node
+    else
+        echo none
+    fi
+}
+
 # Build the scheduler argv for setup.sh, one argument per line.
 # $1 account, $2 partition, $3 the literal --pty (or empty when stdout is not a terminal).
 slurm::launch_args() {
@@ -90,6 +103,7 @@ slurm::launch_args() {
 
 # Run the assembled hooks, then run setup.sh on the scheduler (or here when there is none).
 slurm::run() {
+    export OPENFOLD_FOLD_CONTEXT=$(slurm::fold_context)   # classify this shell before srun rewrites its SLURM_*
     if [ -z "${SLURM_JOB_ID:-}" ] && ! command -v srun >/dev/null 2>&1; then
         exec bash "$OF/install/setup.sh"          # no scheduler: install here
     fi

--- a/backends/openfold/install/tests/launch_args.sh
+++ b/backends/openfold/install/tests/launch_args.sh
@@ -36,6 +36,19 @@ got=$( (unset SLURM_STEP_ID SLURM_JOB_ID; slurm::launch_args acct part "") | tr 
 want=$(printf "$base" "")
 check "$want" "$got" "no tty means no pty"
 
+# slurm::fold_context: what the invoking shell needs to reach a GPU, not what the build node is.
+nvidia-smi() { return 1; }
+got=$( (unset SLURM_JOB_ID; slurm::fold_context) )
+check "none" "$got" "no GPU and no allocation means the hint must ask for one"
+
+got=$(SLURM_JOB_ID=1 slurm::fold_context)
+check "allocation" "$got" "an allocation the shell may be off needs only a step"
+
+nvidia-smi() { echo "NVIDIA A100-SXM4-40GB"; }
+got=$(SLURM_JOB_ID=1 slurm::fold_context)
+check "node" "$got" "a GPU in hand needs no srun at all"
+unset -f nvidia-smi
+
 # slurm::cluster: each source in turn, because no single one works everywhere. Delta's login nodes
 # cannot reach slurmctld (scontrol exits 1, empty), DeltaAI has no readable slurm.conf.
 conf=${TMPDIR:-/tmp}/vizfold-slurm-conf.$$


### PR DESCRIPTION
`vizfold install openfold` run from inside a GPU allocation finished by printing

```
srun -A bbol-delta-gpu -p gpuA100x4-interactive --gres=gpu:1 --cpus-per-task=8 --mem=32G -t 01:00:00 env ... fold.sh 6KWC_1
```

from a node that already holds an A100. Running it asks for a second job from inside the first.

## Cause

`setup::fold_vars` built the prefix from `OPENFOLD_GPU_PARTITION` alone, with no notion of where the command would be typed. That question cannot be answered in `setup.sh` either — it runs on the build node, which is not the caller's node (delta-gh sets `OPENFOLD_BUILD_GRES` and builds on a GPU while the caller waits on a login node), and `srun` has already rewritten its `SLURM_*` by then.

## Change

`slurm::fold_context` classifies the *invoking* shell in `slurm::run`, before the hand-off, and exports the verdict; `setup::fold_vars` switches on it. It mirrors `gpu_launch` in `cli/src/core/config.rs`:

| Caller | Printed prefix |
| --- | --- |
| GPU visible (`node`) | none — runs as printed |
| allocation held, no GPU here (`allocation`) | `srun --ntasks=1` |
| bare shell (`none`) | full `srun -A … -p … --gres=…` (unchanged) |

The middle case is a second fix: from inside an allocation, an `srun` naming a different partition is rejected, so the old full-`srun` hint was wrong there too.

No binary code changed, but the installer scripts are cloned at the binary's own tag, so this needs a release to reach users.

## Test plan

- `bash install/tests/launch_args.sh` — three new assertions for `slurm::fold_context` (stubbed `nvidia-smi`), 14 ok
- `bash install/tests/site_config.sh` — 8 sites resolve **unchanged**: with the context unset, the login-node path still prints the full srun
- `bash install/tests/vocabulary.sh` — 3 ok
- `cargo test` — 122 passed
- Rendered all three branches by hand against Delta's values

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AdhiyVf49e86fLAA8pisFu