### PR TITLE
Bootstrap micromamba once, then assume it

### DIFF
--- a/DEMO.md
+++ b/DEMO.md
@@ -209,8 +209,7 @@ records the run. To use the backend on its own instead, run its CLI inside its e
 `vizfold install openfold` prints this line:
 
 ```bash
-/work/nvme/bbol/yjayawardana/vizfold/bin/micromamba \
-  run -p /work/nvme/bbol/yjayawardana/vizfold/envs/vizfold-openfold openfold --help
+micromamba run -p /work/nvme/bbol/yjayawardana/vizfold/envs/vizfold-openfold openfold --help
 ```
 
 `run -p` applies the environment's `activate.d` hook — `CUTLASS_PATH`, `OPENFOLD_DATA_DIR`, the

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ activations and per-layer, per-head attention maps, ready to explore.
 
 The `vizfold` CLI is the platform; a model backend — a pip/conda-installable package under
 `backends/<name>/` with its own environment and installer — plugs in underneath. **OpenFold** is
-the full cluster install (micromamba env, CUDA extension build, AlphaFold2 databases); **ESMFold**
+the full cluster install (conda env, CUDA extension build, AlphaFold2 databases); **ESMFold**
 is lighter, with its own Python, PyTorch and Transformers and weights pulled from HuggingFace at
 run time.
 
@@ -13,15 +13,18 @@ run time.
 
 ## Install
 
-Releases are Linux only, x86_64 or aarch64. Two steps on a cluster. First bootstrap the CLI:
+Releases are Linux only, x86_64 or aarch64. Two steps on a cluster. First bootstrap the core
+dependencies:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/AI2Science/vizfold-foundation/main/install.sh | bash
 ```
 
 That fetches the prebuilt binary for your architecture from the latest GitHub release into
-`~/.local/bin` (set `VIZFOLD_VERSION=vX.Y.Z` to pin a release). Then a backend — OpenFold below,
-or `vizfold install esmfold` (see [docs/esmfold.md](docs/esmfold.md)):
+`~/.local/bin` (set `VIZFOLD_VERSION=vX.Y.Z` to pin a release), along with `micromamba` beside it:
+every environment is created and run through it, and everything after this point assumes both are
+on your `PATH`. Then a backend — OpenFold below, or `vizfold install esmfold`
+(see [docs/esmfold.md](docs/esmfold.md)):
 
 ```bash
 vizfold install openfold
