### PR TITLE
Bump version to 0.5.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ workbench/public/runs
 # Windows executable artifacts
 *.exe
 *.pdb
+
+# Session worktrees, never part of a release.
+.claude/worktrees/

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "executor"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "async-trait",
  "chrono",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "executor"
-version = "0.5.3"
+version = "0.5.4"
 edition = "2024"
 default-run = "vizfold"
 


### PR DESCRIPTION
Patch release carrying #123.

The install scripts are cloned by the binary at its own release tag, so the banner change and the
bash-side edits only reach users once a release pins them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JeXknd7QzVBysUfuxhuaUz