### PR TITLE
Look for the AlphaFold2 parameters where they live, not only where they are linked

### DIFF
--- a/cli/src/adapters/cli.rs
+++ b/cli/src/adapters/cli.rs
@@ -884,10 +884,8 @@ fn missing(what: &str, path: PathBuf) -> Option<String> {
     (!path.is_file()).then(|| format!("no {what} at {}", path.display()))
 }
 
-/// A fold reads the weights through the checkout: `run_pretrained_openfold.py` resolves them
-/// relative to the installed `openfold` package, and the install is editable. So that link is what
-/// has to resolve -- but naming where they really are is the difference between replanting a
-/// symlink and fetching 4 GB.
+/// The checkout link is what has to resolve: run_pretrained_openfold.py finds the weights relative
+/// to the installed `openfold` package, and the install is editable.
 fn params_problem() -> Option<String> {
     let mirror = config::resolved("OPENFOLD_AF2_ROOT").map(PathBuf::from);
     params_problem_in(
@@ -899,7 +897,6 @@ fn params_problem() -> Option<String> {
     )
 }
 
-/// `sources` in preference order: the site's mirror, then where the install downloads.
 fn params_problem_in(reached: &Path, sources: &[PathBuf]) -> Option<String> {
     const WEIGHTS: &str = "params/params_model_1_ptm.npz";
     let reached = reached.join(WEIGHTS);

--- a/cli/src/adapters/cli.rs
+++ b/cli/src/adapters/cli.rs
@@ -884,16 +884,44 @@ fn missing(what: &str, path: PathBuf) -> Option<String> {
     (!path.is_file()).then(|| format!("no {what} at {}", path.display()))
 }
 
-/// The AlphaFold2 weights, reached through the symlink the install plants in the checkout. An
-/// incomplete database mirror leaves that link dangling, which surfaces only mid-fold otherwise.
+/// The AlphaFold2 weights. A fold reaches them through the checkout, because
+/// `run_pretrained_openfold.py` resolves them relative to the installed `openfold` package and the
+/// install is editable -- so the link the install plants there is what actually has to resolve.
+/// Where they really live is the mirror, or the data directory when there is none, and knowing
+/// which of the two is missing is the difference between "fetch 4 GB" and "replant a symlink".
 fn params_problem() -> Option<String> {
-    let params = config::openfold_home()
-        .join("backends/openfold/openfold/resources/params/params_model_1_ptm.npz");
-    (!params.exists()).then(|| {
-        format!(
+    params_problem_in(
+        &config::openfold_home(),
+        config::af2_root().as_deref(),
+        &config::data_dir(),
+    )
+}
+
+fn params_problem_in(home: &Path, af2_root: Option<&Path>, data_dir: &Path) -> Option<String> {
+    const WEIGHTS: &str = "params/params_model_1_ptm.npz";
+    let reached = home
+        .join("backends/openfold/openfold/resources")
+        .join(WEIGHTS);
+    if reached.exists() {
+        return None;
+    }
+    // The mirror first, then the directory the install downloads into when there is none.
+    let source = [af2_root, Some(data_dir)]
+        .into_iter()
+        .flatten()
+        .map(|root| root.join(WEIGHTS))
+        .find(|path| path.exists());
+    Some(match source {
+        Some(source) => format!(
+            "AlphaFold2 parameters are at {} but the checkout link a fold reads them through is \
+             missing: {}",
+            source.display(),
+            reached.display()
+        ),
+        None => format!(
             "AlphaFold2 parameters missing or a dangling link: {}",
-            params.display()
-        )
+            reached.display()
+        ),
     })
 }
 
@@ -2595,6 +2623,54 @@ mod tests {
 
     /// The checks name config keys as strings; a name outside the schema would report on a value
     /// no install ever writes.
+    /// A fold reads the weights through the checkout, so a missing link there is a real problem
+    /// even when the mirror is intact -- but it is a different problem from having no weights at
+    /// all, and the remedy the user needs differs.
+    #[test]
+    fn params_problem_says_which_half_is_missing() {
+        let base = std::env::temp_dir().join(format!("vizfold-params-{}", std::process::id()));
+        let (home, mirror, data) = (
+            base.join("checkout"),
+            base.join("mirror"),
+            base.join("data"),
+        );
+        let _ = std::fs::remove_dir_all(&base);
+        let reached = home.join("backends/openfold/openfold/resources/params");
+        std::fs::create_dir_all(&reached).unwrap();
+        std::fs::create_dir_all(mirror.join("params")).unwrap();
+
+        // Nowhere at all: the user has 4 GB to fetch.
+        let nothing = params_problem_in(&home, Some(&mirror), &data)
+            .expect("no weights anywhere is a problem");
+        assert!(nothing.contains("missing or a dangling link"), "{nothing}");
+
+        // In the mirror, but the link a fold reads them through is gone: name the mirror.
+        std::fs::write(mirror.join("params/params_model_1_ptm.npz"), "").unwrap();
+        let unlinked =
+            params_problem_in(&home, Some(&mirror), &data).expect("a missing link is a problem");
+        assert!(
+            unlinked.contains(&mirror.display().to_string()),
+            "{unlinked}"
+        );
+        assert!(unlinked.contains("checkout link"), "{unlinked}");
+
+        // No mirror configured, downloaded into the data directory instead.
+        std::fs::create_dir_all(data.join("params")).unwrap();
+        std::fs::write(data.join("params/params_model_1_ptm.npz"), "").unwrap();
+        let downloaded =
+            params_problem_in(&home, None, &data).expect("a missing link is still a problem");
+        assert!(
+            downloaded.contains(&data.display().to_string()),
+            "{downloaded}"
+        );
+
+        // Reachable through the checkout, which is what a fold actually needs.
+        std::fs::write(reached.join("params_model_1_ptm.npz"), "").unwrap();
+        assert!(params_problem_in(&home, Some(&mirror), &data).is_none());
+
+        std::fs::remove_dir_all(&base).ok();
+    }
+
     #[test]
     fn checked_keys_are_all_in_the_schema() {
         let checked = super::CHECKED_PATHS

--- a/cli/src/adapters/cli.rs
+++ b/cli/src/adapters/cli.rs
@@ -884,38 +884,34 @@ fn missing(what: &str, path: PathBuf) -> Option<String> {
     (!path.is_file()).then(|| format!("no {what} at {}", path.display()))
 }
 
-/// The AlphaFold2 weights. A fold reaches them through the checkout, because
-/// `run_pretrained_openfold.py` resolves them relative to the installed `openfold` package and the
-/// install is editable -- so the link the install plants there is what actually has to resolve.
-/// Where they really live is the mirror, or the data directory when there is none, and knowing
-/// which of the two is missing is the difference between "fetch 4 GB" and "replant a symlink".
+/// A fold reads the weights through the checkout: `run_pretrained_openfold.py` resolves them
+/// relative to the installed `openfold` package, and the install is editable. So that link is what
+/// has to resolve -- but naming where they really are is the difference between replanting a
+/// symlink and fetching 4 GB.
 fn params_problem() -> Option<String> {
+    let mirror = config::resolved("OPENFOLD_AF2_ROOT").map(PathBuf::from);
     params_problem_in(
-        &config::openfold_home(),
-        config::af2_root().as_deref(),
-        &config::data_dir(),
+        &config::openfold_home().join("backends/openfold/openfold/resources"),
+        &mirror
+            .into_iter()
+            .chain([config::data_dir()])
+            .collect::<Vec<_>>(),
     )
 }
 
-fn params_problem_in(home: &Path, af2_root: Option<&Path>, data_dir: &Path) -> Option<String> {
+/// `sources` in preference order: the site's mirror, then where the install downloads.
+fn params_problem_in(reached: &Path, sources: &[PathBuf]) -> Option<String> {
     const WEIGHTS: &str = "params/params_model_1_ptm.npz";
-    let reached = home
-        .join("backends/openfold/openfold/resources")
-        .join(WEIGHTS);
+    let reached = reached.join(WEIGHTS);
     if reached.exists() {
         return None;
     }
-    // The mirror first, then the directory the install downloads into when there is none.
-    let source = [af2_root, Some(data_dir)]
-        .into_iter()
-        .flatten()
-        .map(|root| root.join(WEIGHTS))
-        .find(|path| path.exists());
-    Some(match source {
-        Some(source) => format!(
+    let at = sources.iter().map(|r| r.join(WEIGHTS)).find(|p| p.exists());
+    Some(match at {
+        Some(at) => format!(
             "AlphaFold2 parameters are at {} but the checkout link a fold reads them through is \
              missing: {}",
-            source.display(),
+            at.display(),
             reached.display()
         ),
         None => format!(
@@ -2623,51 +2619,34 @@ mod tests {
 
     /// The checks name config keys as strings; a name outside the schema would report on a value
     /// no install ever writes.
-    /// A fold reads the weights through the checkout, so a missing link there is a real problem
-    /// even when the mirror is intact -- but it is a different problem from having no weights at
-    /// all, and the remedy the user needs differs.
     #[test]
-    fn params_problem_says_which_half_is_missing() {
+    fn params_problem_names_where_the_weights_are() {
         let base = std::env::temp_dir().join(format!("vizfold-params-{}", std::process::id()));
-        let (home, mirror, data) = (
+        let _ = std::fs::remove_dir_all(&base);
+        let (reached, mirror, data) = (
             base.join("checkout"),
             base.join("mirror"),
             base.join("data"),
         );
-        let _ = std::fs::remove_dir_all(&base);
-        let reached = home.join("backends/openfold/openfold/resources/params");
-        std::fs::create_dir_all(&reached).unwrap();
-        std::fs::create_dir_all(mirror.join("params")).unwrap();
+        let put = |root: &PathBuf| {
+            std::fs::create_dir_all(root.join("params")).unwrap();
+            std::fs::write(root.join("params/params_model_1_ptm.npz"), "").unwrap();
+        };
+        let sources = [mirror.clone(), data.clone()];
 
-        // Nowhere at all: the user has 4 GB to fetch.
-        let nothing = params_problem_in(&home, Some(&mirror), &data)
-            .expect("no weights anywhere is a problem");
-        assert!(nothing.contains("missing or a dangling link"), "{nothing}");
+        let nowhere = params_problem_in(&reached, &sources).expect("no weights is a problem");
+        assert!(nowhere.contains("missing or a dangling link"), "{nowhere}");
 
-        // In the mirror, but the link a fold reads them through is gone: name the mirror.
-        std::fs::write(mirror.join("params/params_model_1_ptm.npz"), "").unwrap();
-        let unlinked =
-            params_problem_in(&home, Some(&mirror), &data).expect("a missing link is a problem");
+        put(&data);
+        put(&mirror);
+        let unlinked = params_problem_in(&reached, &sources).expect("a missing link is a problem");
         assert!(
             unlinked.contains(&mirror.display().to_string()),
             "{unlinked}"
         );
-        assert!(unlinked.contains("checkout link"), "{unlinked}");
 
-        // No mirror configured, downloaded into the data directory instead.
-        std::fs::create_dir_all(data.join("params")).unwrap();
-        std::fs::write(data.join("params/params_model_1_ptm.npz"), "").unwrap();
-        let downloaded =
-            params_problem_in(&home, None, &data).expect("a missing link is still a problem");
-        assert!(
-            downloaded.contains(&data.display().to_string()),
-            "{downloaded}"
-        );
-
-        // Reachable through the checkout, which is what a fold actually needs.
-        std::fs::write(reached.join("params_model_1_ptm.npz"), "").unwrap();
-        assert!(params_problem_in(&home, Some(&mirror), &data).is_none());
-
+        put(&reached);
+        assert!(params_problem_in(&reached, &sources).is_none());
         std::fs::remove_dir_all(&base).ok();
     }
 

--- a/cli/src/core/config.rs
+++ b/cli/src/core/config.rs
@@ -106,12 +106,6 @@ pub fn default_src() -> PathBuf {
     PathBuf::from(format!("{}/vizfold-src", home_dir()))
 }
 
-/// The site's AlphaFold2 mirror, when one is configured. Where the databases and the parameters
-/// really live; everything under `data_dir` is linked from here.
-pub fn af2_root() -> Option<PathBuf> {
-    resolved("OPENFOLD_AF2_ROOT").map(PathBuf::from)
-}
-
 pub fn data_dir() -> PathBuf {
     resolved("OPENFOLD_DATA_DIR")
         .map(PathBuf::from)

--- a/cli/src/core/config.rs
+++ b/cli/src/core/config.rs
@@ -106,6 +106,12 @@ pub fn default_src() -> PathBuf {
     PathBuf::from(format!("{}/vizfold-src", home_dir()))
 }
 
+/// The site's AlphaFold2 mirror, when one is configured. Where the databases and the parameters
+/// really live; everything under `data_dir` is linked from here.
+pub fn af2_root() -> Option<PathBuf> {
+    resolved("OPENFOLD_AF2_ROOT").map(PathBuf::from)
+}
+
 pub fn data_dir() -> PathBuf {
     resolved("OPENFOLD_DATA_DIR")
         .map(PathBuf::from)


### PR DESCRIPTION
Reported from Delta. `vizfold status` on an install whose mirror holds the parameters:

```
openfold   BROKEN  /work/nvme/bbol/yjayawardana/vizfold/envs/vizfold-openfold
Problems:
  openfold: AlphaFold2 parameters missing or a dangling link:
    /u/yjayawardana/vizfold-src/backends/openfold/openfold/resources/params/params_model_1_ptm.npz

  OPENFOLD_AF2_ROOT = /work/hdd/data/alphafold2/database      <- params are here
```

The check only ever looked at the checkout, so it named a symlink and never the place the weights
actually are — and one message covered two situations whose remedies differ by 4 GB.

It now resolves **`OPENFOLD_AF2_ROOT` first**, then the data directory the install downloads into
when there is no mirror:

| Situation | Message |
|---|---|
| Mirror has them, checkout link missing | `AlphaFold2 parameters are at <mirror>/params/... but the checkout link a fold reads them through is missing: <checkout>/...` |
| Downloaded, no mirror configured | same, naming `<data dir>` |
| Nowhere | `AlphaFold2 parameters missing or a dangling link: <checkout>/...` |

## Why the checkout link still decides whether this is a problem

Worth stating, because "look in the mirror first" could reasonably mean "and stop there":

`scripts/openfold/run_pretrained_openfold.py:542-550` resolves the weights relative to the
*installed* `openfold` package when no `--jax_param_path` is passed — and the seeded profile passes
none. The install is editable (`pip install -e`), so that package **is** the checkout. A fold reads
the weights through `backends/openfold/openfold/resources/params` whatever the config says.

So reporting the mirror as sufficient would produce a status that says `ok` while the fold fails on
a missing checkpoint. The link stays the thing that has to resolve; the mirror is what the message
now names, because that is what tells you whether you are replanting a symlink or fetching 4 GB.

Threading `--jax_param_path` through the invocation profile would remove the dependency on the link
entirely, but re-seeding only ever updates `config_json`, never `parameter_schema_json`, so it would
not reach a single existing install. Noted as a follow-up rather than done here.

`params_problem_in` takes its three roots so both branches are testable without mutating the
environment mid-suite — the pattern `config::gpu_launch` already uses. My first attempt set env vars
and raced `queue_openfold_run_uses_seeded_records` under the parallel test runner.

134 tests, clippy, fmt, the three install suites and `bash -n`. All three messages checked against
the built binary with a reconstructed 19-key config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JeXknd7QzVBysUfuxhuaUz