@@ -71,19 +74,18 @@ droppings its `pip install` left in the checkout:
 vizfold uninstall openfold
 ```
 
-The config, the run database, the checkout, micromamba (shared by every environment) and any other
-backend stay, so `vizfold install openfold` puts it back where it was.
+The config, the run database, the checkout, the shared package cache and any other backend stay,
+so `vizfold install openfold` puts it back where it was.
 
 ```bash
 vizfold uninstall
 ```
 
-With no backend named it takes every backend and, on top, the workbench environment, micromamba
-and its root, `vizfold.db`, `~/.config/vizfold/vizfold.json`, the staged workbench, and the
-checkout vizfold cloned into `$HOME/vizfold-src`. It lists what it will remove and asks first
-(`--yes` skips the prompt). Fold outputs, a checkout you pointed it at yourself with
-`OPENFOLD_HOME`, and the `vizfold` binary are left alone; drop the binary with
-`rm ~/.local/bin/vizfold`.
+With no backend named it takes every backend and, on top, the workbench environment, the package
+cache, `vizfold.db`, `~/.config/vizfold/vizfold.json`, the staged workbench, and the checkout
+vizfold cloned into `$HOME/vizfold-src`. It lists what it will remove and asks first (`--yes` skips
+the prompt). Fold outputs, a checkout you pointed it at yourself with `OPENFOLD_HOME`, and the
+bootstrapped binaries are left alone; drop those with `rm ~/.local/bin/vizfold ~/.local/bin/micromamba`.
 
 ### Supported clusters
 
@@ -286,7 +288,7 @@ For a full end-to-end walkthrough on a cluster, see [DEMO.md](DEMO.md).
 - `docs/` — architecture notes and backlog. `examples/` — inputs, attention-viz utilities, notebooks.
 
 Each backend also installs its own CLI into its environment under its own name, invoked as
-`<prefix>/bin/micromamba run -p <env> <name> --help` — the same form for both, and independent of the
+`micromamba run -p <env> <name> --help` — the same form for both, and independent of the
 `vizfold` binary. Through vizfold, `queue` and `run` fill the model's arguments from the config and
 record the run.
 

--- a/backends/esmfold/install/install.sh
+++ b/backends/esmfold/install/install.sh
@@ -13,7 +13,6 @@ ESM=$REPO/backends/esmfold
 PREFIX=$(vizfold::prefix)
 STATE=$(vizfold::state esmfold)
 ENV=${ESMFOLD_ENV_PREFIX:-$(vizfold::env esmfold)}
-MM=$PREFIX/bin/micromamba
 # A cluster login node's python3 is routinely older than the package needs, so we bring our own.
 PYTHON_VERSION=3.11
 # Its own state dir: else the 2.5-3 GB torch wheel lands in the ~/.cache/pip quota this install avoids.
@@ -25,11 +24,10 @@ esmfold::present() { "$ENV/bin/python" -c 'import torch, transformers, esmfold' 
 esmfold::env() {
     log "env $ENV (python $PYTHON_VERSION)"
     rm -rf "$ENV"   # clear a partial env; create fails on a non-empty dir
-    mamba::ensure "$PREFIX" >/dev/null
     export MAMBA_ROOT_PREFIX=$PREFIX/mamba
     mkdir -p "$(dirname "$ENV")"
     # --no-rc so a user ~/.condarc envs_dirs/channels cannot redirect it.
-    "$MM" create -y --no-rc -p "$ENV" -c conda-forge "python=$PYTHON_VERSION" pip
+    micromamba create -y --no-rc -p "$ENV" -c conda-forge "python=$PYTHON_VERSION" pip
 }
 
 esmfold::install() {
@@ -87,7 +85,7 @@ Check it works -- fold the bundled example, onto a GPU node if one is configured
 
 To drive the model yourself, use its own CLI:
 
-  $MM run -p $ENV esmfold --help
+  micromamba run -p $ENV esmfold --help
 EOF
 }
 main "$@"

--- a/backends/openfold/install/setup.sh
+++ b/backends/openfold/install/setup.sh
@@ -25,13 +25,13 @@ setup::config() {
     esac
     DATA=${OPENFOLD_DATA_DIR:-$STATE/data}           # the one root every data path resolves under
     ENV_DIR=${OPENFOLD_ENV_PREFIX:-$(vizfold::env openfold)}
-    MM=$PREFIX/bin/micromamba
     CUTLASS=$STATE/cutlass
     UNICLUST=$DATA/uniclust30/uniclust30_2018_08
     STEREO=$OF/openfold/resources/stereo_chemical_props.txt
     sentinel=$STATE/.done
 
     export CONDA_PKGS_DIRS=$STATE/pkgs
+    # Unset, micromamba caches packages in $HOME/micromamba -- the quota this whole layout avoids.
     export MAMBA_ROOT_PREFIX=$PREFIX/mamba TMPDIR=$STATE/tmp
     export PIP_CACHE_DIR=$STATE/pip
     # deepspeed's autotune cache defaults to a quota'd NFS $HOME; setup::activate repeats this for runs.
@@ -46,25 +46,23 @@ setup::config() {
 }
 
 setup::preflight() {
-    mkdir -p "$PREFIX/bin" "$TMPDIR" "$DATA" "$OF/openfold/resources"
+    mkdir -p "$TMPDIR" "$DATA" "$OF/openfold/resources"
     hostname
     nvidia-smi --query-gpu=name,compute_cap --format=csv,noheader 2>/dev/null || echo "no GPU on this node"
     echo "prefix=$PREFIX repo=$REPO env=$ENV_DIR data=$DATA max_cuda=$MAX_CUDA mirror=$MIRROR${AF2:+ ($AF2)}"
     test -f "$OF/setup.py" || die "no openfold backend at $OF; is $REPO a vizfold checkout?"
 }
 
-setup::micromamba() { mamba::ensure "$PREFIX" >/dev/null; }
-
 # By path + --no-rc so a ~/.condarc envs_dirs/channels can't hijack a reproducible env.
 setup::env() {
     rm -rf "$ENV_DIR"   # clear a partial env; create fails on a non-empty dir
-    "$MM" create -y --no-rc -p "$ENV_DIR" -f "$ENV_YML" "cuda-version<=$MAX_CUDA"
+    micromamba create -y --no-rc -p "$ENV_DIR" -f "$ENV_YML" "cuda-version<=$MAX_CUDA"
 }
 
 # activate.d is the one place a fold's runtime variables come from; `micromamba run -p` applies it.
 setup::activate() {
     log activate
-    mamba::activate "$MM" "$ENV_DIR"
+    mamba::activate "$ENV_DIR"
     mkdir -p "$CONDA_PREFIX/etc/conda/activate.d"
     cat > "$CONDA_PREFIX/etc/conda/activate.d/openfold.sh" <<ACTIVATE
 export CUTLASS_PATH=$CUTLASS
@@ -106,7 +104,7 @@ print(f'{v.value // 1000}.{v.value % 1000 // 10}')" 2>/dev/null)} || true
 setup::nvrtc_create() {
     local nvrtc=$STATE/nvrtc-$DRIVER_CUDA
     rm -rf "$nvrtc"
-    "$MM" create -y --no-rc -p "$nvrtc" -c conda-forge "cuda-nvrtc<=$DRIVER_CUDA"
+    micromamba create -y --no-rc -p "$nvrtc" -c conda-forge "cuda-nvrtc<=$DRIVER_CUDA"
 }
 
 # Append every run: setup::activate rewrites openfold.sh from scratch, so this must not sit behind the create's sentinel.
@@ -237,14 +235,13 @@ Check it works -- fold the bundled example, onto a GPU node if one is configured
 
 To drive the model yourself, use its own CLI:
 
-  $MM run -p $ENV_DIR openfold --help
+  micromamba run -p $ENV_DIR openfold --help
 EOF
 }
 
 main() {
     setup::config
     setup::preflight
-    step micromamba setup::micromamba
     step env        setup::env
     setup::activate
     step cutlass    setup::cutlass

--- a/cli/src/adapters/cli.rs
+++ b/cli/src/adapters/cli.rs
@@ -407,21 +407,54 @@ fn clamp_cpus(cpus: i64, available_resources_json: &str) -> i64 {
     cpus.min(max_cpus)
 }
 
+/// What each command needs sound before it starts, in `health`'s vocabulary -- the one place a
+/// prerequisite is refused, so no command grows its own check. `Status` names none: it reports.
+fn prereqs(command: &Command) -> Vec<Component> {
+    // `run <id>` replays the run's own backend, which this gate cannot read without the DB; it
+    // checks the default instead, so uninstalling a backend out from under a queued run still
+    // reaches the runner -- which then names the missing interpreter by path.
+    let backend = |explicit: Option<Backend>| {
+        backend_health(
+            explicit
+                .or_else(|| default_backend().ok())
+                .unwrap_or(Backend::Openfold),
+        )
+    };
+    match command {
+        Command::Status | Command::Uninstall(_) | Command::Update(_) | Command::SelfUpdate(_) => {
+            vec![]
+        }
+        Command::Install(_) => vec![core_deps_health()],
+        Command::List(ListArgs {
+            resource: ListResource::Examples { .. },
+        }) => vec![repo_health()],
+        Command::Serve(_) => vec![core_deps_health(), repo_health(), config_health()],
+        Command::Download(args) => vec![config_health(), backend(Some(args.backend))],
+        Command::Queue(args) => vec![
+            config_health(),
+            backend(Some(match args.model {
+                QueueModel::Openfold(_) => Backend::Openfold,
+                QueueModel::Esmfold(_) => Backend::Esmfold,
+            })),
+        ],
+        Command::Run(args) => vec![core_deps_health(), config_health(), backend(args.backend)],
+        _ => vec![config_health()],
+    }
+}
+
 pub async fn run() -> Result<(), DbErr> {
     let cli = Cli::parse();
 
-    // These have to work before a config exists.
-    if !matches!(
-        cli.command,
-        Command::Install(_)
-            | Command::Uninstall(_)
-            | Command::Status
-            | Command::Update(_)
-            | Command::SelfUpdate(_)
-    ) && !config::is_initialized()
-    {
-        eprintln!("run `vizfold install openfold` first");
-        std::process::exit(1);
+    // Ok and Unverified proceed: an unreachable scheduler must not stop a local fold.
+    for component in prereqs(&cli.command).into_iter().map(settled) {
+        if matches!(component.state, State::Absent | State::Broken) {
+            eprintln!("{}: {}", component.name, component.detail);
+            for problem in &component.problems {
+                eprintln!("  {problem}");
+            }
+            eprintln!("  -> {}", component.remedy);
+            std::process::exit(1);
+        }
     }
 
     // These touch the filesystem only; they need no database connection.
@@ -640,9 +673,21 @@ impl State {
     }
 }
 
+/// `Broken` is derived, never tracked: a component that found problems is broken by definition.
+fn settled(component: Component) -> Component {
+    match component.problems.is_empty() {
+        true => component,
+        false => Component {
+            state: State::Broken,
+            ..component
+        },
+    }
+}
+
 /// Everything `vizfold status` can settle about an install without folding anything.
 fn health() -> Vec<Component> {
     [
+        core_deps_health(),
         binary_health(),
         repo_health(),
         config_health(),
@@ -651,14 +696,44 @@ fn health() -> Vec<Component> {
         scheduler_health(),
     ]
     .into_iter()
-    .map(|component| match component.problems.is_empty() {
-        true => component,
-        false => Component {
-            state: State::Broken,
-            ..component
-        },
-    })
+    .map(settled)
     .collect()
+}
+
+/// Executable, not merely present: a failed fetch leaves the truncated file `install.sh` skips over.
+fn executable(path: &Path) -> bool {
+    std::fs::metadata(path).is_ok_and(|meta| {
+        meta.is_file() && std::os::unix::fs::PermissionsExt::mode(&meta.permissions()) & 0o111 != 0
+    })
+}
+
+/// PATH lookup, so nothing has to record where the bootstrap put a core dependency.
+fn on_path(program: &str) -> Option<PathBuf> {
+    std::env::split_paths(&std::env::var_os("PATH")?)
+        .map(|dir| dir.join(program))
+        .find(|path| executable(path))
+}
+
+/// What `install.sh` puts beside the vizfold binary. Every environment is created and run through it.
+fn core_deps_health() -> Component {
+    let found = on_path("micromamba");
+    Component {
+        name: "core deps",
+        detail: found.as_ref().map_or_else(
+            || "micromamba".to_owned(),
+            |path| path.display().to_string(),
+        ),
+        problems: found
+            .is_none()
+            .then(|| "no executable `micromamba` on PATH".to_owned())
+            .into_iter()
+            .collect(),
+        remedy: format!(
+            "curl -fsSL https://raw.githubusercontent.com/{}/main/install.sh | bash",
+            release::repo()
+        ),
+        ..Default::default()
+    }
 }
 
 fn binary_health() -> Component {
@@ -716,7 +791,8 @@ fn config_health() -> Component {
         return Component {
             name: "config",
             state: State::Absent,
-            detail: "not initialized; run `vizfold install <backend>`".to_owned(),
+            detail: "not initialized".to_owned(),
+            remedy: "vizfold install <backend>".to_owned(),
             ..Default::default()
         };
     }
@@ -796,6 +872,7 @@ fn backend_health(backend: Backend) -> Component {
             name: backend.slug(),
             state: State::Absent,
             detail: format!("not installed ({})", env.display()),
+            remedy: format!("vizfold install {}", backend.slug()),
             ..Default::default()
         };
     }
@@ -1201,7 +1278,9 @@ fn run_uninstall(args: UninstallArgs) -> Result<(), DbErr> {
             {
                 let _ = std::fs::remove_dir(dir);
             }
-            println!("\nKept: fold outputs, the vizfold checkout, and the vizfold binary itself.");
+            println!(
+                "\nKept: fold outputs, the vizfold checkout, and the binaries in ~/.local/bin (vizfold, micromamba)."
+            );
         }
     }
     Ok(())
@@ -1214,8 +1293,7 @@ fn shared_paths(prefix: &Path, home: &Path) -> Vec<PathBuf> {
         config::env_dir("workbench"),
         prefix.join("vizfold.db"),
         config::config_file(),
-        // micromamba and its root serve every environment, so they outlive any one backend.
-        config::micromamba(prefix),
+        // The package cache outlives any one backend; the binary is bootstrap state, beside `vizfold` itself.
         prefix.join("mamba"),
     ];
     // The staged copy only; with no prefix settled the two are one path, the source tree.
@@ -1375,12 +1453,11 @@ fn ensure_node() -> Result<PathBuf, DbErr> {
     if let Some(system) = system_node_bin() {
         return Ok(system);
     }
-    let micromamba = ensure_micromamba()?;
     println!("Provisioning Node (first run only)...");
     // --no-rc so a user ~/.condarc envs_dirs/channels can't hijack it, as the backend installs do.
     run_to_completion(
         "provisioning Node",
-        std::process::Command::new(&micromamba)
+        std::process::Command::new("micromamba")
             .args([
                 "create",
                 "-y",
@@ -1394,35 +1471,6 @@ fn ensure_node() -> Result<PathBuf, DbErr> {
             .env("MAMBA_ROOT_PREFIX", config::prefix().join("mamba")),
     )?;
     Ok(bin)
-}
-
-/// The one micromamba, fetched the way `mamba::ensure` does when no backend is installed yet.
-fn ensure_micromamba() -> Result<PathBuf, DbErr> {
-    let prefix = config::prefix();
-    let micromamba = config::micromamba(&prefix);
-    if micromamba.is_file() {
-        return Ok(micromamba);
-    }
-    let arch = match (std::env::consts::OS, std::env::consts::ARCH) {
-        ("macos", "aarch64" | "arm64") => "osx-arm64",
-        ("macos", _) => "osx-64",
-        (_, "aarch64" | "arm64") => "linux-aarch64",
-        _ => "linux-64",
-    };
-    std::fs::create_dir_all(prefix.join("bin")).map_err(|error| {
-        DbErr::Custom(format!(
-            "failed to create '{}/bin': {error}",
-            prefix.display()
-        ))
-    })?;
-    run_to_completion(
-        "fetching micromamba",
-        std::process::Command::new("sh").arg("-c").arg(format!(
-            "curl -fsSL 'https://micro.mamba.pm/api/micromamba/{arch}/latest' | tar -xj -C '{}' bin/micromamba",
-            prefix.display()
-        )),
-    )?;
-    Ok(micromamba)
 }
 
 fn run_npm(dir: &Path, node_bin: &Path, args: &[&str]) -> Result<(), DbErr> {
@@ -2411,10 +2459,11 @@ mod tests {
             assert!(paths.contains(&expected), "missing {}", expected.display());
         }
         assert!(!paths.contains(&prefix.join("outputs")), "run outputs kept");
-        // micromamba serves the workbench env too; one backend's uninstall must not take it.
-        for shared in [prefix.join("mamba"), config::micromamba(&prefix)] {
-            assert!(!paths.contains(&shared), "{} is shared", shared.display());
-        }
+        // The package cache serves the workbench env too; one backend's uninstall must not take it.
+        assert!(
+            !paths.contains(&prefix.join("mamba")),
+            "the cache is shared"
+        );
         std::fs::remove_dir_all(&base).ok();
     }
 
@@ -2550,6 +2599,27 @@ mod tests {
                 component.problems.len()
             );
         }
+    }
+
+    /// A failed micromamba fetch leaves a truncated, non-executable file; reading that as installed
+    /// sends the user into `Permission denied` from inside an installer instead of at the gate.
+    #[test]
+    fn a_present_but_non_executable_file_is_not_the_dependency() {
+        let dir = std::env::temp_dir().join(format!("vizfold-exec-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let program = dir.join("micromamba");
+        std::fs::write(&program, "").unwrap();
+
+        assert!(!super::executable(&program), "0644 is not runnable");
+        std::fs::set_permissions(
+            &program,
+            std::os::unix::fs::PermissionsExt::from_mode(0o755),
+        )
+        .unwrap();
+        assert!(super::executable(&program));
+        assert!(!super::executable(&dir), "a directory is not a program");
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]

--- a/cli/src/core/config.rs
+++ b/cli/src/core/config.rs
@@ -105,11 +105,6 @@ pub fn data_dir() -> PathBuf {
         .unwrap_or_else(|| prefix().join("openfold/data"))
 }
 
-/// The one micromamba every environment is created and run through. Mirrors `mamba::ensure`.
-pub fn micromamba(prefix: &Path) -> PathBuf {
-    prefix.join("bin/micromamba")
-}
-
 /// The one directory holding every environment. Mirrors `vizfold::env_base`.
 pub fn env_base() -> PathBuf {
     resolved("VIZFOLD_ENV_BASE")

--- a/cli/src/core/services/run_execution.rs
+++ b/cli/src/core/services/run_execution.rs
@@ -88,28 +88,19 @@ pub async fn execute_run(
 
         let command = plan_command(&model_backend, &execution_target, &invocation_profile, &run)?;
 
-        // Preflight sees the bare command, the runner an env-wrapped one -- bare where nothing is installed.
+        // Preflight sees the bare command, the runner an env-wrapped one. The CLI's prereq gate
+        // refuses an uninstalled backend before this, so there is no unwrapped fallback to pick.
         let exec_command = match kind {
-            BackendKind::Openfold => {
-                let prefix = config::prefix();
-                compose_exec_command(
-                    &command,
-                    &prefix,
-                    &config::openfold_env_prefix(),
-                    &config::gpu_launch_args(),
-                    config::micromamba(&prefix).is_file(),
-                )
-            }
-            BackendKind::Esmfold => {
-                let env_prefix = config::esmfold_env_prefix();
-                let installed = env_prefix.join("bin/python").is_file();
-                compose_esmfold_command(
-                    &command,
-                    &env_prefix,
-                    &config::gpu_launch_args(),
-                    installed,
-                )
-            }
+            BackendKind::Openfold => compose_exec_command(
+                &command,
+                &config::openfold_env_prefix(),
+                &config::gpu_launch_args(),
+            ),
+            BackendKind::Esmfold => compose_esmfold_command(
+                &command,
+                &config::esmfold_env_prefix(),
+                &config::gpu_launch_args(),
+            ),
         };
 
         let report = match kind {
@@ -221,7 +212,7 @@ async fn mark_failed(
 
 /// `micromamba run -p` applies the env's activate.d hook, where every runtime variable a fold needs
 /// is set -- the same one command `setup::ready` hands the user.
-fn activate_env_command(command: &CommandSpec, prefix: &Path, env_prefix: &Path) -> CommandSpec {
+fn activate_env_command(command: &CommandSpec, env_prefix: &Path) -> CommandSpec {
     let mut args = vec![
         "run".to_owned(),
         "-p".to_owned(),
@@ -230,7 +221,8 @@ fn activate_env_command(command: &CommandSpec, prefix: &Path, env_prefix: &Path)
     ];
     args.extend(command.args.iter().cloned());
     CommandSpec {
-        program: config::micromamba(prefix).display().to_string(),
+        // Off PATH: install.sh puts it in ~/.local/bin, which srun's default --export=ALL carries over.
+        program: "micromamba".to_owned(),
         args,
         ..command.clone()
     }
@@ -239,19 +231,12 @@ fn activate_env_command(command: &CommandSpec, prefix: &Path, env_prefix: &Path)
 /// The env inside srun, streaming always on. srun must stay outermost, or the env is entered on the submit host.
 fn compose_exec_command(
     command: &CommandSpec,
-    prefix: &Path,
     env_prefix: &Path,
     launch: &[String],
-    activate: bool,
 ) -> CommandSpec {
-    let command = if activate {
-        activate_env_command(command, prefix, env_prefix)
-    } else {
-        command.clone()
-    };
     CommandSpec {
         stream: true,
-        ..srun_command(command, launch)
+        ..srun_command(activate_env_command(command, env_prefix), launch)
     }
 }
 
@@ -260,24 +245,18 @@ fn compose_esmfold_command(
     command: &CommandSpec,
     env_prefix: &Path,
     launch: &[String],
-    installed: bool,
 ) -> CommandSpec {
-    let command = if installed {
-        let mut command = CommandSpec {
-            program: env_prefix.join("bin/python").display().to_string(),
-            ..command.clone()
-        };
-        // ~2.6 GB on the first fold; HuggingFace's default is the quota'd $HOME nothing ever cleans.
-        if std::env::var_os("HF_HOME").is_none() {
-            let cache = env_prefix.join("hf");
-            command
-                .env
-                .insert("HF_HOME".to_owned(), cache.display().to_string());
-        }
-        command
-    } else {
-        command.clone()
+    let mut command = CommandSpec {
+        program: env_prefix.join("bin/python").display().to_string(),
+        ..command.clone()
     };
+    // ~2.6 GB on the first fold; HuggingFace's default is the quota'd $HOME nothing ever cleans.
+    if std::env::var_os("HF_HOME").is_none() {
+        let cache = env_prefix.join("hf");
+        command
+            .env
+            .insert("HF_HOME".to_owned(), cache.display().to_string());
+    }
     CommandSpec {
         stream: true,
         ..srun_command(command, launch)
@@ -312,16 +291,12 @@ mod tests {
             ..Default::default()
         };
 
-        let composed = compose_esmfold_command(&planned, &env, &[], true);
+        let composed = compose_esmfold_command(&planned, &env, &[]);
         assert_eq!(
             composed.env.get("HF_HOME").map(String::as_str),
             Some("/scratch/me/vizfold/envs/vizfold-esmfold/hf"),
             "the fold must not cache weights in $HOME"
         );
-
-        // Nothing installed means nothing to run, so no cache to redirect either.
-        let bare = compose_esmfold_command(&planned, &env, &[], false);
-        assert!(!bare.env.contains_key("HF_HOME"));
     }
 
     use std::{
@@ -337,7 +312,7 @@ mod tests {
 
     use crate::core::{
         commands::{CommandOutput, CommandRunner, CommandSpec, FakeCommandRunner},
-        db,
+        config, db,
         entities::runs as run_entity,
         services::{
             execution_targets::{self, RegisterExecutionTargetInput},
@@ -385,14 +360,11 @@ mod tests {
             current_dir: Some(PathBuf::from("/repo")),
             ..Default::default()
         };
-        let wrapped = activate_env_command(
-            &command,
-            &PathBuf::from("/work/of"),
-            &PathBuf::from("/work/of/envs/vizfold-openfold"),
-        );
+        let wrapped =
+            activate_env_command(&command, &PathBuf::from("/work/of/envs/vizfold-openfold"));
 
         // No shell, so nothing is re-quoted; `run -p` applies the env's activate.d hook.
-        assert_eq!(wrapped.program, "/work/of/bin/micromamba");
+        assert_eq!(wrapped.program, "micromamba");
         assert_eq!(
             wrapped.args,
             [
@@ -418,10 +390,8 @@ mod tests {
 
         let composed = compose_exec_command(
             &command,
-            &PathBuf::from("/work/of"),
             &PathBuf::from("/work/of/envs/vizfold-openfold"),
             &["srun".to_owned(), "-p".to_owned(), "gpu".to_owned()],
-            true,
         );
 
         // srun outermost: the reverse enters the env on the submit host, not the compute node.
@@ -431,7 +401,7 @@ mod tests {
             [
                 "-p",
                 "gpu",
-                "/work/of/bin/micromamba",
+                "micromamba",
                 "run",
                 "-p",
                 "/work/of/envs/vizfold-openfold",
@@ -619,8 +589,19 @@ mod tests {
             .expect("command lock")
             .clone()
             .expect("planned command");
-        assert_eq!(command.program, "python3");
-        assert_eq!(command.args, vec!["-u", "run_openfold.py"]);
+        // The plan is always wrapped: the CLI's gate refuses an uninstalled backend before this.
+        assert_eq!(command.program, "micromamba");
+        assert_eq!(
+            command.args,
+            vec![
+                "run",
+                "-p",
+                &config::openfold_env_prefix().display().to_string(),
+                "python3",
+                "-u",
+                "run_openfold.py"
+            ]
+        );
         assert!(command.stream, "long-running folds must stream output");
         let updated = run_entity::Entity::find_by_id(run.id)
             .one(&db)
@@ -652,13 +633,18 @@ mod tests {
 
         assert!(called.load(Ordering::SeqCst));
         assert_eq!(result.output.expect("output").exit_code, 0);
-        // Nothing installed in tests, so the program stays bare python3.
         let command = command
             .lock()
             .expect("command lock")
             .clone()
             .expect("planned command");
-        assert_eq!(command.program, "python3");
+        assert_eq!(
+            command.program,
+            config::esmfold_env_prefix()
+                .join("bin/python")
+                .display()
+                .to_string()
+        );
         assert!(command.args.contains(&"--fasta".into()));
         assert!(command.args.contains(&"--out".into()));
         assert_pair(&command.args, "--device", "cpu");

--- a/docs/esmfold.md
+++ b/docs/esmfold.md
@@ -55,8 +55,7 @@ yourself gets no such redirect — set `HF_HOME` first.
 The entrypoint exists only inside the backend env, so run it the way `vizfold install esmfold` prints:
 
 ```bash
