### PR TITLE
Bump version to 0.5.3

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "executor"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "async-trait",
  "chrono",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "executor"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2024"
 default-run = "vizfold"
 


### PR DESCRIPTION
Patch release carrying #121 (OpenFold/ESMFold install and usage simplification).

The install scripts are cloned by the binary at its own release tag, so the bash-side
fixes in #121 — the ESMFold prefix bug, the config precedence move, and the site
machinery relocation — only reach users once a release exists to pin them to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JeXknd7QzVBysUfuxhuaUz