### PR TITLE
Docs clarity pass, and one quiet fail-fast curl form

### DIFF
--- a/DEMO.md
+++ b/DEMO.md
@@ -11,7 +11,7 @@ The `vizfold` binary and an installed OpenFold backend — the two-command boots
 [README](README.md#install):
 
 ```bash
-curl -sL https://raw.githubusercontent.com/AI2Science/vizfold-foundation/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/AI2Science/vizfold-foundation/main/install.sh | bash
 vizfold install openfold
 ```
 

--- a/DEMO.md
+++ b/DEMO.md
@@ -1,9 +1,9 @@
 # Folding a protein with the vizfold CLI
 
 The full OpenFold lifecycle through the `vizfold` CLI on a cluster: queue a sequence, fold it on a
-GPU, register the outputs, and view them. The commands below are from a clean run on **NCSA Delta**
-(A100). Every `vizfold` call is the installed binary on your `PATH` — nothing is run from a source
-checkout.
+GPU, register the outputs, and view them. The transcripts below are from a clean run on **NCSA
+Delta** (A100), so the paths, accounts and partitions in them are Delta's — `vizfold status` prints
+yours. Every `vizfold` call is the installed binary on your `PATH`, not a source checkout.
 
 ## Prerequisites
 
@@ -57,7 +57,7 @@ vizfold run 6KWC_1
 
 `vizfold run` takes a bundled example id, a path to a FASTA, or a queued run's id; given either of
 the first two it queues the run itself. That is the line `vizfold install openfold` prints on
-success. The rest of this page takes that apart.
+success. The rest of this page walks through each stage separately.
 
 ## 1. Queue a run
 
@@ -215,8 +215,8 @@ records the run. To use the backend on its own instead, run its CLI inside its e
 
 `run -p` applies the environment's `activate.d` hook — `CUTLASS_PATH`, `OPENFOLD_DATA_DIR`, the
 library paths, and the NVRTC `LD_PRELOAD` where the install pinned one — which is exactly how
-`vizfold run` invokes it. Every path is then yours to pass. ESMFold is the same command against its
-own environment; neither needs the `vizfold` binary on your `PATH`.
+`vizfold run` invokes it. You then supply every path yourself. ESMFold is the same command against
+its own environment, and neither form needs the `vizfold` binary on your `PATH`.
 
 ## Common failure modes
 
@@ -241,7 +241,7 @@ databases).
 ### `srun: Requested time limit is invalid` / `Invalid account or account/partition combination`
 
 The GPU partition and time cap come from the site profile (`sites/<ClusterName>.json`); the account
-is worked out during the install instead (on Delta, `slurm::nvme_alloc` names it from the allocation
-plus a `-delta-gpu` suffix). All three are written to `vizfold.json`. If you override any
-`OPENFOLD_GPU_*` value, keep it within the partition's limits (on Delta, `gpuA100x4-interactive`
-caps at `01:00:00`).
+is worked out during the install instead — on Delta, `slurm::nvme_alloc` names it from the allocation
+plus a `-delta-gpu` suffix, and on Delta-AI a `-dtai-gh` one. All three are written to
+`vizfold.json`. If you override any `OPENFOLD_GPU_*` value, keep it within that partition's limits;
+Delta's `gpuA100x4-interactive` caps at `01:00:00`.

--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ vizfold install openfold
 ```
 
 The binary ships only itself, so `install` clones the matching checkout to `$HOME/vizfold-src` on
-first run for the installer scripts and the dashboard. Cold: ~8 min on NCSA Delta, ~25 min where
-the AlphaFold databases have to be downloaded.
+first run for the installer scripts and the dashboard. A cold install takes ~8 minutes on a cluster
+with an AlphaFold2 mirror (measured on NCSA Delta), ~25 minutes on one where the databases are
+downloaded instead — see the cluster table below for which is which.
 
 It holds your terminal and streams every step. On a cluster it runs as a blocking `srun` job, so a
 queue wait shows as `srun: job N queued and waiting for resources`. Use `tmux` or `screen` for long
@@ -221,7 +222,7 @@ intended change.
 
 ## Commands
 
-Once a backend is installed, one command folds:
+Once a backend is installed, one command folds a sequence:
 
 ```bash
 vizfold run 1UBQ_1          # a bundled example id
