### PR TITLE
Bump version to 0.7.0

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "executor"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "executor"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 default-run = "vizfold"
 


### PR DESCRIPTION
Releases #131, #132, #133 and #135.

Minor, not patch — #133 changes behaviour:

- `install`, `run`, `queue`, `serve` and `download` refuse when a prereq is missing, where they previously proceeded
- `<prefix>/bin/micromamba` is no longer created or used
- `install.sh` places micromamba in `~/.local/bin`

#135 also removes the `anvil` and `expanse` site profiles and moves Nexus's AlphaFold2 root.

The tag resolves a mismatch on `main`: `install.sh` is served from the default branch and already bootstraps micromamba, while the release binary it downloads is v0.6.0 — which clones a v0.6.0 checkout that fetches a second copy into the prefix.

## Test plan

- `cargo build` → `vizfold 0.7.0`
- `cargo test` — 134 pass
- Only `cli/Cargo.toml` and `cli/Cargo.lock` change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JeXknd7QzVBysUfuxhuaUz