### PR TITLE
Bump version to 0.5.5

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "executor"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "async-trait",
  "chrono",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "executor"
-version = "0.5.4"
+version = "0.5.5"
 edition = "2024"
 default-run = "vizfold"
 


### PR DESCRIPTION
Patch release carrying #125.

Worth releasing promptly: the fixes in it only reach users through a release, since the binary
clones `install/` at its own tag — and one of them (`vizfold update` refusing on the build output
the install itself leaves) bites on every update until a release carries the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JeXknd7QzVBysUfuxhuaUz