@@ -284,9 +285,9 @@ For a full end-to-end walkthrough on a cluster, see [DEMO.md](DEMO.md).
   one `<ClusterName>.sh`/`.json` pair per cluster. `tests/` — install-side test suites.
 - `docs/` — architecture notes and backlog. `examples/` — inputs, attention-viz utilities, notebooks.
 
-Each backend also installs its own CLI into its environment under its own name, drivable without the
-`vizfold` binary — `<prefix>/bin/micromamba run -p <env> <name> --help`, the same form for both.
-Through vizfold, `queue`/`run` are the way in: they fill the model's arguments from the config and
+Each backend also installs its own CLI into its environment under its own name, invoked as
+`<prefix>/bin/micromamba run -p <env> <name> --help` — the same form for both, and independent of the
+`vizfold` binary. Through vizfold, `queue` and `run` fill the model's arguments from the config and
 record the run.
 
 End users install the prebuilt release binary (see [Install](#install)); the steps below build from
@@ -315,7 +316,7 @@ connect, and the queue/run paths seed the default backends, their `local-*` targ
 invocation profiles themselves, existence-guarded. Those local profiles assume the checked-out
 repository layout, so build and run against the checkout.
 
-To install just the CLI binary into `~/.cargo/bin`:
+To install only the CLI binary into `~/.cargo/bin`:
 
 ```bash
 cargo install --path . --bin vizfold --force

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ run time.
 Releases are Linux only, x86_64 or aarch64. Two steps on a cluster. First bootstrap the CLI:
 
 ```bash
-curl -sL https://raw.githubusercontent.com/AI2Science/vizfold-foundation/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/AI2Science/vizfold-foundation/main/install.sh | bash
 ```
 
 That fetches the prebuilt binary for your architecture from the latest GitHub release into

--- a/backends/openfold/install/setup.sh
+++ b/backends/openfold/install/setup.sh
@@ -165,11 +165,12 @@ setup::fetch_params() {
 setup::fetch_templates() {
     log templates
     mkdir -p "$DATA/pdb_mmcif/mmcif_files"
-    # env -u LD_LIBRARY_PATH: else system curl binds conda's feature-poor libcurl and fails. || true tolerates a 404; assert catches total failure.
+    # env -u LD_LIBRARY_PATH: else system curl binds conda's feature-poor libcurl and fails. No -S here:
+    # a 404 is expected per-entry and || true tolerates it; the count assert catches total failure.
     grep -ohE "^ *[0-9]+ [0-9A-Za-z]{4}_" "$REPO"/examples/monomer/alignments/*/*.hhr |
         awk '{ print tolower(substr($2, 1, 4)) }' | sort -u |
         xargs -P 8 -I{} sh -c \
-            '[ -s "$1/{}.cif" ] || env -u LD_LIBRARY_PATH curl -Lsf -o "$1/{}.cif" https://files.rcsb.org/download/{}.cif' _ \
+            '[ -s "$1/{}.cif" ] || env -u LD_LIBRARY_PATH curl -fsL -o "$1/{}.cif" https://files.rcsb.org/download/{}.cif' _ \
             "$DATA/pdb_mmcif/mmcif_files" || true
     local n; n=$(ls "$DATA/pdb_mmcif/mmcif_files" | wc -l)
     echo "fetched $n template mmCIFs"
@@ -177,7 +178,7 @@ setup::fetch_templates() {
 }
 
 setup::stereo() {
-    [ -f "$STEREO" ] || { env -u LD_LIBRARY_PATH curl -Lsf -o "$STEREO.part" \
+    [ -f "$STEREO" ] || { env -u LD_LIBRARY_PATH curl -fsSL -o "$STEREO.part" \
         https://git.scicore.unibas.ch/schwede/openstructure/-/raw/7102c63615b64735c4941278d92b554ec94415f8/modules/mol/alg/src/stereo_chemical_props.txt &&
         mv "$STEREO.part" "$STEREO"; }
     mkdir -p "$OF/tests/test_data/alphafold/common"

--- a/cli/src/adapters/cli.rs
+++ b/cli/src/adapters/cli.rs
@@ -1418,7 +1418,7 @@ fn ensure_micromamba() -> Result<PathBuf, DbErr> {
     run_to_completion(
         "fetching micromamba",
         std::process::Command::new("sh").arg("-c").arg(format!(
-            "curl -Ls 'https://micro.mamba.pm/api/micromamba/{arch}/latest' | tar -xj -C '{}' bin/micromamba",
+            "curl -fsSL 'https://micro.mamba.pm/api/micromamba/{arch}/latest' | tar -xj -C '{}' bin/micromamba",
             prefix.display()
         )),
     )?;

--- a/install.sh
+++ b/install.sh
@@ -33,7 +33,7 @@ bootstrap::asset() {
 bootstrap::download() {
     mkdir -p "$BIN"
     echo "downloading $ASSET ($VERSION) from $REPO ..."
-    curl -fSL "$URL" -o "$BIN/vizfold" ||
+    curl -fsSL "$URL" -o "$BIN/vizfold" ||
         die "download failed: $URL -- check that a release with this asset exists (set VIZFOLD_VERSION to pin one)"
     chmod +x "$BIN/vizfold"
     echo "installed vizfold to $BIN/vizfold"

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -68,7 +68,7 @@ mamba::ensure() {
             *) die "no micromamba build for $(uname -s)-$(uname -m)" ;;
         esac
         mkdir -p "$prefix"
-        curl -Ls "https://micro.mamba.pm/api/micromamba/$build/latest" | tar -xj -C "$prefix" bin/micromamba
+        curl -fsSL "https://micro.mamba.pm/api/micromamba/$build/latest" | tar -xj -C "$prefix" bin/micromamba
     fi
     echo "$mm"
 }


### PR DESCRIPTION
Two related changes on one branch, since both touch the same doc lines.

---

## 1. The tutorial's clarity pass, applied to README and DEMO

Same three fixes the PEARC26 tutorial took — per-machine value clarity, neutral register, no overselling — without turning either file into a walkthrough. Both stay reference documentation.

**Per-machine values attached to their machine:**

| File | Was | Now |
|---|---|---|
| `DEMO.md` | the `srun` troubleshooting named Delta's `-delta-gpu` account suffix and stopped | names Delta-AI's `-dtai-gh` too, so a reader on either machine gets a whole answer |
| `README.md` | "~8 min on NCSA Delta, ~25 min where the databases have to be downloaded" — without saying which clusters download | points at the cluster table below, which already answers it per machine |

**DEMO's transcripts are Delta's** — every path, account and partition comes from one real run. Stated once at the top, naming `vizfold status` as where a reader finds their own, rather than leaving them to infer it from `/work/nvme/bbol/...`.

**Register:** `the way in`, `takes that apart`, `Every path is then yours to pass`, and `install just the CLI binary` replaced with plain equivalents.

---

## 2. One quiet, fail-fast curl form

`curl -fsSL` everywhere: silent, no progress meter, but `-S` still surfaces a real failure and `-f` turns an HTTP error into a non-zero exit.

**Two were more than cosmetic.** The bootstrap line in README and DEMO pipes into `bash`, and `mamba::ensure` (with its Rust twin in `serve`) pipes into `tar` — neither carried `-f`, so a 404 or an outage page was handed straight to the interpreter rather than failing.

| Where | Was | Now |
|---|---|---|
| `README.md`, `DEMO.md` bootstrap | `-sL` → piped to `bash` | `-fsSL` |
| `lib/config.sh` `mamba::ensure` | `-Ls` → piped to `tar` | `-fsSL` |
| `cli/src/adapters/cli.rs` (same fetch, for `serve`) | `-Ls` → piped to `tar` | `-fsSL` |
| `install.sh` release download | `-fSL`, printed a progress meter | `-fsSL` |
| `setup.sh` stereo-props | `-Lsf`, failed silently | `-fsSL` |
| `setup.sh` mmCIF fetch | `-Lsf` | `-fsL` — **deliberately no `-S`** |

The last one expects a 404 per entry and tolerates it with `|| true`, so `-S` would print an error per miss. The comment above it now says so instead of leaving the odd flag set unexplained.

---

## Test plan

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` — 133 pass
- `bash -n` sweep, `tests/vocabulary.sh`, `tests/site_config.sh`, `tests/launch_args.sh`
- Every remaining `curl` in the tree enumerated and confirmed `-fsSL`, or `-fsL` for the documented exception
- Sweeps confirming no removed CLI spelling, no overselling phrasing, no ambiguous machine pairings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JeXknd7QzVBysUfuxhuaUz