### PR TITLE
Bump version to 0.6.0

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "executor"
-version = "0.5.5"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "executor"
-version = "0.5.5"
+version = "0.6.0"
 edition = "2024"
 default-run = "vizfold"
 


### PR DESCRIPTION
Releases the lean-down in #129.

Minor rather than patch — in 0.x that is the breaking-change signal, and #129 breaks three things:

- `queue-run` → `queue`, `fold` → `run`; `execute-run`, `--fasta-dir`, `--demo-attn` and `seed` are gone
- `OPENFOLD_DATA_DIR` moves from `<prefix>/data` to `<prefix>/openfold/data`
- release assets are Linux-only by declaration (the darwin name was never published)

## Test plan

- `cargo build` → `vizfold 0.6.0`
- `cargo test` — 133 pass
- Only `cli/Cargo.toml` and `cli/Cargo.lock` change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JeXknd7QzVBysUfuxhuaUz