-# <prefix> is OPENFOLD_PREFIX (default ~/openfold), <env> is ESMFOLD_ENV_PREFIX -- both from `vizfold status`
-<prefix>/bin/micromamba run -p <env> esmfold \
+micromamba run -p <env> esmfold \
   --fasta examples/monomer/fasta_dir_6KWC/6KWC.fasta \
   --out outputs/esmf_6KWC \
   --trace_mode attention+activations \

--- a/docs/esmfold_backend_repro.md
+++ b/docs/esmfold_backend_repro.md
@@ -6,12 +6,11 @@ Verifying the ESMFold backend end to end: inference, trace extraction, and the a
 
 ```bash
 vizfold install esmfold
-vizfold status                          # prints OPENFOLD_PREFIX and ESMFOLD_ENV_PREFIX
+vizfold status                          # prints ESMFOLD_ENV_PREFIX
 
-# neither is exported into your shell -- set them from what status printed
-export OPENFOLD_PREFIX=... ESMFOLD_ENV_PREFIX=...
-MM="$OPENFOLD_PREFIX/bin/micromamba"    # drive the backend through its own env
-$MM run -p "$ESMFOLD_ENV_PREFIX" esmfold --help
+# it is not exported into your shell -- set it from what status printed
+export ESMFOLD_ENV_PREFIX=...
+micromamba run -p "$ESMFOLD_ENV_PREFIX" esmfold --help
 ```
 
 The installer brings its own Python 3.11 — a login node's `python3` is routinely too old. For a
