### PR TITLE
Bump version to 0.5.1

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "executor"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "async-trait",
  "chrono",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "executor"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 default-run = "vizfold"
 


### PR DESCRIPTION
Cuts the release that carries everything merged since v0.5.0 to a cluster: the installer scripts are
cloned at the binary's own tag, so #115, #116 and #117 only land once this tag exists.

- **#116** — the install's fold hint no longer prints an `srun` when you are already on a GPU node
- **#117** — `vizfold uninstall <backend>`; `status` reports per-component health; `vizfold update` /
  `self-update` / `--version`; `vizfold-openfold` and `vizfold-esmfold` entrypoints; ESMFold brings
  its own Python; CI runs the Rust suite
- **#115** — the docs sweep, which never made it onto a tag

After this, `vizfold self-update` replaces the re-bootstrap for future releases.

## Test plan

`cargo test` (132 passed) and `vizfold --version` reports 0.5.1 from the built binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AdhiyVf49e86fLAA8pisFu