### PR TITLE
Keep install state off $HOME, and fix the guards that ask the wrong thing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ __pycache__/
 # build outputs
 build/
 dist/
+# OpenFold's CUDA extension, built in place by the editable install.
+*.so
 
 # files from script downloads
 backends/openfold/openfold/resources/

--- a/backends/esmfold/install/install.sh
+++ b/backends/esmfold/install/install.sh
@@ -34,6 +34,7 @@ esmfold::present() { "$ENV/bin/python" -c 'import torch, transformers, esmfold' 
 
 esmfold::env() {
     log "env $ENV (python $PYTHON_VERSION)"
+    rm -rf "$ENV"   # clear a partial env; create fails on a non-empty dir
     local mm; mm=$(mamba::ensure "$PREFIX")
     export MAMBA_ROOT_PREFIX=$PREFIX/mamba
     mkdir -p "$(dirname "$ENV")"

--- a/backends/openfold/install/setup.sh
+++ b/backends/openfold/install/setup.sh
@@ -36,6 +36,9 @@ setup::config() {
     export CONDA_PKGS_DIRS=$PREFIX/../.openfold-pkgs
     export MAMBA_ROOT_PREFIX=$PREFIX/mamba TMPDIR=$PREFIX/tmp
     export PIP_CACHE_DIR=$PREFIX/../.openfold-pip
+    # setup::verify imports deepspeed, whose autotune cache defaults to a quota'd NFS $HOME.
+    # Node-local, as run_execution.rs gives a fold.
+    export TRITON_CACHE_DIR=${TRITON_CACHE_DIR:-/tmp/vizfold-triton-$(id -u)}
     export MAX_JOBS="${MAX_JOBS:-${SLURM_CPUS_PER_TASK:-4}}"
     # Every GPU these sites schedule (7.0 V100 .. 9.0 H100); a missing arch = "no kernel image".
     export TORCH_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST:-$ARCH_DEFAULT}"

--- a/cli/src/adapters/cli.rs
+++ b/cli/src/adapters/cli.rs
@@ -146,6 +146,12 @@ impl Backend {
                 paths.push(prefix.join("esmfold-venv"));
                 // Its pip cache, parked beside the prefix by its installer.
                 paths.extend(prefix.parent().map(|dir| dir.join(".esmfold-pip")));
+                // `pip install <dir>` builds in-tree, so setuptools plants these in the checkout --
+                // the same droppings OpenFold's arm removes for its own subtree.
+                paths.extend(
+                    ["build", "esmfold.egg-info"]
+                        .map(|entry| home.join("backends/esmfold").join(entry)),
+                );
             }
             Self::Openfold => {
                 // `params` is where installs before the data-dir move put the weights; a target
@@ -1085,13 +1091,20 @@ fn run_update(wanted: Option<&str>) -> Result<(), DbErr> {
     }
     // Tracked edits only: the install builds OpenFold's CUDA extension in place, so this checkout
     // is expected to carry untracked build output, and a checkout preserves it anyway.
-    if !git(&src, &["status", "--porcelain", "--untracked-files=no"])
-        .is_some_and(|out| out.trim().is_empty())
-    {
-        return Err(DbErr::Custom(format!(
-            "{} has uncommitted changes; commit or discard them first",
-            src.display()
-        )));
+    match git(&src, &["status", "--porcelain", "--untracked-files=no"]) {
+        None => {
+            return Err(DbErr::Custom(format!(
+                "cannot read `git status` in {}; is git on PATH and the checkout yours to read?",
+                src.display()
+            )));
+        }
+        Some(changes) if !changes.trim().is_empty() => {
+            return Err(DbErr::Custom(format!(
+                "{} has uncommitted changes; commit or discard them first",
+                src.display()
+            )));
+        }
+        _ => {}
     }
     println!("Updating {} to {target} ...", src.display());
     // The clone is shallow and single-branch: the ref has to be fetched by name to exist here at
@@ -1536,6 +1549,13 @@ fn run_npm(dir: &Path, node_bin: &Path, args: &[&str]) -> Result<(), DbErr> {
     if let Ok(binary) = std::env::current_exe() {
         command.env("VIZFOLD_BIN", binary);
     }
+    // npm caches in $HOME/.npm by default: hundreds of MB and tens of thousands of inodes on
+    // the quota'd home that staging the workbench off it exists to avoid. In the dashboard's
+    // own env dir, which uninstall already removes.
+    command.env(
+        "npm_config_cache",
+        config::env_dir("workbench").join(".npm"),
+    );
     command.env("OPENFOLD_PREFIX", config::prefix());
     // The dashboard reads the sqlite file directly; hand it the plain path (database_url() carries
     // a sqlite://...?mode=rwc wrapper that node:sqlite can't open).
@@ -1717,6 +1737,9 @@ async fn run_execute(
                     submit_openfold_run(
                         database,
                         OpenfoldQueueArgs {
+                            // Only the bundled examples ship alignments; a FASTA of the user's own
+                            // has none, and would otherwise preflight against the examples' dir.
+                            use_precomputed_alignments: fasta.is_none(),
                             fasta: fasta.clone(),
                             ..OpenfoldQueueArgs::for_example(&example, args.attn)
                         },

--- a/cli/src/adapters/cli.rs
+++ b/cli/src/adapters/cli.rs
@@ -183,6 +183,19 @@ impl Backend {
                     ]
                     .map(|entry| backend.join(entry)),
                 );
+                // The CUDA extension, named for the Python ABI and arch that built it. Left behind
+                // it would be importable against an environment it was not built for.
+                paths.extend(
+                    std::fs::read_dir(&backend)
+                        .into_iter()
+                        .flatten()
+                        .flatten()
+                        .map(|entry| entry.path())
+                        .filter(|path| {
+                            path.extension().is_some_and(|ext| ext == "so")
+                                && file_name(path).starts_with("attn_core_inplace_cuda.")
+                        }),
+                );
             }
         }
         paths
@@ -1070,7 +1083,11 @@ fn run_update(wanted: Option<&str>) -> Result<(), DbErr> {
             src.display()
         )));
     }
-    if !git(&src, &["status", "--porcelain"]).is_some_and(|out| out.trim().is_empty()) {
+    // Tracked edits only: the install builds OpenFold's CUDA extension in place, so this checkout
+    // is expected to carry untracked build output, and a checkout preserves it anyway.
+    if !git(&src, &["status", "--porcelain", "--untracked-files=no"])
+        .is_some_and(|out| out.trim().is_empty())
+    {
         return Err(DbErr::Custom(format!(
             "{} has uncommitted changes; commit or discard them first",
             src.display()
@@ -2481,6 +2498,11 @@ mod tests {
         let _ = std::fs::remove_dir_all(&base);
         std::fs::create_dir_all(prefix.join("nvrtc-12.2")).unwrap();
         std::fs::create_dir_all(prefix.join("outputs")).unwrap();
+        // The editable install's extension, named for the Python ABI and arch that built it.
+        let backend = home.join("backends/openfold");
+        std::fs::create_dir_all(&backend).unwrap();
+        let extension = backend.join("attn_core_inplace_cuda.cpython-311-x86_64-linux-gnu.so");
+        std::fs::write(&extension, "").unwrap();
 
         let paths = Backend::Openfold.install_paths(&prefix, &home);
 
@@ -2493,6 +2515,7 @@ mod tests {
             // Under the backend subtree, where setup.sh actually plants them.
             home.join("backends/openfold/openfold/resources/params"),
             home.join("backends/openfold/openfold.egg-info"),
+            extension,
         ] {
             assert!(paths.contains(&expected), "missing {}", expected.display());
         }

--- a/cli/src/core/config.rs
+++ b/cli/src/core/config.rs
@@ -109,7 +109,7 @@ pub fn default_src() -> PathBuf {
 pub fn data_dir() -> PathBuf {
     resolved("OPENFOLD_DATA_DIR")
         .map(PathBuf::from)
-        .unwrap_or_else(|| openfold_home().join("data"))
+        .unwrap_or_else(|| prefix().join("data"))
 }
 
 /// The one directory holding every environment the install creates. Mirrors `vizfold::env_base`

--- a/cli/src/core/services/run_execution.rs
+++ b/cli/src/core/services/run_execution.rs
@@ -289,10 +289,20 @@ fn compose_esmfold_command(
     installed: bool,
 ) -> CommandSpec {
     let command = if installed {
-        CommandSpec {
+        let mut command = CommandSpec {
             program: env_prefix.join("bin/python").display().to_string(),
             ..command.clone()
+        };
+        // The weights (~2.6 GB) download on the first fold. HuggingFace's default puts them in
+        // $HOME/.cache, the quota'd home this install exists to stay off, and nothing ever removes
+        // them; under the env prefix, `vizfold uninstall esmfold` takes them with it.
+        if std::env::var_os("HF_HOME").is_none() {
+            let cache = env_prefix.join("hf");
+            command
+                .env
+                .insert("HF_HOME".to_owned(), cache.display().to_string());
         }
+        command
     } else {
         command.clone()
     };
@@ -321,6 +331,28 @@ fn srun_command(command: CommandSpec, launch: &[String]) -> CommandSpec {
 
 #[cfg(test)]
 mod tests {
+    /// The weights are fetched on the first fold, so the env var has to be on the command that
+    /// runs it -- not just recorded somewhere. Without it HuggingFace writes ~2.6 GB to $HOME.
+    #[test]
+    fn an_installed_esmfold_command_caches_its_weights_under_the_env() {
+        let env = PathBuf::from("/scratch/me/vizfold/envs/vizfold-esmfold");
+        let planned = CommandSpec {
+            program: "python3".to_owned(),
+            ..Default::default()
+        };
+
+        let composed = compose_esmfold_command(&planned, &env, &[], true);
+        assert_eq!(
+            composed.env.get("HF_HOME").map(String::as_str),
+            Some("/scratch/me/vizfold/envs/vizfold-esmfold/hf"),
+            "the fold must not cache weights in $HOME"
+        );
+
+        // Nothing installed means nothing to run, so no cache to redirect either.
+        let bare = compose_esmfold_command(&planned, &env, &[], false);
+        assert!(!bare.env.contains_key("HF_HOME"));
+    }
+
     use std::{
         path::PathBuf,
         sync::{
@@ -345,7 +377,7 @@ mod tests {
         test_support::TestLayout,
     };
 
-    use super::{activate_env_command, compose_exec_command, execute_run};
+    use super::{activate_env_command, compose_esmfold_command, compose_exec_command, execute_run};
 
     #[test]
     fn srun_command_wraps_the_whole_activated_command() {

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -61,7 +61,7 @@ mamba::activate() { set +u; eval "$("$1" shell hook --shell bash)"; micromamba a
 # one `vizfold serve` builds come from this one copy.
 mamba::ensure() {
     local prefix=$1 mm=$1/bin/micromamba build
-    if [ ! -x "$mm" ]; then
+    if ! "$mm" --version >/dev/null 2>&1; then
         case "$(uname -s)-$(uname -m)" in
             Linux-aarch64|Linux-arm64)   build=linux-aarch64 ;;
             Linux-*)                     build=linux-64 ;;

--- a/lib/slurm.sh
+++ b/lib/slurm.sh
@@ -64,7 +64,7 @@ slurm::default_prefix() { echo "${OPENFOLD_BASE:+$OPENFOLD_BASE/vizfold}"; }
 
 # Resolve ~/scratch (a symlink on PACE) to the user's scratch root, dropping any subdir it points into.
 slurm::scratch_root() {
-    local s; s=$(readlink -f "$HOME/scratch") || return 1
+    local s; [ -d "$HOME/scratch" ] || return 1; s=$(readlink -f "$HOME/scratch")
     case "$s" in */"$USER"/*) echo "${s%%/"$USER"/*}/$USER" ;; *) echo "$s" ;; esac
 }
 


### PR DESCRIPTION
Started from a report on Delta — `vizfold update` refusing because of an untracked `.so` — then
swept that defect's whole class across the codebase. Two commits; 17 fixes.

## The reported bug

```
$ vizfold update
/u/yjayawardana/vizfold-src has uncommitted changes; commit or discard them first
$ git status
Untracked files:
        backends/openfold/attn_core_inplace_cuda.cpython-311-x86_64-linux-gnu.so
```

`git status --porcelain` reports untracked files, so the guard blocked on anything the install left
lying around rather than on edits worth protecting. Since the install builds OpenFold's CUDA
extension in place, that `.so` is always there and every update after the first refused. Git
preserves untracked files across a checkout and refuses loudly by itself if the target ref carries
that path, so the guard only needs to ask about tracked changes. The `.so` is now also gitignored,
and `vizfold uninstall openfold` removes it — left behind it stays importable against an
environment it was not built for.

Reproduced the exact reported state (detached HEAD + that untracked `.so`) against the built
binary: it proceeds, and a real tracked edit is still refused with exit 1.

## The same shape, everywhere else

**State landing on the quota'd `$HOME` this install exists to avoid:**

| What | Default location | Size |
|---|---|---|
| ESMFold's weights (`facebook/esmfold_v1`) | `$HOME/.cache/huggingface` | ~2.6 GB |
| AlphaFold2 databases, when `OPENFOLD_DATA_DIR` was unsettled | `$HOME/vizfold-src/data` | up to ~2.2 TB |
| DeepSpeed's Triton autotune cache | `$HOME/.triton` | small, but NFS-warns on every install |
| npm's cache under `vizfold serve` | `$HOME/.npm` | tens of thousands of inodes |

Nothing set `HF_HOME` anywhere in the repo, and the weights are fetched on the *first fold* — so it
had to go on the command that runs it, not just recorded somewhere. `config::data_dir()` fell back
to the checkout while `setup.sh` resolves `<prefix>/data`, which bites `vizfold download` before any
OpenFold install, or after an ESMFold-only one. `run_execution.rs` already pinned
`TRITON_CACHE_DIR` for folds but the installer did not for its own steps — the reported log warns
about exactly this during `setup::verify`.

**Guards that asked the wrong question:**

- `mamba::ensure` trusted `-x` on the binary, so a truncated or wrong-arch micromamba was never
  re-fetched. It now asks whether it runs.
- `slurm::scratch_root`'s `readlink -f … || return 1` could never fire — GNU `readlink` needs only
  the parent to exist — so ice-slurm and phoenix never reached their `cannot resolve ~/scratch` die.
- The ESMFold installer could not rebuild a half-created env, since micromamba refuses a non-empty
  prefix. Same clear-then-create the OpenFold installer already does.
- `fold <path>` inherited `use_precomputed_alignments` from the bundled examples, so folding your
  own FASTA preflighted against the examples' alignment directory.

## Deliberately not taken

Making `vizfold::settle_site` always run `slurm::discover`. Discovery settles the *accounts* too, so
pinning `OPENFOLD_PREFIX` inline silently loses them — but ice-slurm, phoenix and expanse `die` when
their discover atom is absent, and that inline override is documented in README. It would turn a
wrong default into a hard failure on three clusters I cannot test against. Flagged rather than
changed.

## Verification

133 tests (one new, and it fails without the `HF_HOME` fix), clippy `-D warnings`, fmt, the three
install suites and a `bash -n` sweep. Checked against the built binary: `download` now targets
`<prefix>/data` rather than the checkout, and the update guard behaves in both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JeXknd7QzVBysUfuxhuaUz