@@ -20,7 +19,7 @@ manual pip install instead, see Option B in [esmfold.md](esmfold.md#install).
 ## Structure-Only Inference Test
 
 ```bash
-$MM run -p "$ESMFOLD_ENV_PREFIX" esmfold \
+micromamba run -p "$ESMFOLD_ENV_PREFIX" esmfold \
   --fasta examples/monomer/fasta_dir_6KWC/6KWC.fasta \
   --out outputs/test_run \
   --trace_mode none \
@@ -37,7 +36,7 @@ Expected outputs:
 ## Trace Extraction Test (Attention + Activations)
 
 ```bash
-$MM run -p "$ESMFOLD_ENV_PREFIX" esmfold \
+micromamba run -p "$ESMFOLD_ENV_PREFIX" esmfold \
   --fasta examples/monomer/fasta_dir_6KWC/6KWC.fasta \
   --out outputs/test_trace \
   --trace_mode attention+activations \

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Bootstrap the vizfold platform CLI: download the release binary into ~/.local/bin, then `vizfold install` installs a model backend (OpenFold, ESMFold; each a pip/conda-installable package under backends/<name>/ with its own installer).
+# Bootstrap vizfold's core dependencies into ~/.local/bin -- the release binary and micromamba, which every environment is created and run through. Then `vizfold install` installs a model backend (OpenFold, ESMFold; each a pip/conda-installable package under backends/<name>/ with its own installer).
 set -euo pipefail
 
 die() { echo "FATAL: $*" >&2; exit 1; }
@@ -9,20 +9,22 @@ bootstrap::config() {
     REPO=${VIZFOLD_REPO:-AI2Science/vizfold-foundation}
     VERSION=${VIZFOLD_VERSION:-latest}   # a release tag (e.g. v0.1.0) or "latest"
     BIN=${VIZFOLD_BIN_DIR:-$HOME/.local/bin}
+    mkdir -p "$BIN"
 }
 
-# The release asset for this machine. Linux only: that is what release.yml publishes, and a model
-# backend needs CUDA and a scheduler anyway.
-bootstrap::asset() {
-    local arch
+# One OS/arch detection for every binary this bootstrap installs. Linux only: that is what
+# release.yml publishes, and a model backend needs CUDA and a scheduler anyway.
+bootstrap::arch() {
     [ "$(uname -s)" = Linux ] || die "vizfold releases are Linux-only (this is $(uname -s))"
-    arch=$(uname -m)
-    case "$arch" in
-        x86_64|amd64)  arch=x86_64 ;;
-        aarch64|arm64) arch=aarch64 ;;
-        *) die "unsupported architecture: $arch" ;;
+    case "$(uname -m)" in
+        x86_64|amd64)  ARCH=x86_64;  MAMBA_BUILD=linux-64 ;;
+        aarch64|arm64) ARCH=aarch64; MAMBA_BUILD=linux-aarch64 ;;
+        *) die "unsupported architecture: $(uname -m)" ;;
     esac
