### PR TITLE
Make the docs describe v0.6.0, and fix the error message that outlived its command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,33 @@
 # Contributing
 
-Work should branch from `main`.
+Branch from `main`, keep commits focused, open a pull request back into `main`.
 
-1. Pull the latest `main`.
-2. Create a feature branch.
-3. Make focused commits.
-4. Open a pull request back into `main`.
+## Run what CI runs
 
+Rust (stable toolchain, edition 2024):
+
+```bash
+cd cli
+cargo fmt --check
+cargo clippy --all-targets -- -D warnings
+cargo test
+```
+
+Shell and config:
+
+```bash
+for f in $(git ls-files '*.sh'); do bash -n "$f"; done
+bash tests/launch_args.sh
+bash tests/site_config.sh   # snapshot of every site's resolved config; -u to accept a change
+bash tests/vocabulary.sh    # rejects env names outside the 19-key config schema
+```
+
+Python is checked with `flake8 . --select=E9,F63,F7,F82`.
+
+## Shell fixes ship on a tag
+
+The installed binary clones this repo pinned to its own release tag, so a change to
+`install.sh`, `lib/`, `sites/` or `backends/*/install/*.sh` does not reach users on
+merge — it needs a version bump and a `v*` tag. The release workflow publishes two
+Linux musl assets (`vizfold-linux-x86_64`, `vizfold-linux-aarch64`); there is no
+darwin build.

--- a/DEMO.md
+++ b/DEMO.md
@@ -1,14 +1,14 @@
 # Folding a protein with the vizfold CLI
 
-This is the full OpenFold lifecycle through the `vizfold` CLI on a cluster: seed the executor,
-queue a sequence, fold it on a GPU, register the outputs, and view them. The commands below are
-from a clean run on **NCSA Delta** (A100); the outputs shown are that run's actual results. Every
-`vizfold` call is the installed binary on your `PATH` — nothing is run from a source checkout.
+The full OpenFold lifecycle through the `vizfold` CLI on a cluster: queue a sequence, fold it on a
+GPU, register the outputs, and view them. The commands below are from a clean run on **NCSA Delta**
+(A100). Every `vizfold` call is the installed binary on your `PATH` — nothing is run from a source
+checkout.
 
 ## Prerequisites
 
-The `vizfold` binary and an installed OpenFold backend. If you have neither, do the two-command
-bootstrap from the [README](README.md#install):
+The `vizfold` binary and an installed OpenFold backend — the two-command bootstrap from the
+[README](README.md#install):
 
 ```bash
 curl -sL https://raw.githubusercontent.com/AI2Science/vizfold-foundation/main/install.sh | bash
@@ -16,7 +16,7 @@ vizfold install openfold
 ```
 
 On Delta the install is dispatched by SLURM `ClusterName`, so it needs no site arguments and takes
-~8 min. When it finishes, `vizfold status` shows every part healthy and a populated config:
+~8 min. Afterwards `vizfold status` shows every part healthy and a populated config:
 
 ```text
 $ vizfold status
@@ -24,8 +24,8 @@ VizFold status
 
 COMPONENT  STATUS  DETAIL
 ---------  ------  ------
-binary     ok      0.5.0 (latest)
-repo       ok      /u/yjayawardana/vizfold-src at v0.5.0
+binary     ok      0.6.0 (latest)
+repo       ok      /u/yjayawardana/vizfold-src at v0.6.0
 config     ok      19 keys
 openfold   ok      /work/nvme/bbol/yjayawardana/vizfold/envs/vizfold-openfold
 esmfold    absent  not installed (/work/nvme/bbol/yjayawardana/vizfold/envs/vizfold-esmfold)
@@ -34,53 +34,35 @@ scheduler  ok      cpu, gpuA100x4-interactive, bbol-delta-cpu, bbol-delta-gpu
 Everything checks out.
 
 Config: /u/yjayawardana/.config/vizfold/vizfold.json
-  ESMFOLD_ENV_PREFIX =
-  OPENFOLD_ACCOUNT = bbol-delta-cpu
-  OPENFOLD_AF2_ROOT = /work/hdd/data/alphafold2/database
-  OPENFOLD_DATA_DIR = /work/nvme/bbol/yjayawardana/vizfold/data
-  OPENFOLD_DRIVER_CUDA = 12.2
-  OPENFOLD_ENV_PREFIX = /work/nvme/bbol/yjayawardana/vizfold/envs/vizfold-openfold
-  OPENFOLD_EXAMPLE = 6KWC_1
+  ...
+  OPENFOLD_DATA_DIR = /work/nvme/bbol/yjayawardana/vizfold/openfold/data
   OPENFOLD_GPU_ACCOUNT = bbol-delta-gpu
-  OPENFOLD_GPU_GRES = gpu:1
   OPENFOLD_GPU_PARTITION = gpuA100x4-interactive
-  OPENFOLD_GPU_RESOURCES = --cpus-per-task=8 --mem=32G
   OPENFOLD_GPU_TIME = 01:00:00
   OPENFOLD_HOME = /u/yjayawardana/vizfold-src
-  OPENFOLD_MAX_CUDA = 12.8
-  OPENFOLD_PARTITION = cpu
   OPENFOLD_PREFIX = /work/nvme/bbol/yjayawardana/vizfold
-  OPENFOLD_SITE = delta
-  VIZFOLD_DB = /work/nvme/bbol/yjayawardana/vizfold/vizfold.db
-  VIZFOLD_ENV_BASE = /work/nvme/bbol/yjayawardana/vizfold/envs
+  ...
   database = /work/nvme/bbol/yjayawardana/vizfold/vizfold.db (present)
 ```
 
-That key set is fixed: every cluster and either backend writes the same names, and a name this
-install did not settle (`ESMFOLD_ENV_PREFIX` above) is written empty, which
-every reader treats as unset. The values are resolved live during install — on Delta the prefix and
-data directory land under your `/work/nvme` allocation. Everything after this point reads them from
-`vizfold.json`.
+The key set is fixed at 19 keys; a value this install did not settle is written empty and reads as
+unset. Anything unhealthy is listed under `Problems:` with the command that fixes it.
 
-`status` leads with the health of each part rather than only reporting the config; anything wrong
-is listed under `Problems:` with the command that fixes it.
-
-## 1. Inspect the executor records
-
-Queueing a run seeds the catalog for you — the OpenFold backend, the local execution target, and the
-invocation profile that ties them together. Inspect what it created:
+## The short version
 
 ```bash
-vizfold list models
-vizfold list targets
-vizfold list profiles
+vizfold list examples
+vizfold run 6KWC_1
 ```
 
-## 2. Queue a run
+`vizfold run` takes a bundled example id, a path to a FASTA, or a queued run's id; given either of
+the first two it queues the run itself. That is the line `vizfold install openfold` prints on
+success. The rest of this page takes that apart.
 
-Queue the bundled example, 6KWC (a 191-residue monomer). On a cluster install the input paths all
-default off the config and the checkout examples, and the sequence is read from the FASTA, so the
-id is the only flag you need:
+## 1. Queue a run
+
+Queue the bundled example, 6KWC (a 191-residue monomer). On a cluster install every input path
+defaults off the config and the checkout examples, so the id is the only flag you need:
 
 ```bash
 vizfold queue openfold --input-id 6KWC_1
@@ -107,26 +89,34 @@ What the omitted flags default to (all overridable — see `vizfold queue openfo
 | `--model-device` | `cuda:0` — a GPU partition is configured, so the fold will `srun` onto a GPU node |
 | `--use-precomputed-alignments` | `true` — reuse `alignment-dir/6KWC_1`, skipping the MSA search |
 
-The id and the sequence both come from the FASTA's header record, so they cannot disagree with what
-is folded; pass `--fasta <path>` to fold one of your own and `--input-id` becomes optional. The
-queue step canonicalizes and stores absolute paths in the run record, so all inputs must be present
-when you queue.
+The sequence is always read from the FASTA; `--input-id` only names the run, and preflight rejects
+it when it does not match the FASTA's header tag. Pass `--fasta <path>` to fold one of your own.
+Queue canonicalizes and stores absolute paths, so every input must exist at queue time.
 
-## 3. Execute the run
+Queueing also seeds the catalog — the OpenFold backend, the local execution target, and the
+invocation profile tying them together. Inspect what it created with `vizfold list models`,
+`vizfold list targets`, and `vizfold list profiles`.
+
+## 2. Execute the run
 
 ```bash
 vizfold run 1
 ```
 
-`fold` prints each preflight check — the `gpu` one warns because the login node has none —
-then, because a GPU partition is configured but no allocation is held, wraps the OpenFold command
-in the srun `vizfold.json` describes:
-`srun -A bbol-delta-gpu -p gpuA100x4-interactive --gres=gpu:1 --cpus-per-task=8 --mem=32G -t 01:00:00`,
-streams its logs, and reports the final status. On Delta the fold itself took ~78 s on one A100
-(a queue wait shows first as `srun: job N queued and waiting for resources`).
+A GPU partition is configured and no allocation is held, so the OpenFold command is wrapped in the
+srun `vizfold.json` describes:
+
+```bash
+srun -A bbol-delta-gpu -p gpuA100x4-interactive --gres=gpu:1 --cpus-per-task=8 --mem=32G -t 01:00:00
+```
+
+Its output streams as it comes (a queue wait shows first as `srun: job N queued and waiting for
+resources`); the preflight report and the final status print after it finishes. The `gpu` check
+warns because the login node has none.
 
 ```text
 Executing run 1
+... OpenFold's own output streams here ...
 
 Preflight: passed
 [warning] gpu: no GPU visible; the run will fall back to CPU
@@ -138,13 +128,15 @@ Preflight: passed
 [passed] fasta_dir: '/u/yjayawardana/vizfold-src/examples/monomer/fasta_dir_6KWC' contains one FASTA file with tag '6KWC_1' matching run input_id
 ...
 
+Command exit_code: 0
+
 Final status: completed
 
 Run 1 completed in 78s. View it with: vizfold serve
 ```
 
-Verify the structure directly — a relaxed 6KWC prediction is 2839 atoms, and `--attn` wrote
-one text trace per layer/head:
+Verify the structure directly — a relaxed 6KWC prediction is 2839 atoms, and `--attn` wrote one
+text trace per layer/head:
 
 ```bash
 $ grep -c '^ATOM' /work/nvme/bbol/yjayawardana/vizfold/runs/1/predictions/6KWC_1_model_1_ptm_relaxed.pdb
@@ -154,33 +146,23 @@ $ ls /work/nvme/bbol/yjayawardana/vizfold/runs/1/attention | wc -l
 ```
 
 Outputs land in the run workspace `$OPENFOLD_PREFIX/runs/<run-id>`: `predictions/` (relaxed and
-unrelaxed PDBs, `timings.json`) and, with `--attn`, `attention/`.
+unrelaxed PDBs, `timings.json`) and `attention/`. An OpenFold run always creates `attention/`;
+`--attn=false` only leaves it empty.
 
-## 4. Register artifacts
+## 3. Register artifacts
 
-`fold` already did this — a completed run whose outputs were never registered is invisible
-to the workbench, so registration rides along with execution. The command remains for re-running it
-against a run whose outputs appeared later; it is idempotent and reports what is already present.
+`vizfold run` already did this — a completed run whose outputs were never registered is invisible to
+the workbench, so registration rides along with execution. The command remains for a run whose
+outputs appeared later:
 
 ```bash
 vizfold register-artifacts 1
 ```
 
-```text
-Registered artifacts for run 1
-
-Output workspace:
-  /work/nvme/bbol/yjayawardana/vizfold/runs/1
-
-Artifacts:
-  [registered] run_output_directory -> /work/nvme/bbol/yjayawardana/vizfold/runs/1
-  [registered] attention_output_directory -> /work/nvme/bbol/yjayawardana/vizfold/runs/1/attention
-```
-
-Registration never blocks a partial run — if a run failed it warns and registers only the
+It is idempotent, and it never blocks a partial run: if a run failed it warns and registers only the
 directories that actually exist.
 
-## 5. Inspect the run
+## 4. Inspect the run
 
 ```bash
 vizfold show run 1
@@ -205,7 +187,7 @@ ID  TYPE ID  FORMAT     STORAGE URI
 
 `vizfold list runs` (optionally `--status completed`) lists all runs.
 
-## 6. View it in the dashboard
+## 5. View it in the dashboard
 
 ```bash
 vizfold serve
@@ -222,8 +204,8 @@ ssh -L 3000:localhost:3000 <you>@delta.ncsa.illinois.edu
 
 ## Driving the model directly
 
-Everything above goes through the executor, which fills the model's arguments in from the config
-and records the run. To use the backend on its own instead, run its CLI inside its environment —
+Everything above goes through the executor, which fills the model's arguments in from the config and
+records the run. To use the backend on its own instead, run its CLI inside its environment —
 `vizfold install openfold` prints this line:
 
 ```bash
@@ -231,12 +213,10 @@ and records the run. To use the backend on its own instead, run its CLI inside i
   run -p /work/nvme/bbol/yjayawardana/vizfold/envs/vizfold-openfold openfold --help
 ```
 
-`micromamba run -p` applies the environment's activation hooks — `CUTLASS_PATH`, the library
-paths, `OPENFOLD_DATA_DIR`, and the NVRTC `LD_PRELOAD` where the install pinned one — so the model
-sees exactly what it sees under `vizfold run`, which runs it the same way. That is the model's own
-CLI, so every path is yours to pass: the databases, the alignment directory, the output directory.
-ESMFold is the same command against its own environment. Neither needs the `vizfold` binary on
-your `PATH`.
+`run -p` applies the environment's `activate.d` hook — `CUTLASS_PATH`, `OPENFOLD_DATA_DIR`, the
+library paths, and the NVRTC `LD_PRELOAD` where the install pinned one — which is exactly how
+`vizfold run` invokes it. Every path is then yours to pass. ESMFold is the same command against its
+own environment; neither needs the `vizfold` binary on your `PATH`.
 
 ## Common failure modes
 
@@ -255,14 +235,13 @@ The executor checks that the FASTA header-derived tag matches the run `input_id`
 
 With `--use-precomputed-alignments=true` (the default), the directory `alignment-dir/<input-id>`
 must exist — for the example, `examples/monomer/alignments/6KWC_1`. Pass
-`--use-precomputed-alignments=false` to run the full MSA search instead (much slower; needs the
-full databases).
+`--use-precomputed-alignments=false` to run the full MSA search instead (much slower; needs the full
+databases).
 
 ### `srun: Requested time limit is invalid` / `Invalid account or account/partition combination`
 
-The GPU partition and time cap come from the site profile
-(`sites/<ClusterName>.json`); the account is not in that file — it is
-worked out during the install (on Delta, `slurm::nvme_alloc` names it from the allocation plus a
-`-delta-gpu` suffix). All three are written to `vizfold.json`. If you override any
-`OPENFOLD_GPU_*` value, keep it within the partition's limits (on Delta,
-`gpuA100x4-interactive` caps at `01:00:00`).
+The GPU partition and time cap come from the site profile (`sites/<ClusterName>.json`); the account
+is worked out during the install instead (on Delta, `slurm::nvme_alloc` names it from the allocation
+plus a `-delta-gpu` suffix). All three are written to `vizfold.json`. If you override any
+`OPENFOLD_GPU_*` value, keep it within the partition's limits (on Delta, `gpuA100x4-interactive`
+caps at `01:00:00`).

