### PR TITLE
Drop anvil and expanse; point Nexus at the new AlphaFold2 path

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ re-confirmed in this pass; ⚙️ site profile written and its paths probed live
 1. AF2 mirrors: Delta & Delta-AI (shared `/work/hdd`) `/work/hdd/data/alphafold2/database`, Phoenix
    `/storage/coda1/ice1/shared/d-pace_community/alphafold/alphafold_2.3.2_data`, ICE
    `/storage/ice1/shared/d-pace_community/…`, Bridges-2 `/ocean/datasets/community/alphafold/v2.3.2`,
-   Nexus `/media/volume/nexus-staging-slurm-data/database`. Each lays out `uniclust30` differently,
+   Nexus `/media/volume/data/alphafold2/database`. Each lays out `uniclust30` differently,
    so the install stages it into a canonical dir — real set if present, else aliased from uniref30.
    With no mirror the install downloads the ~4 GB parameters + the example's templates.
 2. Delta and Delta-AI share `/work/nvme`, so the aarch64 site uses a `-gh` suffix — otherwise the

--- a/README.md
+++ b/README.md
@@ -98,9 +98,7 @@ fresh install settles on.
 | `delta` (NCSA Delta) | ✅ install + fold | x86-64 | mirror¹ | `cpu` → `gpuA100x4-interactive` (A100) | `/work/nvme/<alloc>/<user>/vizfold` |
 | `delta-gh` (NCSA Delta-AI) | ✅ install + fold³ | aarch64 (GH200) | mirror¹ | `ghx4` → `ghx4-interactive` (GH200) | `/work/nvme/<alloc>/<user>/vizfold-gh`² |
 | `nexus-dev` (Nexus) | ◐ install⁵ | x86-64 | mirror¹ | `gpu` → `gpu` (A100 10 GB vGPU)⁴ | `/projects/<user>/vizfold` |
-| `anvil` (Purdue Anvil) | ◐ install⁵ | x86-64 | downloaded | `shared` → `gpu` (A100) | `$PROJECT/<user>/vizfold` |
 | `bridges2` (PSC Bridges-2) | ◐ install⁵ | x86-64 | mirror¹ | `RM-shared` → `GPU-shared` (V100-32) | `/ocean/projects/<acct>/<user>/vizfold` |
-| `expanse` (SDSC Expanse) | ⚙️ profile | x86-64 | downloaded | `shared` → `gpu-shared` (V100) | `/expanse/lustre/projects/<acct>/<user>/vizfold` |
 | `ice-slurm` (GT PACE ICE) | ⚙️ profile | x86-64 | mirror¹ | `ice-cpu` → `ice-gpu` (A100) | `<scratch>/vizfold` (`/storage/ice1/…`) |
 | `phoenix-slurm` (GT PACE Phoenix) | ⚙️ profile | x86-64 | mirror¹ | `cpu-small` → `gpu-a100` (A100) | `<scratch>/vizfold` (`/storage/scratch1/…`) |
 
@@ -120,8 +118,8 @@ re-confirmed in this pass; ⚙️ site profile written and its paths probed live
 4. Nexus's 535 driver is older than the env's NVRTC, so the install pins a matching NVRTC via
    `LD_PRELOAD`; the 10 GB vGPU gets the smaller `1UBQ_1` example. CUDA is capped at 12.8 on every
    x86 site and 12.9 on aarch64 (the 13.x build won't compile OpenFold's extension).
-5. `◐` installs each needed a site-specific fix: nexus an NVRTC pin, anvil a conda-libcurl mmCIF
-   workaround, bridges2 memory / gcc / CUDA-arch / NVRTC adjustments.
+5. `◐` installs each needed a site-specific fix: nexus an NVRTC pin, bridges2 memory / gcc /
+   CUDA-arch / NVRTC adjustments.
 
 ### Settings
 

--- a/sites/anvil.json
+++ b/sites/anvil.json
@@ -1,5 +1,0 @@
-{
-  "OPENFOLD_GPU_ACCOUNT_SUFFIX": "-gpu",
-  "OPENFOLD_GPU_PARTITION": "gpu",
-  "OPENFOLD_PARTITION": "shared"
-}

--- a/sites/anvil.sh
+++ b/sites/anvil.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-# Purdue Anvil ("anvil"). GPU jobs charge <account>-gpu (suffix in <site>.json); the prefix defaults to $OPENFOLD_BASE/vizfold (slurm::default_prefix), with OPENFOLD_BASE = $PROJECT/$USER (not the purged $SCRATCH), falling back to /anvil/scratch/$USER.
-
-slurm::discover() { OPENFOLD_BASE=${PROJECT:+$PROJECT/$USER}; export OPENFOLD_BASE=${OPENFOLD_BASE:-/anvil/scratch/$USER}; }