-    ASSET="vizfold-linux-${arch}"
+}
+
+bootstrap::asset() {
+    ASSET="vizfold-linux-${ARCH}"
     if [ "$VERSION" = latest ]; then
         URL="https://github.com/$REPO/releases/latest/download/$ASSET"
     else
@@ -31,12 +33,22 @@ bootstrap::asset() {
 }
 
 bootstrap::download() {
-    mkdir -p "$BIN"
     echo "downloading $ASSET ($VERSION) from $REPO ..."
     curl -fsSL "$URL" -o "$BIN/vizfold" ||
         die "download failed: $URL -- check that a release with this asset exists (set VIZFOLD_VERSION to pin one)"
     chmod +x "$BIN/vizfold"
     echo "installed vizfold to $BIN/vizfold"
+}
+
+# micromamba creates and runs every environment; everything downstream assumes it is on PATH.
+bootstrap::micromamba() {
+    if [ -x "$BIN/micromamba" ] || command -v micromamba >/dev/null; then return; fi
+    echo "downloading micromamba ($MAMBA_BUILD) ..."
+    # A failed fetch leaves a non-executable file, so the guard above self-heals on the next run.
+    curl -fsSL "https://micro.mamba.pm/api/micromamba/$MAMBA_BUILD/latest" |
+        tar -xj -O bin/micromamba > "$BIN/micromamba" || die "micromamba download failed"
+    chmod +x "$BIN/micromamba"
+    echo "installed micromamba to $BIN/micromamba"
 }
 
 # Put ~/.local/bin on PATH for future shells (idempotent), and note it for this one.
@@ -52,8 +64,10 @@ bootstrap::path() {
 
 main() {
     bootstrap::config
+    bootstrap::arch
     bootstrap::asset
     bootstrap::download
+    bootstrap::micromamba
     bootstrap::path
     echo "vizfold installed at $BIN/vizfold. Run \`vizfold install openfold\` (or \`esmfold\`) to install a model backend."
 }

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -28,7 +28,9 @@ config::file() {
 # environment first, then the file's own keys, in any order. No commands run; an unknown name is empty.
 config::fill() {
     local file=$1 label=${2:-config} key value
-    [ -r "$file" ] && command -v python3 >/dev/null || return 0
+    [ -r "$file" ] || return 0
+    # Not a missing file: without python3 every site default and saved answer is silently lost.
+    command -v python3 >/dev/null || die "no python3 on PATH: cannot read or write $file"
     echo "$label: $file" >&2
     # `if`, not `&&`: a skipped last line would return non-zero and abort a set -e caller.
     while IFS='=' read -r key value; do
@@ -53,25 +55,8 @@ for k, v in scope.items():
     return 0
 }
 
-# Activate a micromamba env ($2, a name or path) via its binary ($1). set +u: the conda gcc hook reads SYS_SYSROOT unset.
-mamba::activate() { set +u; eval "$("$1" shell hook --shell bash)"; micromamba activate "$2"; set -u; }
-
-# One micromamba at <prefix>/bin, downloaded once: every environment comes from this copy.
-mamba::ensure() {
-    local prefix=$1 mm=$1/bin/micromamba build
-    if ! "$mm" --version >/dev/null 2>&1; then
-        case "$(uname -s)-$(uname -m)" in
-            Linux-aarch64|Linux-arm64)   build=linux-aarch64 ;;
-            Linux-*)                     build=linux-64 ;;
-            Darwin-arm64|Darwin-aarch64) build=osx-arm64 ;;
-            Darwin-*)                    build=osx-64 ;;
-            *) die "no micromamba build for $(uname -s)-$(uname -m)" ;;
-        esac
-        mkdir -p "$prefix"
-        curl -fsSL "https://micro.mamba.pm/api/micromamba/$build/latest" | tar -xj -C "$prefix" bin/micromamba
-    fi
-    echo "$mm"
-}
+# Activate a micromamba env ($1, a name or path). set +u: the conda gcc hook reads SYS_SYSROOT unset.
+mamba::activate() { set +u; eval "$(micromamba shell hook --shell bash)"; micromamba activate "$1"; set -u; }
 
 # The previous install's answers. Never at source time: that would land them ahead of live discovery.
 # Called after <site>.json, fixing the precedence at