--- a/README.md
+++ b/README.md
@@ -1,47 +1,39 @@
 # Vizfold Foundations
 
-Vizfold is a platform for running protein-structure models and inspecting what they compute:
+Vizfold runs protein-structure models and keeps what they compute on the way: intermediate
+activations and per-layer, per-head attention maps, ready to explore.
 
-1. Model inference & feature extraction: Run protein structure prediction models and extract intermediate activations (hidden representations) and attention maps from any chosen layer.
-2. Visualization & analysis: Explore, visualize, and analyze the extracted activations and attention maps.
-
-The `vizfold` CLI is the platform; a model backend plugs in underneath it. Install one with
-`vizfold install <backend>` — **OpenFold** (the full cluster install: micromamba env, CUDA
-extension build, AlphaFold2 databases) or **ESMFold** (a lightweight environment with its own
-Python, PyTorch and Transformers, weights pulled from HuggingFace at run time). `vizfold status` shows the resolved
-config and the health of every part of the install. Each backend is a pip/conda-installable package under
-`backends/<name>/` with its own environment and installer, so others (openfold3, boltz) slot in
-the same way as they land.
+The `vizfold` CLI is the platform; a model backend — a pip/conda-installable package under
+`backends/<name>/` with its own environment and installer — plugs in underneath. **OpenFold** is
+the full cluster install (micromamba env, CUDA extension build, AlphaFold2 databases); **ESMFold**
+is lighter, with its own Python, PyTorch and Transformers and weights pulled from HuggingFace at
+run time.
 
 ---
 
 ## Install
 
-Two steps on a cluster. First bootstrap the `vizfold` CLI — one command, needs nothing from you:
+Releases are Linux only, x86_64 or aarch64. Two steps on a cluster. First bootstrap the CLI:
 
 ```bash
 curl -sL https://raw.githubusercontent.com/AI2Science/vizfold-foundation/main/install.sh | bash
 ```
 
-That downloads the prebuilt `vizfold` binary for your architecture from the latest GitHub
-release and installs it to `~/.local/bin` (set `VIZFOLD_VERSION=vX.Y.Z` to pin a release). Then
-install a backend — OpenFold below, or the lighter `vizfold install esmfold` (see
-[docs/esmfold.md](docs/esmfold.md)):
+That fetches the prebuilt binary for your architecture from the latest GitHub release into
+`~/.local/bin` (set `VIZFOLD_VERSION=vX.Y.Z` to pin a release). Then a backend — OpenFold below,
+or `vizfold install esmfold` (see [docs/esmfold.md](docs/esmfold.md)):
 
 ```bash
 vizfold install openfold
 ```
 
-`vizfold install <backend>` clones the matching checkout to `$HOME/vizfold-src` on first run (the binary
-ships only itself; the `install/` scripts and dashboard come from there), works out where it is
-running, picks the site, submits the OpenFold install to the scheduler, and prints the exact
-command to fold a test sequence. Cold: ~8 min on NCSA Delta, ~25 min where the AlphaFold
-databases have to be downloaded.
+The binary ships only itself, so `install` clones the matching checkout to `$HOME/vizfold-src` on
+first run for the installer scripts and the dashboard. Cold: ~8 min on NCSA Delta, ~25 min where
+the AlphaFold databases have to be downloaded.
 
-`vizfold install openfold` holds your terminal and streams every step of the install as it happens. On a
-cluster it runs as a blocking `srun` job, so a queue wait shows as
-`srun: job N queued and waiting for resources`. Use `tmux` or `screen` for long installs — if the
-connection drops, re-run `vizfold install openfold` and it continues from the last completed step.
+It holds your terminal and streams every step. On a cluster it runs as a blocking `srun` job, so a
+queue wait shows as `srun: job N queued and waiting for resources`. Use `tmux` or `screen` for long
+installs — if the connection drops, re-run it and it continues from the last completed step.
 
 To keep a log, wrap the whole command rather than piping it:
 
@@ -54,51 +46,49 @@ meters and makes the output arrive in delayed bursts.
 
 ### Keeping it current
 
-An install is two halves: the `vizfold` binary and the checkout it runs the installers, scripts and
-dashboard from, pinned to the binary's own release tag. `vizfold --version` says which release this
-binary is, and `vizfold status` says whether it is the latest.
+An install is two halves: the `vizfold` binary and the checkout it runs the installers and
+dashboard from, pinned to the binary's own release tag.
 
 ```bash
 vizfold self-update      # replace the binary with the newest release, then bring its checkout along
 vizfold update           # move the checkout to this binary's tag (clones it if there is none)
 ```
 
-`self-update` downloads the release asset for your platform, refuses to install one that will not
-run, and swaps it in place. It then runs `vizfold update`, because a new binary on an old checkout
-runs the old install scripts — which `status` reports as a broken `repo` if the two ever drift.
-`vizfold update --ref <tag-or-branch>` moves the checkout somewhere else; it refuses to touch a
-checkout with uncommitted changes.
+`self-update` runs `vizfold update` afterwards because a new binary on an old checkout runs the old
+install scripts — which `status` reports as a broken `repo` if the two ever drift. `vizfold update
+--ref <tag-or-branch>` moves the checkout somewhere else; it refuses to touch a checkout with
+uncommitted changes.
 
 ### Uninstall
 
-```bash
-vizfold uninstall
-```
-
-Lists everything the install generated — every environment, micromamba itself, and the
-rest of the install prefix, the package caches beside it, the symlinks and build droppings it left in the checkout,
-the run database, the checkout it cloned into `$HOME/vizfold-src`, and
-`~/.config/vizfold/vizfold.json` — then removes it once you confirm (`--yes` skips the prompt).
-Fold outputs under the prefix, a checkout you pointed it at yourself with `OPENFOLD_HOME`, and the `vizfold` binary
-are left alone; drop the binary with `rm ~/.local/bin/vizfold`.
-
-Name a backend to remove only that one:
+Everything a backend plants is its environment plus one state dir under the prefix,
+`<prefix>/<backend>/` — `cutlass`, the `nvrtc-<ver>` side prefixes, the `pkgs`/`pip`/`tmp` caches,
+the `.done` sentinel, and by default `data/`. Removing one backend is that pair, plus the build
+droppings its `pip install` left in the checkout:
 
 ```bash
 vizfold uninstall openfold
 ```
 
-This takes that backend's environment and everything its own installer created — for OpenFold
-CUTLASS, the staged databases, the NVRTC side prefixes, the package caches, and the links and
-build droppings in its subtree — and nothing else. The config, the run database, the checkout,
-micromamba (which every environment shares), and any other backend stay, so
-`vizfold install openfold` puts it back where it was.
+The config, the run database, the checkout, micromamba (shared by every environment) and any other
+backend stay, so `vizfold install openfold` puts it back where it was.
+
+```bash
+vizfold uninstall
+```
+
+With no backend named it takes every backend and, on top, the workbench environment, micromamba
+and its root, `vizfold.db`, `~/.config/vizfold/vizfold.json`, the staged workbench, and the
+checkout vizfold cloned into `$HOME/vizfold-src`. It lists what it will remove and asks first
+(`--yes` skips the prompt). Fold outputs, a checkout you pointed it at yourself with
+`OPENFOLD_HOME`, and the `vizfold` binary are left alone; drop the binary with
+`rm ~/.local/bin/vizfold`.
 
 ### Supported clusters
 
 Dispatch is on the SLURM `ClusterName`, so on these machines `vizfold install openfold` needs no
-site arguments. Accounts and the install prefix are worked out live (your project space, the
-accounts you can charge); the values below are what a fresh install settles on.
+site arguments. Accounts and the install prefix are worked out live; the values below are what a
+fresh install settles on.
 
 | `ClusterName` (cluster) | Verified | Arch | AF2 databases | Build → fold partition (GPU) | Install prefix |
 | --- | --- | --- | --- | --- | --- |