--- a/sites/expanse.json
+++ b/sites/expanse.json
@@ -1,6 +1,0 @@
-{
-  "OPENFOLD_BASE": "/expanse/lustre/projects/$OPENFOLD_ALLOCATION/$USER",
-  "OPENFOLD_GPU_GRES": "gpu:v100:1",
-  "OPENFOLD_GPU_PARTITION": "gpu-shared",
-  "OPENFOLD_PARTITION": "shared"
-}

--- a/sites/expanse.sh
+++ b/sites/expanse.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-# SDSC Expanse ("expanse"). No mirror; no default account, so the first association is the atom -- it doubles as the slurm account and as the /expanse project dir expanse.json templates.
-
-slurm::discover() { OPENFOLD_ALLOCATION=$(interactive::resolve OPENFOLD_ALLOCATION allocation "${OPENFOLD_ALLOCATION:-$(sacctmgr -nP show assoc user="$USER" format=Account 2>/dev/null | grep . | head -1)}"); [ -n "$OPENFOLD_ALLOCATION" ] || die "no usable allocation; set OPENFOLD_ALLOCATION"; export OPENFOLD_ALLOCATION OPENFOLD_ACCOUNT=${OPENFOLD_ACCOUNT:-$OPENFOLD_ALLOCATION}; }

--- a/sites/nexus-dev.json
+++ b/sites/nexus-dev.json
@@ -1,5 +1,5 @@
 {
-  "OPENFOLD_AF2_ROOT": "/media/volume/nexus-staging-slurm-data/database",
+  "OPENFOLD_AF2_ROOT": "/media/volume/data/alphafold2/database",
   "OPENFOLD_BUILD_TIME": "01:00:00",
   "OPENFOLD_EXAMPLE": "1UBQ_1",
   "OPENFOLD_GPU_PARTITION": "gpu",

--- a/tests/site_config.expected
+++ b/tests/site_config.expected
@@ -105,7 +105,7 @@ env=/projects/x-test/vizfold/envs/vizfold-openfold arch=x86_64 max_cuda=12.8 ove
 {
   "ESMFOLD_ENV_PREFIX": "",
   "OPENFOLD_ACCOUNT": "bbka",
-  "OPENFOLD_AF2_ROOT": "/media/volume/nexus-staging-slurm-data/database",
+  "OPENFOLD_AF2_ROOT": "/media/volume/data/alphafold2/database",
   "OPENFOLD_DATA_DIR": "/projects/x-test/vizfold/openfold/data",
   "OPENFOLD_DRIVER_CUDA": "",
   "OPENFOLD_ENV_PREFIX": "/projects/x-test/vizfold/envs/vizfold-openfold",

--- a/tests/site_config.expected
+++ b/tests/site_config.expected
@@ -1,28 +1,3 @@
-## anvil
-account=bbka partition=shared
-build=8/24G/02:00:00/
-env=/anvil/projects/x-test/x-test/vizfold/envs/vizfold-openfold arch=x86_64 max_cuda=12.8 override_cuda=12.8
-{
-  "ESMFOLD_ENV_PREFIX": "",
-  "OPENFOLD_ACCOUNT": "bbka",
-  "OPENFOLD_AF2_ROOT": "",
-  "OPENFOLD_DATA_DIR": "/anvil/projects/x-test/x-test/vizfold/openfold/data",
-  "OPENFOLD_DRIVER_CUDA": "",
-  "OPENFOLD_ENV_PREFIX": "/anvil/projects/x-test/x-test/vizfold/envs/vizfold-openfold",
-  "OPENFOLD_EXAMPLE": "6KWC_1",
-  "OPENFOLD_GPU_ACCOUNT": "bbka-gpu",
-  "OPENFOLD_GPU_GRES": "gpu:1",
-  "OPENFOLD_GPU_PARTITION": "gpu",
-  "OPENFOLD_GPU_RESOURCES": "--cpus-per-task=8 --mem=32G",
-  "OPENFOLD_GPU_TIME": "02:00:00",
-  "OPENFOLD_HOME": "{REPO}",
-  "OPENFOLD_MAX_CUDA": "12.8",
-  "OPENFOLD_PARTITION": "shared",
-  "OPENFOLD_PREFIX": "/anvil/projects/x-test/x-test/vizfold",
-  "OPENFOLD_SITE": "anvil",
-  "VIZFOLD_DB": "/anvil/projects/x-test/x-test/vizfold/vizfold.db",
-  "VIZFOLD_ENV_BASE": "/anvil/projects/x-test/x-test/vizfold/envs"
-}
 ## bridges2
 account=bbka partition=RM-shared
 build=16/24G/02:00:00/
@@ -97,31 +72,6 @@ env=/work/nvme/bbka/x-test/vizfold/envs/vizfold-openfold arch=x86_64 max_cuda=12
   "OPENFOLD_SITE": "delta",
   "VIZFOLD_DB": "/work/nvme/bbka/x-test/vizfold/vizfold.db",
   "VIZFOLD_ENV_BASE": "/work/nvme/bbka/x-test/vizfold/envs"
-}
-## expanse
-account=abc123 partition=shared
-build=8/24G/02:00:00/
-env=/expanse/lustre/projects/abc123/x-test/vizfold/envs/vizfold-openfold arch=x86_64 max_cuda=12.8 override_cuda=12.8
-{
-  "ESMFOLD_ENV_PREFIX": "",
-  "OPENFOLD_ACCOUNT": "abc123",
-  "OPENFOLD_AF2_ROOT": "",
-  "OPENFOLD_DATA_DIR": "/expanse/lustre/projects/abc123/x-test/vizfold/openfold/data",
-  "OPENFOLD_DRIVER_CUDA": "",
-  "OPENFOLD_ENV_PREFIX": "/expanse/lustre/projects/abc123/x-test/vizfold/envs/vizfold-openfold",
-  "OPENFOLD_EXAMPLE": "6KWC_1",
-  "OPENFOLD_GPU_ACCOUNT": "abc123",
-  "OPENFOLD_GPU_GRES": "gpu:v100:1",
-  "OPENFOLD_GPU_PARTITION": "gpu-shared",
-  "OPENFOLD_GPU_RESOURCES": "--cpus-per-task=8 --mem=32G",
-  "OPENFOLD_GPU_TIME": "02:00:00",
-  "OPENFOLD_HOME": "{REPO}",
-  "OPENFOLD_MAX_CUDA": "12.8",
-  "OPENFOLD_PARTITION": "shared",
-  "OPENFOLD_PREFIX": "/expanse/lustre/projects/abc123/x-test/vizfold",
-  "OPENFOLD_SITE": "expanse",
-  "VIZFOLD_DB": "/expanse/lustre/projects/abc123/x-test/vizfold/vizfold.db",
-  "VIZFOLD_ENV_BASE": "/expanse/lustre/projects/abc123/x-test/vizfold/envs"
 }
 ## ice-slurm
 account=bbka partition=ice-cpu

--- a/tests/site_config.sh
+++ b/tests/site_config.sh
@@ -12,9 +12,7 @@ trap 'rm -rf "$SANDBOX"' EXIT
 # The one login-specific atom each discover reads off the cluster; nexus-dev probes paths and skips it.
 site_env() {
     case $1 in
-        anvil)          echo 'export PROJECT=/anvil/projects/x-test' ;;
         delta|delta-gh) echo 'export OPENFOLD_ALLOCATION=bbka' ;;
