### PR TITLE
Bump version to 0.5.2

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "executor"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "async-trait",
  "chrono",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "executor"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2024"
 default-run = "vizfold"
 


### PR DESCRIPTION
Carries #119 to a cluster: the installer scripts are cloned at the binary's own tag, so the backend
entrypoints only land once this tag exists.

- **#119** — each backend's package installs its own CLI as `openfold` / `esmfold`, also
  `python -m <backend>`, usable without the `vizfold` binary on `PATH`. The `vizfold-openfold`
  wrapper and the install-time `srun` guess behind it are gone; `queue-run`/`execute-run` are the
  vizfold-side way in.

`vizfold self-update` picks this up from v0.5.1.

## Test plan

`cargo test` (132 passed) and `vizfold --version` reports 0.5.2 from the built binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AdhiyVf49e86fLAA8pisFu