@@ -111,34 +101,28 @@ accounts you can charge); the values below are what a fresh install settles on.
 | `ice-slurm` (GT PACE ICE) | ⚙️ profile | x86-64 | mirror¹ | `ice-cpu` → `ice-gpu` (A100) | `<scratch>/vizfold` (`/storage/ice1/…`) |
 | `phoenix-slurm` (GT PACE Phoenix) | ⚙️ profile | x86-64 | mirror¹ | `cpu-small` → `gpu-a100` (A100) | `<scratch>/vizfold` (`/storage/scratch1/…`) |
 
-Legend — ✅ install + fold verified end-to-end from `vizfold install` (fold → 2839-atom relaxed
-structure); ◐ install run on the cluster with its site-specific fixes, final fold not re-confirmed
-in this pass⁵; ⚙️ site profile written and its paths probed live, full install not yet run.
+✅ verified end-to-end from `vizfold install`; ◐ installed on the cluster, final fold not
+re-confirmed in this pass; ⚙️ site profile written and its paths probed live, no install run yet.
 
-1. AF2 mirrors: Delta & Delta-AI (shared `/work/hdd`) `/work/hdd/data/alphafold2/database`,
-   Phoenix `/storage/coda1/ice1/shared/d-pace_community/alphafold/alphafold_2.3.2_data`, ICE
+1. AF2 mirrors: Delta & Delta-AI (shared `/work/hdd`) `/work/hdd/data/alphafold2/database`, Phoenix
+   `/storage/coda1/ice1/shared/d-pace_community/alphafold/alphafold_2.3.2_data`, ICE
    `/storage/ice1/shared/d-pace_community/…`, Bridges-2 `/ocean/datasets/community/alphafold/v2.3.2`,
-   Nexus `/media/volume/nexus-staging-slurm-data/database`.
-   Each mirror lays out `uniclust30` differently (real single- or double-nested set, or none), so
-   the install stages it into a canonical dir — real set if present, else aliased from uniref30.
-   Where there is no mirror the install downloads the ~4 GB parameters + the example's templates.
-2. Delta and Delta-AI share `/work/nvme`, so the aarch64 site uses an `-gh` suffix — otherwise the
+   Nexus `/media/volume/nexus-staging-slurm-data/database`. Each lays out `uniclust30` differently,
+   so the install stages it into a canonical dir — real set if present, else aliased from uniref30.
+   With no mirror the install downloads the ~4 GB parameters + the example's templates.
+2. Delta and Delta-AI share `/work/nvme`, so the aarch64 site uses a `-gh` suffix — otherwise the
    two architectures' environments would clobber each other.
 3. The aarch64 conda OpenMM ships no CUDA platform, so relaxation falls back to CPU (~15 s for the
    example) and yields the same structure as the x86 CUDA path.
 4. Nexus's 535 driver is older than the env's NVRTC, so the install pins a matching NVRTC via
    `LD_PRELOAD`; the 10 GB vGPU gets the smaller `1UBQ_1` example. CUDA is capped at 12.8 on every
    x86 site and 12.9 on aarch64 (the 13.x build won't compile OpenFold's extension).
-5. `◐` detail — nexus: cold-start install completed this session, NVRTC-pinned relaxation confirmed
-   in earlier runs, though that run predates the mirror and no install has yet been run against
-   `OPENFOLD_AF2_ROOT` there; anvil: install reached the dataset stage (fixed a conda-libcurl mmCIF bug),
-   A100 fold queue-bound; bridges2: build + fold ran through to relaxation (memory / gcc / CUDA-arch
-   / NVRTC fixes applied).
+5. `◐` installs each needed a site-specific fix: nexus an NVRTC pin, anvil a conda-libcurl mmCIF
+   workaround, bridges2 memory / gcc / CUDA-arch / NVRTC adjustments.
 
 ### Settings
 
-Three layers, highest first. Each only fills what the one above left unset, so you override
-exactly what you care about and nothing else:
+Three layers, highest first. Each only fills what the one above left unset:
 
 | | | |
 | --- | --- | --- |
@@ -151,10 +135,12 @@ the newest release, the checkout, the config, each backend, and the scheduler �
 those layers settled on below it:
 
 ```text
+VizFold status
+
 COMPONENT  STATUS  DETAIL
 ---------  ------  ------
-binary     ok      0.5.3 (latest)
-repo       ok      /u/you/vizfold-src at v0.5.3
+binary     ok      0.6.0 (latest)
+repo       ok      /u/you/vizfold-src at v0.6.0
 config     ok      19 keys
 openfold   BROKEN  /work/nvme/bbol/you/vizfold/envs/vizfold-openfold
 esmfold    absent  not installed (/work/nvme/bbol/you/vizfold/envs/vizfold-esmfold)
@@ -167,28 +153,22 @@ Problems:
 1 of 6 components need attention: openfold.
 ```
 
-It checks that the config holds exactly the keys this binary reads (one written by an older install
-says so instead of failing later), that every path it names is there, that each installed backend's
-environment and inputs are intact, and that the scheduler recognises the accounts and partitions.
-What it cannot check here — no scheduler on this host — is `unverified`, and a backend nobody
-installed is `absent`; neither counts against the install.
+It checks that the config holds exactly the keys this binary reads, that every path it names is
+there, that each installed backend's environment and inputs are intact, and that the scheduler
+recognises the accounts and partitions. What it cannot check here — no scheduler on this host — is
+`unverified`, and a backend nobody installed is `absent`; neither counts against the install.
 
-Every environment the install creates lives in one base directory under a fixed name:
-`$VIZFOLD_ENV_BASE/vizfold-<backend>`, defaulting to `<prefix>/envs`. That is
-`vizfold-openfold`, `vizfold-workbench` and `vizfold-esmfold` — same directory,
-same shape, so nothing has to be told where any of them is. `vizfold::env` in `lib/config.sh` and
-`env_dir()` in `cli/src/core/config.rs` are the two definitions, and each names the other.
-
-Move them all with `VIZFOLD_ENV_BASE`. An install predating the env base keeps working untouched:
-it recorded absolute `OPENFOLD_ENV_PREFIX`/`ESMFOLD_ENV_PREFIX` values, and those still outrank the
-derived paths.
+Two paths worth knowing. Environments live at `$VIZFOLD_ENV_BASE/vizfold-<backend>`, defaulting to
+`<prefix>/envs` (`vizfold::env` in `lib/config.sh`, mirrored by `env_dir()` in
+`cli/src/core/config.rs`); an install predating the env base recorded absolute
+`OPENFOLD_ENV_PREFIX`/`ESMFOLD_ENV_PREFIX` values, which still outrank it. OpenFold's data — search
+databases, templates, and the AlphaFold2 weights at `params/params_<preset>.npz` — lands in
+`$OPENFOLD_DATA_DIR`, defaulting to `<prefix>/openfold/data`.
 
 A `<site>.json` carries only what the site does differently, and templates paths off `$VAR`
-references resolved recursively (`$VAR` against the environment first, then other keys in the same
-file). Anything a default already covers is left out, so what remains is the site's actual facts.
+references resolved recursively against the environment first, then other keys in the same file.
 The site's `<site>.sh` discovers the one login-specific atom the templates need — the allocation,
-the SLURM account, or `OPENFOLD_BASE` (the install directory).
-`sites/delta.json`:
+the SLURM account, or `OPENFOLD_BASE` (the install directory). `sites/delta.json`:
 
 ```json
 {
@@ -202,25 +182,9 @@ the SLURM account, or `OPENFOLD_BASE` (the install directory).
 
 Five keys, all of them things only Delta knows. `delta.sh` discovers `$OPENFOLD_ALLOCATION` with
 `slurm::nvme_alloc -delta-cpu -delta-gpu`, which both picks the `/work/nvme` allocation and names
-the two accounts from those suffixes — so a suffix is written once, not restated as a
-`$OPENFOLD_ALLOCATION-delta-cpu` template here. The install prefix defaults to `$OPENFOLD_BASE/vizfold`
+the two accounts from those suffixes. The install prefix defaults to `$OPENFOLD_BASE/vizfold`
 (`slurm::default_prefix`); only `delta-gh.json` overrides it, because Grace-Hopper shares
 `/work/nvme` with x86 Delta and the two must not share an env.
-
-`sites/nexus-dev.json` — its GPU is a 10 GB vGPU, hence the smaller
-example and memory. Setting `OPENFOLD_AF2_ROOT`
-is what makes the install link the staged databases instead of downloading the parameters itself:
-
-```json
-{
-  "OPENFOLD_AF2_ROOT": "/media/volume/nexus-staging-slurm-data/database",
-  "OPENFOLD_BUILD_TIME": "01:00:00",
-  "OPENFOLD_EXAMPLE": "1UBQ_1",
-  "OPENFOLD_GPU_PARTITION": "gpu",
-  "OPENFOLD_GPU_RESOURCES": "--cpus-per-task=8 --mem=24G",
-  "OPENFOLD_PARTITION": "gpu"
-}
-```
 
 A mirror is all-or-nothing: with `OPENFOLD_AF2_ROOT` set the install stops fetching parameters and
 templates, so the root must also carry `params/` and `pdb_mmcif/mmcif_files` alongside the search
@@ -233,59 +197,55 @@ OPENFOLD_EXAMPLE=1UBQ_1 OPENFOLD_GPU_PARTITION=gpuA100x4 vizfold install openfol
 ```
 
 Every value the install settles on — fully expanded — is written to
-`~/.config/vizfold/vizfold.json`, so other tools can read where things ended up instead of guessing.
-
-That file has a fixed shape. The same binary reads it on every cluster, so it holds the same keys
-on every cluster: the schema is `VIZFOLD_CONFIG_KEYS` in `lib/config.sh`, and a name the install
-did not settle is written empty rather than left out.
-
-A name belongs in the schema when the install **settles** it and something **later** needs it —
-those two conditions, and no others. So the build partition is in it (the install chose one) while
-`OPENFOLD_BUILD_MEM` is not (a re-install re-reads the same `<site>.json`); the fold's output
-directory is not (it belongs to one run, not to the install); and `VIZFOLD_CONFIG`, which selects
-*which* config to read, cannot be. Nothing the binary resolves may sit outside the schema, and
-nothing a `<site>.json` sets may go unconsumed — `tests/vocabulary.sh` enforces both, and
-that every `$VAR` in a site value is provided by something rather than expanding to empty. Empty means unset everywhere that reads it —
-`${VAR:-default}` in bash, `non_empty` in `cli/src/core/config.rs` — so an unsettled key falls
-through to the same default a missing one would, and never masks a `<site>.json` value beneath it.
-Both backends save the whole schema, so installing one after the other rewrites the shared keys
-instead of dropping the ones it doesn't know about.
+`~/.config/vizfold/vizfold.json`, a fixed 19-key schema (`CONFIG_KEYS` in `cli/src/core/config.rs`,
+`VIZFOLD_CONFIG_KEYS` in `lib/config.sh`) identical on every cluster. A key the install did not
+settle is written empty rather than left out, and empty means unset everywhere that reads it. A
+name belongs in the schema when the install settles it *and* something later needs it;
+`tests/vocabulary.sh` enforces that, and that nothing a `<site>.json` sets goes unconsumed.
 
 ### Adding a cluster
 