### PR DESCRIPTION
`install.sh` installs micromamba into `~/.local/bin` alongside the vizfold binary. Everything downstream resolves it off `PATH`.

## Deleted

| | Was |
|---|---|
| `mamba::ensure` (`lib/config.sh`) | fetched micromamba to `<prefix>/bin/micromamba` |
| `ensure_micromamba` (`cli.rs`) | the same fetch, for `serve` |
| `config::micromamba` (`config.rs`) | the path helper |
| `setup::micromamba` step + sentinel | `setup.sh` |
| four `Darwin-*`/`osx-*` arms | `mamba::ensure`, `ensure_micromamba` |

`install.sh` detects arch once, for both binaries. `<prefix>/bin` no longer exists. `MAMBA_ROOT_PREFIX` stays on the prefix; `uninstall` removes it and leaves the bootstrapped binaries.

## Gate-checks

`prereqs(&Command)` table + one loop at the dispatch guard, using `status`'s `Component`/`State`.

| Command | Requires |
|---|---|
| `install` | core deps |
| `run` | core deps, config, backend |
| `queue` | config, its backend |
| `serve` | core deps, repo, config |
| `download` | config, its backend |
| `status`, `update`, `self-update`, `uninstall` | — |

`Absent`/`Broken` refuses with `status`'s remedy line and exits 1. `Unverified` proceeds. `status` gains a `core deps` row.

## Also

- uv is not installed. It replaces nothing here: openfold's env is conda-native and `serve` provisions Node through micromamba, so micromamba is bootstrapped regardless.
- `config::fill` treated a missing `python3` as "file unreadable", dropping every site default and saved answer before failing at `config::save`. It now fails up front.

## Diff

**+242 / −198**, net +44. Gate-check machinery is ~90 of the additions.

## Test plan

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` — 134 pass
- `bash -n` over every tracked script; `tests/vocabulary.sh`, `tests/site_config.sh`, `tests/launch_args.sh`
- `tests/site_config.expected` unchanged
- With the config absent: `run` and `queue` print problem + remedy and exit 1; `status` exits 0

## Note

The fold invokes `micromamba` by name, so across `srun` it relies on `--export=ALL` carrying `PATH`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JeXknd7QzVBysUfuxhuaUz