-        expanse)        echo 'export OPENFOLD_ALLOCATION=abc123' ;;
         ice-slurm)      echo 'SCRATCH=/storage/ice1/x-test' ;;
         phoenix-slurm)  echo 'SCRATCH=/storage/scratch1/x-test' ;;
         nexus-dev)      echo 'export OPENFOLD_BASE=/projects/x-test; skip=1' ;;


### PR DESCRIPTION
## Dropped anvil and expanse

Neither cluster has AlphaFold2 databases.

- `sites/anvil.sh`, `sites/anvil.json`, `sites/expanse.sh`, `sites/expanse.json`
- their rows in the README cluster table, and anvil from the site-fix footnote
- their arms in `tests/site_config.sh`'s `site_env`

Remaining sites: `bridges2`, `delta`, `delta-gh`, `ice-slurm`, `nexus-dev`, `phoenix-slurm`.

## Nexus AlphaFold2 path

`/media/volume/nexus-staging-slurm-data/database` → `/media/volume/data/alphafold2/database`, in `sites/nexus-dev.json`, the README mirror footnote, and the snapshot.

(Also updated outside this repo: `PEARC26_TUTORIAL.md` and the PEARC26 artifact.)

## Test plan

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` — 134 pass
- `bash -n` over every tracked script; `tests/vocabulary.sh`, `tests/launch_args.sh`
- `tests/site_config.sh` — 6 sites resolve unchanged
- The site-removal snapshot diff was 0 added / 50 removed, so no surviving site's resolution moved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JeXknd7QzVBysUfuxhuaUz