-Two files in `sites/`, named after the cluster's SLURM `ClusterName`: `<name>.sh` — a
-single `slurm::discover` that exports the one login-specific atom — and `<name>.json`, which
-declares what differs from the defaults and templates paths off that atom (and `$USER`). `vizfold
-install openfold` (via `backends/openfold/install/install.sh`) dispatches on the name `slurm::cluster` returns — `SLURM_CLUSTER_NAME`, else `scontrol`, else `ClusterName` in `slurm.conf`, lower-cased — so nothing else needs to change.
+Two files in `sites/`, named after the cluster's SLURM `ClusterName`: `<name>.sh` — a single
+`slurm::discover` that exports the one login-specific atom — and `<name>.json`, which declares what
+differs from the defaults and templates paths off that atom (and `$USER`). `vizfold install
+openfold` (via `backends/openfold/install/install.sh`) dispatches on the name `slurm::cluster`
+returns — `SLURM_CLUSTER_NAME`, else `scontrol`, else `ClusterName` in `slurm.conf`, lower-cased —
+so nothing else needs to change.
 
-Write only what the cluster actually determines. `tests/site_config.sh` resolves every site
-end to end and snapshots the result, so a key that changes nothing shows up as removable — and a
-key that changes something shows up in the diff. Run it after editing any site file, and
-`-u` to accept an intended change.
+Write only what the cluster actually determines. `tests/site_config.sh` resolves every site end to
+end and snapshots the result, so a key that changes nothing shows up as removable — and a key that
+changes something shows up in the diff. Run it after editing any site file, and `-u` to accept an
+intended change.
 
 ---
 
 ## Commands
 
-`vizfold <command>`. After a backend is installed, folding a bundled example is one command —
-`fold <example-id>` queues it, runs it, and registers its outputs. A sequence of your own is the
-same command with a path: `run ./my.fasta`. `queue` records a run without executing it, and
-`fold` takes the id it prints. `serve` opens the dashboard
-over the outputs. `vizfold <command> --help` details any one.
+Once a backend is installed, one command folds:
+
+```bash
+vizfold run 1UBQ_1          # a bundled example id
+vizfold run ./my.fasta      # a sequence of your own
+vizfold run 42              # a queued run, by id
+```
+
+`run` queues the target, executes it, and registers its outputs. `queue openfold|esmfold` records a
+run without executing it and prints the id to hand back to `run`. `serve` opens the dashboard over
+the outputs. `vizfold <command> --help` details any one.
 
 ```text
-install                  Install a model backend (openfold or esmfold) on this machine
-download                 Download a backend's data (OpenFold AlphaFold2 databases/params)
-status                   Show resolved config, installed backends, and whether it all checks out
-uninstall                Remove one backend (uninstall <backend>), or the whole install
-update                   Move the checkout to this binary's release tag
-self-update              Replace this binary with the latest release, checkout included
-queue                    Queue a run for a backend, without executing it (queue openfold|esmfold ...)
-run <target>             Run a fold: a bundled example, a FASTA, or a queued run by id
-register-artifacts <id>  Re-register a run's artifacts (run already does)
-list                     List records (list examples|models|targets|profiles|runs)
-show                     Show one executor record (show run <id>)
-serve                    Start the workbench dashboard
+install             Install a model backend (openfold or esmfold) on this machine
+download            Download a backend's data (OpenFold AlphaFold2 databases/params)
+status              Show resolved config, which backends are installed, and whether it all checks out
+uninstall           Remove one backend, or everything the install generated
+update              Update the vizfold checkout the installers and dashboard come from
+self-update         Replace this binary with the latest release, then update the checkout to match
+serve               Start the workbench dashboard
+list                List executor records
+show                Show one executor record
+queue               Queue a run for a supported model backend, without executing it
+run                 Run a fold: a bundled example, a FASTA, or a queued run by id
+register-artifacts  Register known artifacts for a completed run
 ```
 
 `vizfold list examples` shows what folds without an MSA search — the bundled monomers whose
@@ -304,25 +264,33 @@ ID      RESIDUES  DESCRIPTION
 The dashboard drives the same path: pick one of these in **Fold a protein** and it queues,
 executes, and registers the run for you.
 
-For a full end-to-end walkthrough on a cluster — queue a sequence, fold it on a GPU, register
-and view the outputs, with real commands and results — see [DEMO.md](DEMO.md).
+For a full end-to-end walkthrough on a cluster, see [DEMO.md](DEMO.md).
 
 ---
 
 ## Development
 
-The repository is laid out as:
+- `cli/` — the Rust `vizfold` CLI and executor core (SeaORM entities, migrations, services, seed).
+- `workbench/` — a Next.js dashboard reading the executor's SQLite read-only: a 3D viewer for
+  predicted PDBs plus the attention-map images.
+- `backends/<name>/` — one package per backend: Python package, packaging metadata, environment
+  spec, env-provisioning installer (`install/`). `openfold` installs as `import openfold` (conda
+  env, CUDA extension); `esmfold` as `import esmfold` (own Python, no CUDA build).
+- `downloaders/<name>/` — data-download scripts; `downloaders/openfold/` holds the AlphaFold2
+  fetchers behind `vizfold download openfold`. ESMFold has none — HuggingFace at run time.
+- `scripts/<name>/` — the model entrypoints the executor runs (`run_pretrained_*.py`), importing
+  their backend by module from the installed env.
+- `lib/` — backend-neutral install machinery (`config.sh`, `slurm.sh`, `interactive.sh`). `sites/` —
+  one `<ClusterName>.sh`/`.json` pair per cluster. `tests/` — install-side test suites.
+- `docs/` — architecture notes and backlog. `examples/` — inputs, attention-viz utilities, notebooks.
 
-- `cli/` — the Rust `vizfold` CLI and executor core (SeaORM entities, migrations, services, and seed). This is the primary active implementation path.
-- `workbench/` — a Next.js dashboard that reads the executor's SQLite directly (read-only) and renders each run's outputs: an interactive 3D structure viewer for predicted PDBs plus the attention-map images.
-- `backends/<name>/` — one pip/conda-installable package per model backend: its Python package, packaging metadata, environment spec, and env-provisioning installer (`install/`). `backends/openfold/` installs as `import openfold` (conda env, CUDA extension; its dataprep/training tooling is the installed `openfold.scripts` subpackage); `backends/esmfold/` as `import esmfold` (micromamba env with its own Python, no CUDA build).
-- `downloaders/<name>/` — data-download scripts. `downloaders/openfold/` holds the AlphaFold2 database/params fetchers (`vizfold download openfold`); ESMFold has none — it pulls weights from HuggingFace at run time.
-- `scripts/<name>/` — the model entrypoints the executor runs (`run_pretrained_*.py`). Each imports its backend **by module** from the installed env — no relative paths, no cross-backend dependencies.
-- Each backend's package installs its own CLI into its environment as `<name>` (also `python -m <name>`), usable without the `vizfold` binary. Through vizfold, `queue`/`fold` are the way in — they fill the model's arguments from the config and record the run.
-- `lib/` — the backend-neutral shared install machinery (`config.sh`, `slurm.sh`, `interactive.sh`), owned by no backend. `sites/` — one `<ClusterName>.sh`/`.json` pair per supported cluster; `tests/` — the install-side test suites.
-- `docs/` — architecture notes and backlog. `examples/` — example inputs, attention-viz utilities, and notebooks.
+Each backend also installs its own CLI into its environment under its own name, drivable without the
+`vizfold` binary — `<prefix>/bin/micromamba run -p <env> <name> --help`, the same form for both.
+Through vizfold, `queue`/`run` are the way in: they fill the model's arguments from the config and
+record the run.
 
-End users install the prebuilt release binary (see [Install](#install)); the steps below build from source.
+End users install the prebuilt release binary (see [Install](#install)); the steps below build from
+source.
 
 ### Prerequisites
 
@@ -331,37 +299,36 @@ End users install the prebuilt release binary (see [Install](#install)); the ste
 
 ### CLI and executor
 
-Build and run the `vizfold` CLI from `cli/` (it is the crate's `default-run`, so `cargo run` alone runs it):
+Build and run the `vizfold` CLI from `cli/` (it is the crate's `default-run`, so `cargo run` alone
+runs it):
 
 ```bash
 cd cli
-cargo run -- seed          # create/migrate the SQLite DB and seed default records
+cargo run -- status        # works with no install; everything else needs one
 cargo run -- list models
 ```
 
-`seed` is safe to repeat and existence-guarded: it ensures the local OpenFold and ESMFold
-backends, their `local-*` targets, and matching invocation profiles exist. SeaORM migrations run
-automatically on every connect.
+Every command except `install`, `uninstall`, `status`, `update` and `self-update` is gated on a
+config existing at `~/.config/vizfold/vizfold.json` (`VIZFOLD_CONFIG` selects a different file), and
+exits telling you to install a backend first. There is no seed step: migrations run on every
+connect, and the queue/run paths seed the default backends, their `local-*` targets and matching
+invocation profiles themselves, existence-guarded. Those local profiles assume the checked-out
+repository layout, so build and run against the checkout.
 
 To install just the CLI binary into `~/.cargo/bin`:
 
 ```bash
 cargo install --path . --bin vizfold --force
-vizfold --help
 ```
-
-The seeded local profiles assume the checked-out repository layout, so build and run against the
-checkout rather than treating this as a standalone install. For a full end-to-end OpenFold run,
-see [DEMO.md](DEMO.md).
 
 #### Database
 
-The executor uses SQLite. `config::database_url()` resolves the file in order: `VIZFOLD_DB`
-(env or install config, and it takes a full `sqlite:` URL), then `<OPENFOLD_PREFIX>/vizfold.db`, then
+The executor uses SQLite. `config::database_url()` resolves the file in order: `VIZFOLD_DB` (env or
+install config, and it takes a full `sqlite:` URL), then `<OPENFOLD_PREFIX>/vizfold.db`, then
 `$XDG_DATA_HOME/vizfold/vizfold.db` (`~/.local/share/vizfold/vizfold.db` by default). Parent
 directories are created automatically. The migration history was collapsed into a single baseline
-on 2026-07-23; an older executor database fails with an actionable error naming the file to
-delete — remove it and let the executor recreate it (seeding repopulates the defaults).
+on 2026-07-23; an older executor database fails with an actionable error naming the file to delete —
+remove it and let the executor recreate it (seeding repopulates the defaults).
 
 ### Workbench
 
@@ -371,10 +338,10 @@ npm install
 npm run dev            # http://localhost:3000
 ```
 
-The workbench reads the executor's SQLite read-only. `vizfold serve` sets `VIZFOLD_DB` and links
-run outputs under `public/runs` so the 3D viewer and attention images can load them; running
-`npm run dev` by hand falls back to `<OPENFOLD_PREFIX>/vizfold.db` and shows an empty list until a
-run exists.
+`vizfold serve` exports `VIZFOLD_DB`/`OPENFOLD_PREFIX` and links run outputs under `public/runs` so
+the 3D viewer and attention images can load them. The workbench reads `process.env` only, never the
+vizfold config, so `npm run dev` by hand needs both passed in — see
+[workbench/README.md](workbench/README.md).
 
 ### Tests
 
@@ -383,9 +350,8 @@ cd cli
 cargo test
 ```
 
-These exercise the in-memory SQLite path, SeaORM migrations, and the core registration/run/artifact services.
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for branching and contribution guidance.
+These exercise the in-memory SQLite path, SeaORM migrations, and the core registration/run/artifact
+services. See [CONTRIBUTING.md](CONTRIBUTING.md) for branching and contribution guidance.
 
 ---
 
@@ -396,21 +362,6 @@ visualization of attention in protein structure prediction. It renders MSA-row a
 attention scores as **arc diagrams** (sequence space) and **3D PyMOL overlays** (structure space).
 The code lives under `examples/`.
 
-### Key features
-
-- Compatible with OpenFold outputs (`.pdb`, attention text dumps)
-- Layer- and head-specific visualizations
-- Integrated residue highlighting
-- Notebook-friendly and HPC-friendly workflow
-
-### Architecture
-
-AttentionViz layers three lightweight components on top of upstream OpenFold:
-
-- **Workflow assets** (docs, scripts, notebooks) provide reproducible configs and runnable examples.
-- **Instrumented CLIs** wrap OpenFold inference/training so attention tensors are siphoned off without modifying the scientific core.
-- **Visualization helpers** read the exported metadata and generate PyMOL overlays plus sequence-space plots.
-
 ![AttentionViz architecture](./docs/openfold/imgs/AttentionViz_Architecture.png)
 
 - [High-res PDF](./docs/openfold/imgs/AttentionViz_Architecture.pdf) for zooming/printing
@@ -419,26 +370,17 @@ AttentionViz layers three lightweight components on top of upstream OpenFold:
 ### Installation
 
 Assumes OpenFold is installed (`vizfold install openfold`, or see
-[OpenFold's install docs](https://openfold.readthedocs.io/en/latest/Installation.html)). The visualization helpers also need `PyMOL`
-(open-source is fine), `matplotlib`, `numpy`, `scipy`, `pandas`, and `biopython`. Verify the
-repo-specific dependencies with:
-
-```python
-import os
-import numpy as np
-import matplotlib.pyplot as plt
-import csv
-from pymol import cmd
-from pymol.cgo import CYLINDER, SPHERE
-```
+[OpenFold's install docs](https://openfold.readthedocs.io/en/latest/Installation.html)). The
+visualization helpers also need `PyMOL` (open-source is fine), `matplotlib`, `numpy`, `scipy`,
+`pandas` and `biopython`.
 
 ### Interactive demo
 
-`examples/viz_attention_demo_base.ipynb` demonstrates the full pipeline: it runs
-OpenFold inference with precomputed alignments, extracts top-k residue-residue attention scores per
-layer and head, saves them to text files, and visualizes **MSA row attention** and **triangle
-start attention** as arc diagrams and 3D PyMOL overlays. Line thickness encodes attention strength.
-(On CyberShuttle, use `examples/viz_attention_demo.ipynb` instead.)
+`examples/viz_attention_demo_base.ipynb` demonstrates the full pipeline: it runs OpenFold inference
+with precomputed alignments, extracts top-k residue-residue attention scores per layer and head,
+saves them to text files, and visualizes **MSA row attention** and **triangle start attention** as
+arc diagrams and 3D PyMOL overlays. Line thickness encodes attention strength. (On CyberShuttle,
+use `examples/viz_attention_demo.ipynb` instead.)
 
 **MSA row attention (layer 47, protein 6KWC)** — pairwise attention inferred from the MSA, across
 all heads at a selected layer:
@@ -455,17 +397,12 @@ to others, as part of triangle-based geometric reasoning:
 ### Acknowledgements
 
 Based on [**OpenFold**](https://github.com/aqlaboratory/openfold), an open-source reimplementation
-of AlphaFold, distributed under the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0).
-This repository extends OpenFold with attention-map visualization tools (3D + arc diagrams), demo
-scripts and configuration, and inference-pipeline modifications for simplified usage, and includes
-source originally developed by the OpenFold contributors with all original rights and attributions
-retained under the Apache 2.0 License.
+of AlphaFold. This repository extends it with attention-map visualization tools, demo scripts and
+configuration, and inference-pipeline modifications for simplified usage; original rights and
+attributions are retained per [NOTICE](./NOTICE).
 
 ---
 
 ## License
 
-This project is licensed under the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0).  
-See the [LICENSE](./LICENSE) file for details.
-
----
+Apache License 2.0 — see [LICENSE](./LICENSE).

--- a/cli/src/adapters/cli.rs
+++ b/cli/src/adapters/cli.rs
@@ -2022,11 +2022,16 @@ fn read_fasta(path: &str) -> Result<examples::Example, DbErr> {
     })
 }
 
+/// Seeding runs immediately before every lookup, so a miss here means the database is not one
+/// vizfold wrote -- naming the file is the only thing that helps.
 fn seed_required_error() -> DbErr {
-    DbErr::Custom(
-        "the run's backend, local execution target, or matching profile is missing; run `vizfold seed`"
-            .into(),
-    )
+    DbErr::Custom(format!(
+        "the run's backend, local execution target, or matching profile is missing from {} \
+         even after seeding; point VIZFOLD_DB at a vizfold database, or remove that file",
+        config::database_path()
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(config::database_url)
+    ))
 }
 
 async fn list_models(database: &sea_orm::DatabaseConnection) -> Result<(), DbErr> {

--- a/docs/esmfold.md
+++ b/docs/esmfold.md
@@ -1,91 +1,88 @@
 # ESMFold backend
 
-The ESMFold backend runs [ESMFold](https://github.com/facebookresearch/esm) via **HuggingFace Transformers** (`EsmForProteinFolding`) and writes **VizFold-compatible** trace archives: structure + optional attention and activation tensors with metadata. Using Transformers avoids the OpenFold build dependency (no CUDA compilation on cluster).
+Runs [ESMFold](https://github.com/facebookresearch/esm) via **HuggingFace Transformers**
+(`EsmForProteinFolding`) and writes **VizFold-compatible** trace archives: structure plus optional
+attention and activation tensors with metadata. No CUDA compilation, no AlphaFold2 databases.
 
 ## Install
 
-**Option A – `vizfold install` (recommended)**  
-The executor CLI provisions a self-contained environment — its own Python 3.11, PyTorch,
-Transformers, and the `esmfold` package with its `esmfold` entrypoint — and records it in
-`~/.config/vizfold/vizfold.json`. It brings its own interpreter rather than building on the host's,
-which on a cluster login node is routinely older than the package needs:
+**Option A – `vizfold install` (recommended).** Provisions a self-contained environment (its own
+Python 3.11, PyTorch, Transformers, the `esmfold` package) and records `ESMFOLD_ENV_PREFIX` in
+`~/.config/vizfold/vizfold.json`.
 
 ```bash
 vizfold install esmfold
-vizfold status          # shows resolved config + which backends are installed
+vizfold status          # resolved config + which backends are installed
 ```
 
-Override the torch wheel when a specific CUDA build is needed:
+For a specific torch build, point the installer at a wheel index:
 
 ```bash
-ESMFOLD_TORCH_SPEC=torch \
-ESMFOLD_PIP_INDEX_URL=https://download.pytorch.org/whl/cu128 \
-  vizfold install esmfold
+ESMFOLD_PIP_INDEX_URL=https://download.pytorch.org/whl/cu128 vizfold install esmfold
 ```
 
-**Option B – pip (manual, into a Python ≥3.10 environment)**  
-`backends/esmfold/pyproject.toml` declares everything the backend imports, so one command is
-enough. Install PyTorch first only when you need a specific CUDA build — pip then finds the
-`torch>=2.1` requirement already satisfied and leaves that build alone:
+`ESMFOLD_TORCH_SPEC` pins the spec itself (default `torch`), e.g. `torch==2.5.1`. Neither is saved to
+the config, so pass them again on a re-install; the verify step prints what you ended up with.
+
+**Option B – pip**, into a Python ≥3.10 environment. Install PyTorch first if you need a specific
+CUDA build — pip then leaves it alone.
 
 ```bash
-pip install ./backends/esmfold          # torch, transformers, numpy, and the esmfold package
+pip install ./backends/esmfold   # torch>=2.1, transformers>=4.36,<5, numpy>=1.24, + the esmfold package
 ```
 
-
-
-## Run locally
-
-The executor runs the same entrypoint and records the run and its outputs:
-`vizfold run 6KWC_1 --backend esmfold`, or `vizfold run ./my.fasta` for a sequence of your own.
-The commands below call it directly, through the environment's own `esmfold` — run it the way
-`vizfold install esmfold` prints, `micromamba run -p $ESMFOLD_ENV_PREFIX esmfold` (`python -m
-esmfold` is the same entrypoint). It needs nothing from the checkout.
-`scripts/esmfold/run_pretrained_esmf.py` runs the same function by path.
-
-**Structure only (fast):**
+## Fold through vizfold
 
 ```bash
-esmfold \
+vizfold run 6KWC_1 --backend esmfold        # bundled example
+vizfold run ./my.fasta --backend esmfold    # your own sequence
+```
+
+`--backend` defaults to the only backend installed, else openfold — so pass `--backend esmfold`
+whenever OpenFold is installed too. To queue with non-default trace settings and run later:
+
+```bash
+vizfold queue esmfold --fasta ./my.fasta --trace-mode attention --layers 0,1,2
+vizfold run <run-id>
+```
+
+The first fold downloads `facebook/esmfold_v1` (~2.6 GB). `vizfold run` points `HF_HOME` at
+`<env>/hf` when it is unset, keeping the weights out of a quota'd `$HOME`. Driving the model
+yourself gets no such redirect — set `HF_HOME` first.
+
+## Drive the model directly
+
+The entrypoint exists only inside the backend env, so run it the way `vizfold install esmfold` prints:
+
+```bash
+# <prefix> is OPENFOLD_PREFIX (default ~/openfold), <env> is ESMFOLD_ENV_PREFIX -- both from `vizfold status`
+<prefix>/bin/micromamba run -p <env> esmfold \
   --fasta examples/monomer/fasta_dir_6KWC/6KWC.fasta \
   --out outputs/esmf_6KWC \
-  --trace_mode none
-```
-
-**Structure + attention + activations:**
-
-```bash
-esmfold \
-  --fasta examples/monomer/fasta_dir_6KWC/6KWC.fasta \
-  --out outputs/esmf_6KWC \
-  --model facebook/esmfold_v1 \
-  --device cuda \
   --trace_mode attention+activations \
   --layers all \
-  --save_fp16
+  --save_fp16 \
+  --structure_traces
 ```
 
-**Limit layers/heads (saves memory and disk):**
+(`python -m esmfold` and `scripts/esmfold/run_pretrained_esmf.py` are the same function.)
 
-```bash
-esmfold \
-  --fasta examples/monomer/fasta_dir_6KWC/6KWC.fasta \
-  --out outputs/esmf_6KWC \
-  --trace_mode attention \
-  --layers 0,1,2,5 \
-  --heads 0,1,2
-```
+Flags, and their spelling on `vizfold queue esmfold`:
 
-**Structure + IPA attention + per-recycle backbone (structure module traces):**
-
-```bash
-esmfold \
-  --fasta examples/monomer/fasta_dir_6KWC/6KWC.fasta \
-  --out outputs/esmf_6KWC \
-  --trace_mode attention+activations \
-  --structure_traces \
-  --save_fp16
-```
+| raw CLI | queue esmfold | notes |
+|---|---|---|
+| `--fasta` | `--fasta` | required on both |
+| `--out` | — | the run's output workspace |
+| `--model` | `--model` | default `facebook/esmfold_v1` |
+| `--device` | `--model-device` | default: cuda if visible, else cpu |
+| `--dtype` | `--dtype` | `float32` \| `float16` |
+| `--trace_mode` | `--trace-mode` | `none` \| `attention` \| `activations` \| `attention+activations` |
+| `--layers` | `--layers` | `all`, `0,1,2`, or `0:12` |
+| `--save_fp16` | `--save-fp16` | |
+| `--structure_traces` | `--structure-traces` | IPA attention + per-recycle backbone |
+| `--heads`, `--top_k` | — | raw CLI only; runs through vizfold use `all` and `50` |
+| `--seed`, `--deterministic` | — | raw CLI only; recorded in `meta.json` when set |
+| — | `--input-id` | name recorded for the run |
 
 ## Output layout
 
@@ -93,14 +90,13 @@ After a run, `--out` contains:
 
 ```
 outputs/esmf_6KWC/
-  meta.json              # Run metadata (backend, model, shapes, seed, etc.)
+  meta.json
   structure/
-    predicted.pdb        # Predicted structure (PDB)
-    predicted.pt          # Optional coordinate tensor
+    predicted.pdb
+    predicted.pt          # optional coordinate tensor
   trace/
     attention/
       layer_000.pt
-      layer_001.pt
       ...
     activations/
       layer_000.pt
@@ -111,72 +107,40 @@ outputs/esmf_6KWC/
       ...
       s_s.pt              # [L, C_s]  final trunk single representations
       s_z.pt              # [L, L, C_z]  final trunk pair representations
-    structure_module/     # Only with --structure_traces
+    structure_module/     # only with --structure_traces
       ipa_attention/
         recycle_00_block_00.pt   # IPA attention [H, N, N]
-        ...
       backbone/
-        recycle_00_positions.pt  # Per-recycle backbone coords
-        recycle_00_states.pt     # Per-recycle single representations
-        ...
-    summary.json          # Per-layer attention entropy, sparsity, norms
-    index.json            # Maps layer/head to path, dtype, shape
+        recycle_00_positions.pt  # per-recycle backbone coords
+        recycle_00_states.pt     # per-recycle single representations
+    summary.json          # per-layer attention entropy, sparsity, norms
+    index.json            # maps layer/head to path, dtype, shape
   attention/
     msa_row_attn_layer0.txt   # VizFold text format (top-k per head)
     ...
-  logs.txt               # Log lines from the run
+  logs.txt
 ```
 
 ## meta.json
 
-Includes:
-
 - `backend`, `model_name`, `date_time`, `device`, `dtype`
 - `sequence_length`, `input_fasta_hash`, `input_fasta_path`
-- `layer_count`, `head_count`, `trace_mode`, `tensor_format` (fp16/fp32)
-- `trace_formats`: which output formats were produced (`pt`, `txt`)
+- `layer_count`, `head_count`, `trace_mode`, `tensor_format` (fp16/fp32), `top_k`
+- `trace_formats`: formats produced — `pt`, `txt`, or `["none"]`
 - `shapes_recorded`: per-file shapes for attention, activations, trunk, and structure module
-- `seed`, `deterministic` (if set)
+- `seed`, `deterministic` (only when set)
 - `repo_commit` (if run from a git repo)
-
-## Reproducibility
-
-- `--seed 42` fixes the PyTorch RNG.
-- `--deterministic` sets CuDNN deterministic mode (can be slower).
-
-Both are recorded in `meta.json`.
 
 ## Long sequences
 
-Attention storage is O(N²). For long proteins the script warns and suggests:
-
-- `--trace_mode activations` (no attention), or
-- `--layers 0,1,2` to save only a few layers.
+Attention storage is O(N²). Above 400 residues, a run with attention tracing warns and suggests
+`--layers 0,1` or `--trace_mode activations`.
 
 ## Running on a cluster
 
 `vizfold install esmfold` picks the cluster, allocation and install prefix the same way
-`vizfold install openfold` does, so there is no batch script to edit and nothing to submit by hand.
-Folds go to a GPU node whenever the site settled a GPU partition:
+`vizfold install openfold` does — no batch script to edit, nothing to submit by hand.
 
-```bash
-vizfold install esmfold
-vizfold run 6KWC_1 --backend esmfold
-```
-
-Two things worth knowing:
-
-- **`OPENFOLD_GPU_*` governs ESMFold folds too.** The GPU partition, account, gres, resources and
-  time that `vizfold status` shows are what an ESMFold run is `srun`'d onto — the names are
-  OpenFold-prefixed for historical reasons, but nothing about them is OpenFold-specific.
-- **The environment installs a CPU torch build by default.** For a CUDA build, point the installer
-  at the matching wheel index:
-
-  ```bash
-  ESMFOLD_PIP_INDEX_URL=https://download.pytorch.org/whl/cu126 vizfold install esmfold
-  ```
-
-  `ESMFOLD_TORCH_SPEC` pins the spec itself (default `torch`), e.g. `torch==2.5.1`. Neither is part
-  of the saved config: they describe how to build the environment, not what the install settled, so
-  pass them again on a re-install. The installer's verify step prints which build you ended up with
-  (`torch 2.5.1 cuda True`).
+**`OPENFOLD_GPU_*` governs ESMFold folds too.** The GPU partition, account, gres, resources and time
+that `vizfold status` shows are what an ESMFold run is `srun`'d onto. The names are OpenFold-prefixed
+for historical reasons; nothing about them is OpenFold-specific.

--- a/docs/esmfold_backend_repro.md
+++ b/docs/esmfold_backend_repro.md
@@ -1,34 +1,26 @@
 # ESMFold Backend Reproducibility Guide
 
-This document describes how to run the HuggingFace-based ESMFold backend with
-VizFold-compatible trace export.
+Verifying the ESMFold backend end to end: inference, trace extraction, and the archive it writes.
 
-It provides instructions for verifying structure inference, attention extraction,
-activation extraction, and expected archive outputs locally and on the ICE cluster.
-
-## Environment Setup (Local)
-
-Create a virtual environment:
+## Environment Setup
 
 ```bash
-python3 -m venv .venv
-source .venv/bin/activate
+vizfold install esmfold
+vizfold status                          # prints OPENFOLD_PREFIX and ESMFOLD_ENV_PREFIX
+
+# neither is exported into your shell -- set them from what status printed
+export OPENFOLD_PREFIX=... ESMFOLD_ENV_PREFIX=...
+MM="$OPENFOLD_PREFIX/bin/micromamba"    # drive the backend through its own env
+$MM run -p "$ESMFOLD_ENV_PREFIX" esmfold --help
 ```
 
-Install dependencies (torch first from its own wheel index, then the esmfold project, which pulls
-Transformers and installs the `esmfold` package):
-
-```bash
-pip install torch
-pip install -e ./backends/esmfold
-```
+The installer brings its own Python 3.11 — a login node's `python3` is routinely too old. For a
+manual pip install instead, see Option B in [esmfold.md](esmfold.md#install).
 
 ## Structure-Only Inference Test
 
-Run:
-
 ```bash
-python scripts/esmfold/run_pretrained_esmf.py \
+$MM run -p "$ESMFOLD_ENV_PREFIX" esmfold \
   --fasta examples/monomer/fasta_dir_6KWC/6KWC.fasta \
   --out outputs/test_run \
   --trace_mode none \
@@ -38,110 +30,76 @@ python scripts/esmfold/run_pretrained_esmf.py \
 Expected outputs:
 
 - `outputs/test_run/meta.json`
+- `outputs/test_run/logs.txt` — written for every run, including `--trace_mode none`
 - `outputs/test_run/structure/predicted.pdb`
-
-Successful execution confirms:
-
-- model loads correctly
-- inference pipeline runs end-to-end
-- archive metadata generation works
+- `outputs/test_run/structure/predicted.pt` — when the model returns coordinates
 
 ## Trace Extraction Test (Attention + Activations)
 
-Run:
-
 ```bash
-python scripts/esmfold/run_pretrained_esmf.py \
+$MM run -p "$ESMFOLD_ENV_PREFIX" esmfold \
   --fasta examples/monomer/fasta_dir_6KWC/6KWC.fasta \
   --out outputs/test_trace \
   --trace_mode attention+activations \
   --device cpu
 ```
 
-Expected outputs:
+Adds `trace/attention/`, `trace/activations/`, `trace/trunk/`, `trace/index.json`,
+`trace/summary.json`, and top-k text exports in `attention/` at the archive root. The complete
+layout is in [esmfold.md](esmfold.md#output-layout) — check the run against that, not a copy here.
 
-- `outputs/test_trace/meta.json`
-- `outputs/test_trace/structure/predicted.pdb`
-- `outputs/test_trace/trace/`
+`attention/msa_row_attn_layer*.txt` uses OpenFold's own `save_attention_topk` when `openfold` is
+importable, and otherwise reproduces the same format.
 
-Trace directory should contain:
+## Through the Executor
 
-- `trace/attention/`
-- `trace/activations/`
+The same run, recorded in the run database. `queue` prints the run id and the `run` line to follow
+it with; note the queue surface spells its flags with dashes (`--trace-mode`, `--structure-traces`)
+where the script uses underscores.
 
-## Verified Tensor Outputs (Local Validation)
-
-Attention tensors follow expected shape:
-
-`[B, H, N, N]`
-
-where:
-
-- B = batch size
-- H = number of attention heads
-- N = sequence length (after special-token slicing)
-
-This confirms compatibility with VizFold's visualization pipeline.
-
-## Archive Structure Validation
-
-Expected archive layout:
-
-```
-outputs/test_trace/
-├── meta.json
-├── structure/
-│   └── predicted.pdb
-└── trace/
-    ├── attention/
-    └── activations/
+```bash
+vizfold queue esmfold --fasta examples/monomer/fasta_dir_6KWC/6KWC.fasta --structure-traces
+vizfold run <RUN_ID>
+vizfold show run <RUN_ID>          # the run and its registered artifacts
 ```
 
-This structure matches the OpenFold-compatible VizFold archive schema.
+`vizfold run 6KWC_1 --backend esmfold` queues and folds the bundled example in one step. Preflight
+checks the GPU, the base command, `input_id`, that `--fasta` is a readable file, and the output dir.
 
 ## Running on ICE Cluster (PACE)
 
-Login:
-
 ```bash
 ssh <gt_username>@login-ice.pace.gatech.edu
+vizfold install esmfold
+vizfold run 6KWC_1 --backend esmfold
 ```
 
-Navigate to the repository:
+The site is `ice-slurm`: `ice-cpu` / `ice-gpu` partitions, `gpu:a100:1`. Two gotchas:
 
-```bash
-cd "$OPENFOLD_HOME"   # the vizfold checkout; the bootstrap clones it to $HOME/vizfold-src
-```
+- `OPENFOLD_GPU_*` governs ESMFold folds too — those settings are what an ESMFold run is `srun`'d
+  onto. The names are OpenFold-prefixed for historical reasons only.
+- The installer takes plain `torch` off PyPI unless told otherwise. For a specific CUDA build,
+  re-run it with a wheel index:
+  `ESMFOLD_PIP_INDEX_URL=https://download.pytorch.org/whl/cu126 vizfold install esmfold`. The
+  verify step prints the torch version and whether CUDA is available.
 
-Activate environment:
+## Verification Checklist
 
-```bash
-source .venv/bin/activate
-```
+Counts from a full `attention+activations` trace of the 6KWC example:
 
-Run the same two commands as above with `--device cuda`; the expected outputs are unchanged.
+- 36 attention tensors in `trace/attention/` (one per ESM-2 layer)
+- 36 + 2 per captured recycling iteration in `trace/activations/` — the extras are
+  `recycle_<i>_s_s` and `recycle_<i>_s_z`, which land in `activations/`, not `trunk/`
+- ~98 Evoformer trunk tensors in `trace/trunk/` (48 blocks × seq/pair, plus final `s_s` and `s_z`)
+- 36 text files in `attention/`
 
+Shapes:
 
-## Additional Intermediate Output Validation
+- attention: `[B, H, N, N]` — `<cls>`/`<eos>` sliced off, so `N` is the sequence length
+- activations: `[B, N, D]` — sliced the same way, so residue indices line up with attention
+- pair representations (`s_z`): `[L, L, C_z]`
 
-The backend exports intermediate outputs beyond encoder attention and activation traces.
+With `--structure_traces`, also check:
 
-Verified local outputs include:
-
-- 36 attention tensors in `trace/attention/`
-- 36 activation tensors in `trace/activations/`
-- ~98 Evoformer trunk intermediate tensors in `trace/trunk/`
-- 36 VizFold attention text files in `attention/`
-
-Expected tensor shapes include:
-
-- attention tensors: `[B, H, N, N]`
-- activation tensors: `[B, N, D]`
-- pair representations (`s_z`): `[N, N, D]`
-
-If recycling outputs are enabled, they are expected to appear under `trace/trunk/` with keys such as:
-
-- `recycle_*_s_s`
-- `recycle_*_s_z`
-
-If structure-module / IPA outputs are enabled, they should also be saved as `.pt` tensors in the trace archive and can be validated separately for expected attention dimensions.
+- `trace/structure_module/ipa_attention/recycle_NN_block_NN.pt`
+- `trace/structure_module/backbone/recycle_NN_positions.pt` and `recycle_NN_states.pt`

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,10 +1,12 @@
 ## Model / Execution Target Compatibility
 
-`MODEL_INVOCATION_PROFILE` already is the compatibility link: a profile exists only for a supported backend/target pair, `submit_run` rejects a run whose profile does not match the selected pair (cli/src/core/services/runs.rs), and `queue <backend>` resolves the target and profile from the backend rather than offering them independently. What is still missing is compatibility *metadata* — a status and notes per pair — so an unsupported combination can be listed and explained instead of merely having no profile.
+A profile exists only for a supported backend/target pair (cli/src/core/seed.rs), and `submit_run` rejects a run whose profile does not match its backend and target (cli/src/core/services/runs.rs).
+
+Still missing: a status and notes per pair, so an unsupported combination can be listed and explained instead of merely having no profile.
 
 
 ## Current JSON validation approach
 
-For the MVP, model capabilities, artifact capabilities, parameter schemas, and selected run parameters are stored as JSON strings in SQLite and validated in the Rust core service layer.
+Artifact capabilities, parameter schemas, target resources, profile config, and run parameters are stored as JSON strings in SQLite. The validation helpers live in cli/src/core/services/validation.rs and are called from both the services and the model runners.
 
-The CLI adapter already writes only through the core services (`services::runs::submit_run` and friends) and touches entities directly only for reads. Still open: once CLI/API interfaces are formalized, JSON parsing can move to those adapter boundaries so the core receives structured `serde_json::Value` inputs.
+The CLI adapter writes only through the core services and touches entities directly only for reads (cli/src/adapters/cli.rs:1470, 1481, 1732, 1737). Still open: move JSON parsing to the adapter boundary so the core receives `serde_json::Value`.

--- a/docs/vizfold_gateway/architecture.md
+++ b/docs/vizfold_gateway/architecture.md
@@ -8,69 +8,48 @@
 
 This diagram describes the MVP data model for the Rust executor core. The goal is to separate model definition, execution environment, invocation configuration, concrete runs, artifact classification, and produced artifact instances.
 
-`MODEL_BACKEND` represents a registered model implementation, such as OpenFold, ESMFold, or Boltz. It stores model-level metadata, the model parameter schema, and the artifact types the model can theoretically produce.
+`MODEL_BACKEND` is a registered model implementation. Two are seeded: `openfold` and `esmfold`. It owns model-level metadata, the artifact types the model can produce, and — in `parameter_schema_json` — the canonical contract for the model-native arguments the planner emits.
 
-`EXECUTION_TARGET` represents an environment where execution can happen, such as local runtime, Docker, HPC, or a science gateway. It stores target-level metadata and available resources/capabilities, such as supported devices, CPU bounds, GPU availability, memory/resource options, and runtime constraints. It does not store model-specific command parameters or installation details.
+`EXECUTION_TARGET` is an environment where execution can happen, described by its resources and capabilities: supported devices, CPU bounds, resource constraints. Both seeded targets are `target_type: "local"`. HPC is not a separate target — it is the same local profile with an `srun` prefix wrapped on at execution time when a GPU partition is configured. The target stores no model-specific paths or installation details.
 
-`MODEL_INVOCATION_PROFILE` connects a specific model backend to a specific execution target. It owns the model-target-specific invocation configuration, such as subprocess, Docker, SLURM, or gateway invocation details. This prevents model-specific paths or command templates from leaking into the generic execution target definition.
+`MODEL_INVOCATION_PROFILE` connects a specific model backend to a specific execution target and owns the invocation configuration for that pair in `config_json`: `program`, `script`, `working_dir`, environment variables, and `output_location`. This keeps model-specific paths and command templates out of the generic execution target. `local_subprocess` is the only supported `invocation_kind`; the planner rejects any other value.
 
-`RUN` represents one concrete execution request. It selects a model backend, execution target, and invocation profile, then records the concrete model selections and run-time execution/input choices for that run, the sequence folded (`input_sequence`), and an immutable `provenance_json` snapshot of the backend/target/profile and resolved install paths as they were at queue time. `RUN.input_id` is the stable model-facing input identity for the run. For OpenFold this is enforced: preflight fails a run whose FASTA header tag differs from `input_id`, and the precomputed-alignment key is `alignment_dir/<input_id>`. It should not be mutated for workspace/output collision handling; use run/workspace identifiers for that instead.
+`RUN` is one concrete execution request. It selects a model backend, execution target, and invocation profile, then records the concrete model and runtime choices for that run, the sequence folded (`input_sequence`), and an immutable `provenance_json` snapshot of the backend/target/profile and resolved install paths as they were at queue time. `RUN.input_id` is the stable model-facing input identity. For OpenFold this is enforced: preflight fails a run whose FASTA header tag differs from `input_id`, and the precomputed-alignment key is `alignment_dir/<input_id>`. It should not be mutated for workspace/output collision handling; use run/workspace identifiers for that instead.
 
-`ARTIFACT_TYPE` represents catalog/reference data for known artifact kinds that the executor or visualization layer may understand, such as protein structures, attention heatmaps, PyMOL sessions, trace archives, or manifests. It stores stable type metadata including a slug, default format, display mode, viewer kind, description, and optional metadata schema. This separates artifact classification and visualization hints from concrete produced artifact instances.
+`ARTIFACT_TYPE` is catalog/reference data for known artifact kinds — protein structures, attention heatmaps, PyMOL sessions, trace archives, manifests. It stores a slug, default format, display mode, viewer kind, description, and an optional metadata schema, separating classification and visualization hints from produced instances.
 
-`ARTIFACT` represents a manifest entry for a concrete output produced by a run. It references an `ARTIFACT_TYPE`, records the concrete produced format, storage URI, and artifact metadata. The database records what artifact exists and where it is stored, while the heavy scientific output files remain in external storage such as the filesystem, HPC storage, or object storage.
+`ARTIFACT` is a manifest entry for one concrete output of a run: its `ARTIFACT_TYPE`, the produced format, storage URI, and metadata. The database records what artifact exists and where it is stored; the heavy scientific output files remain in external storage. Artifact capabilities stay model-level — the MVP has no model-target artifact constraint logic.
 
-This model intentionally does not include model-target artifact constraint logic in the MVP. Artifact capabilities remain model-level, while actual produced outputs are recorded as `ARTIFACT` rows classified by the `ARTIFACT_TYPE` catalog.
-
-The artifact type catalog exists to provide stable artifact metadata and display hints. Post-run artifact discovery now runs inline: a run that exits 0 registers its output directories (`run_output_directory`, `attention_output_directory`) through `services::run_artifacts::register_known_run_artifacts`, idempotently, and `vizfold register-artifacts <id>` re-runs it. The workbench (`vizfold serve`) reads those rows, lists the registered directories, and renders each run's structure and attention images. Discovery below directory granularity — classifying individual files by artifact type — is still deferred.
+Post-run artifact discovery runs inline: a run that exits 0 registers its output directories (`run_output_directory`, `attention_output_directory`) through `services::run_artifacts::register_known_run_artifacts`, idempotently, and `vizfold register-artifacts <id>` re-runs it. The workbench (`vizfold serve`) reads those rows, lists the registered directories, and renders each run's structure and attention images. Discovery below directory granularity — classifying individual files by artifact type — is still deferred.
 
 ## Architecture note: parameter and resource ownership
 
-The current MVP has one model-facing parameter schema and one target-level resource description:
-
-- `ModelBackend.parameter_schema_json`
-- `ExecutionTarget.available_resources_json`
-
-`Run` has two concrete parameter buckets with distinct responsibilities:
+`Run` has two parameter buckets, resolved against `ModelBackend.parameter_schema_json` and `ExecutionTarget.available_resources_json`:
 
 | Column | Intended meaning |
 | --- | --- |
 | `Run.model_parameters_json` | Explicit model-argument values or overrides selected for this run, such as an OpenFold preset or model feature flag. The allowed arguments, types, CLI flags, and defaults are defined by `ModelBackend.parameter_schema_json`; schema defaults may be applied when a value is omitted here. This column is not redundant with the schema: it preserves the run's chosen model values. |
-| `Run.execution_parameters_json` | Run-scoped input, runtime, and resource choices consumed by schema entries sourced from `execution_parameters`, such as FASTA/alignment inputs, the current `data_dir`, device selection, or CPU count. Target resources constrain these values through `ExecutionTarget.available_resources_json`. It must not carry invocation-profile configuration or normalized output paths. |
+| `Run.execution_parameters_json` | Run-scoped input, runtime, and resource choices consumed by schema entries sourced from `execution_parameters`, such as FASTA/alignment inputs, the current `data_dir`, device selection, or CPU count. It must not carry invocation-profile configuration or normalized output paths. |
 
 Resolved output locations are derived from the run's `provenance_json` snapshot of `output_location` — falling back to the live `ModelInvocationProfile.config_json.output_location` for runs queued before snapshots existed — joined with `Run.id`, rather than being stored as `output_dir` or `attn_map_dir` execution parameters.
 
-The target resource description must not be treated as a competing model-command parameter schema.
-
-A cleaner model may be:
-
-1. `ModelBackend` owns the canonical model parameter contract. It defines the parameters a backend supports, their meaning, and where their values should be sourced from.
-
-2. `ModelInvocationProfile` owns backend-target invocation configuration in `config_json`, such as local paths, remote paths, program/script configuration, environment variables, and target-specific output locations. It does not currently define a separate parameter schema. If backend-target-specific run requirements are needed later, they should be added deliberately with a clear name and design rather than a generic unused wildcard field.
-
-3. `ExecutionTarget` describes runtime capabilities/resources rather than model-specific command parameters. For example, GPU availability, CPU limits, supported execution type, or resource constraints.
-
-Under this direction, model-specific CLI flags such as OpenFold `--attn_map_dir` should not live on a generic execution target. Output paths are resolved from the invocation profile rather than supplied as unrelated run execution parameters.
-
-`ExecutionTarget.available_resources_json` is the current target-level field for these capabilities. The OpenFold workflow uses it to constrain the concrete resource values selected in `Run.execution_parameters_json`.
+`ExecutionTarget.available_resources_json` both constrains the values in `Run.execution_parameters_json` and emits its own flags: `append_available_resources_args` appends `--model_device` and `--cpus` for the OpenFold target, `--device` for the ESMFold one. Model-native flags such as OpenFold's `--attn_map_dir` live in the backend's parameter schema, not on the target.
 
 ## Executor Architecture Flow
 
-![Science Gateway Metadata Model](ExecutionFlow.png)
+![Executor Architecture Flow](ExecutionFlow.png)
 
-The executor separates registration, planning, optional preflight, execution, and artifact recording. `MODEL_BACKEND` defines what model exists, `EXECUTION_TARGET` defines where execution can happen, and `MODEL_INVOCATION_PROFILE` defines how a specific model runs on a specific target.
+The executor separates registration, planning, preflight, execution, and artifact recording. For a concrete `RUN` it loads the selected model, target, invocation profile, and parameters, and a planner converts those records into a `CommandSpec` — the final resolved plan holding program, arguments, working directory, and environment variables.
 
-For a concrete `RUN`, the executor loads the selected model, target, invocation profile, and parameters. A planner then converts those records into a `CommandSpec`, which is the final resolved execution plan containing the program, arguments, working directory, and environment variables.
+Before execution the command always passes through a preflight, selected by the run's backend slug — `preflight_openfold` or `preflight_esmfold`, with unknown slugs falling back to OpenFold's. Each performs model-specific readiness checks against the planned (unwrapped) command and returns a `PreflightReport` of passed checks, warnings, or failures. If failures are reported, execution is skipped and the run is marked `failed` with the failure messages.
 
-Before execution the command always passes through a preflight, selected by the run's backend slug — `preflight_openfold` or `preflight_esmfold`, with unknown slugs falling back to OpenFold's. Each performs model-specific readiness checks against the planned (unwrapped) command and returns a `PreflightReport` of passed checks, warnings, or failures. If failures are reported, execution is skipped, the run is marked `failed` with the failure messages, and the report is returned.
+`services::run_execution::execute_run` coordinates this flow: create the run workspace → plan a `CommandSpec` → wrap it for the backend's environment (micromamba activation for OpenFold; for ESMFold its env's own `bin/python`, which needs no activate.d hook; `srun` outermost when a GPU partition is configured) → preflight the unwrapped command → `CommandRunner`. The runner executes the command and returns a `CommandOutput` with exit code, stdout, and stderr; `execute_run` moves the run through `running` → `completed`/`failed` and registers its artifacts on success.
 
-`services::run_execution::execute_run` coordinates this flow: create the run workspace → plan a `CommandSpec` → wrap it for the backend's environment (micromamba activation for OpenFold, the venv interpreter for ESMFold, `srun` outermost when a GPU partition is configured) → preflight the unwrapped command → `CommandRunner`. The `CommandRunner` executes the command and returns a `CommandOutput` containing the exit code, stdout, and stderr; `execute_run` moves the run through `running` → `completed`/`failed` and registers its artifacts on success.
-
-One built-in schema-driven Rust planner serves every backend — it emits OpenFold's or ESMFold's CLI from that backend's `parameter_schema_json` — and each backend contributes its own preflight. Later, the same abstractions can support DB-driven command templates, external model plugins, richer preflight checks, and additional execution targets without changing the core execution flow. Produced outputs are not stored directly in the database; they remain in external storage and are registered as `ARTIFACT` manifest entries classified by the `ARTIFACT_TYPE` catalog. `ARTIFACT_TYPE` is catalog/reference data. `ARTIFACT` is run-specific manifest data.
+One built-in schema-driven Rust planner serves every backend — it emits OpenFold's or ESMFold's CLI from that backend's `parameter_schema_json` — and each backend contributes its own preflight. The same abstractions can later support DB-driven command templates, external model plugins, richer preflight checks, and additional execution targets without changing the core execution flow. Produced outputs are never stored in the database; they remain in external storage and are registered as `ARTIFACT` manifest entries classified by the `ARTIFACT_TYPE` catalog.
 
 ### Schema parameter sources
 
-`ModelBackend.parameter_schema_json` is the canonical contract for model-native arguments: it declares argument types, CLI flags, defaults, and where the planner obtains a value. A schema describes what a backend accepts; the selected run values remain in the `RUN` record for reproducibility.
+`ModelBackend.parameter_schema_json` declares argument types, CLI flags, defaults, and where the planner obtains a value. A schema describes what a backend accepts; the selected run values remain in the `RUN` record for reproducibility.
 
 The planner's source vocabulary, shared by every backend schema, is:
 
@@ -104,20 +83,4 @@ For example, OpenFold's normalized output arguments are declared in the model sc
 
 ### Output location resolution
 
-The executor should maintain a normalized output location concept that is independent of model-native argument names.
-
-`ModelInvocationProfile.config_json.output_location` defines the base output location for a specific backend-target invocation, and each run snapshots it into `provenance_json` at queue time so a later edit to the profile cannot move a finished run's outputs. A concrete run resolves its output workspace using the run identifier:
-
-```text
-resolved_output_location = (run.provenance.profile.config.output_location
-                            ?? invocation_profile.output_location) / run.id
-```
-Model-specific command planning maps this resolved location to the backend-native argument. For OpenFold, the resolved output location maps to `--output_dir`, and the attention directory is derived as `<resolved_output_location>/attention` for `--attn_map_dir`.
-
-Model-specific secondary output paths, such as OpenFold attention map directories, should be derived from the resolved run output location where possible rather than supplied as unrelated top-level paths.
-
-This keeps:
-
-- ModelInvocationProfile responsible for target-specific location conventions;
-- Run responsible for the concrete run identity and selected parameters;
-- artifact registration responsible for indexing produced files under the resolved output location.
+`ModelInvocationProfile.config_json.output_location` is the base output location for a backend-target pair, and each run snapshots it into `provenance_json` at queue time so a later edit to the profile cannot move a finished run's outputs. The resolved workspace is that snapshot (else the live profile) joined with `Run.id`. OpenFold maps it to `--output_dir`, with `<workspace>/attention` for `--attn_map_dir`; secondary output paths should be derived this way rather than supplied as unrelated top-level paths.

--- a/workbench/README.md
+++ b/workbench/README.md
@@ -1,19 +1,27 @@
 # VizFold Workbench
 
-This is the Next.js workbench app for the VizFold science gateway prototype.
-
-It reads the executor's SQLite directly (read-only, via `node:sqlite`) and shells out to the
-`vizfold` binary to list examples and queue/execute runs.
+Next.js dashboard for the vizfold executor. Reads the executor's SQLite read-only via `node:sqlite`
+and shells out to the `vizfold` binary (`list examples`, `queue openfold`, `run <id>`).
 
 ## Running it
 
 ```bash
-vizfold serve            # http://localhost:3000
+vizfold serve                # http://localhost:3000
+vizfold serve --port 4000
 ```
 
-`serve` stages the app, provisions Node if the host has none, exports `VIZFOLD_BIN`, `VIZFOLD_DB`
-and `OPENFOLD_PREFIX`, and symlinks `<OPENFOLD_PREFIX>/runs` to `public/runs` so the 3D viewer and
-attention images resolve. `npm run dev` here works too, but falls back to
-`<OPENFOLD_PREFIX>/vizfold.db` and has no `public/runs` link. Needs Node >= 22.13 for `node:sqlite`.
+`serve`:
+- stages this directory to `<OPENFOLD_PREFIX>/workbench` (in place when the prefix is
+  `OPENFOLD_HOME`); it never clones a missing checkout
+- provisions Node if the host has none (>= 22.13, for `node:sqlite`)
+- runs `npm install` on first use, then `npm run dev`
+- exports `VIZFOLD_BIN`, `OPENFOLD_PREFIX` and `VIZFOLD_DB`
+- symlinks `<OPENFOLD_PREFIX>/runs` to `public/runs`, so the 3D viewer and attention images resolve
 
+`npm run dev` by hand needs that env passed in — the workbench reads `process.env` only, never the
+vizfold config, so without it the run list is silently empty and folding 500s:
 
+```bash
+# both values are in `vizfold status`, as OPENFOLD_PREFIX and database
+OPENFOLD_PREFIX=<OPENFOLD_PREFIX> VIZFOLD_DB=<database> npm run dev
+```


### PR DESCRIPTION
Every vizfold markdown verified claim-by-claim against the source — commands, flags, paths, env vars, and the sample output they print — then cut to size. **8 repo docs 1233 → 1064 lines**; the workspace tutorial `PEARC26_TUTORIAL.md` 540 → 445 (that file is outside the repo, so it is not in this diff).

## Corrections a reader would have hit

| File | Was | Actually |
|---|---|---|
| `PEARC26_TUTORIAL.md` | `Preflight: passed` printed straight after `Executing run 1` | `report_execution` (`cli.rs:1511`) calls `execute_run` **first** — model output streams, *then* preflight, then `Command exit_code:`, then `Final status:`. It also contradicted DEMO.md, which had it right. |
| `docs/esmfold_backend_repro.md` | `MM="$OPENFOLD_PREFIX/bin/micromamba"` | vizfold never exports that into your shell, so the block expanded to `/bin/micromamba` and failed. Now sources it from `vizfold status`. |
| `docs/esmfold_backend_repro.md` | "the env installs a **CPU** torch build by default" | `install.sh:38-40` passes `--index-url` only when `ESMFOLD_PIP_INDEX_URL` is set; otherwise plain `torch` from PyPI. |
| `README.md` | bare `npm run dev` "falls back to `<OPENFOLD_PREFIX>/vizfold.db`" | `workbench/lib/db.ts:6` interpolates `process.env.OPENFOLD_PREFIX ?? ""` — with nothing exported the path is a literal `/vizfold.db`. |
| `README.md` | `install` clones "for the `install/` scripts" | no top-level `install/` exists — only `install.sh` and `backends/*/install/`. |

## A CLI defect the audit surfaced

Removing `seed` in #129 left `seed_required_error` telling the user to *run `vizfold seed`*. Since `seed_defaults` runs on the line immediately above every lookup that raises it, reaching it means the database is not one vizfold wrote — so the message now names the file and points at `VIZFOLD_DB` instead of a command that no longer exists.

## Terseness

| File | Lines |
|---|---|
| `README.md` | 471 → 408 |
| `DEMO.md` | 268 → 247 |
| `docs/esmfold.md` | 182 → 146 |
| `docs/esmfold_backend_repro.md` | 146 → 105 |
| `docs/vizfold_gateway/architecture.md` | 123 → 86 |
| `workbench/README.md` | 19 → 27 |
| `CONTRIBUTING.md` | 9 → 33 |
| `docs/todo.md` | 9 → 12 |

The two that grew were content-free stubs. `CONTRIBUTING.md` now reproduces CI exactly and states the non-obvious release rule — the installed binary clones this repo pinned to *its own* tag, so a fix to `install.sh`, `lib/`, `sites/` or `backends/*/install/` does not reach users on merge, only on a `v*` tag. `workbench/README.md` now carries the env a hand-run `npm run dev` actually needs.

## Left alone deliberately

`backends/openfold/README.md:19` still says the CC BY 4.0 copy lands in `openfold/resources/params`. That is upstream's copyright notice about upstream's installer; I am not rewriting a legal notice in a terseness pass. Worth a separate decision.

## Test plan

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` — 133 pass
- `bash -n` sweep, `tests/vocabulary.sh`, `tests/launch_args.sh`, `tests/site_config.sh`
- Independent sweep confirming no removed spelling survives in any vizfold markdown: `queue-run`, `execute-run`, `--fasta-dir`, `--demo-attn`, `vizfold fold`, `vizfold seed`, `esmfold-venv`, `.openfold-pip`, `.openfold-pkgs`
- Output samples re-derived from the source that prints them (`report_queued` `cli.rs:1771`, `report_execution` `cli.rs:1511`, status verdicts `cli.rs:966`) rather than assumed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JeXknd7QzVBysUfuxhuaUz