### PR TITLE
Carry the fold's data root on the command, not in the env's hook

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "executor"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "chrono",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "executor"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2024"
 default-run = "vizfold"
 

--- a/cli/src/core/services/run_execution.rs
+++ b/cli/src/core/services/run_execution.rs
@@ -220,12 +220,27 @@ fn activate_env_command(command: &CommandSpec, env_prefix: &Path) -> CommandSpec
         command.program.clone(),
     ];
     args.extend(command.args.iter().cloned());
-    CommandSpec {
+    let mut wrapped = CommandSpec {
         // Off PATH: install.sh puts it in ~/.local/bin, which srun's default --export=ALL carries over.
         program: "micromamba".to_owned(),
         args,
         ..command.clone()
+    };
+    // Carried, not left to the env's activate.d hook: that hook is written by whichever installer
+    // built the env, so a fold through an older one runs without them. Triton's default is NFS $HOME.
+    let user = std::env::var("USER").unwrap_or_else(|_| "vizfold".to_owned());
+    for (key, value) in [
+        (
+            "OPENFOLD_DATA_DIR",
+            config::data_dir().display().to_string(),
+        ),
+        ("TRITON_CACHE_DIR", format!("/tmp/vizfold-triton-{user}")),
+    ] {
+        if std::env::var_os(key).is_none() {
+            wrapped.env.entry(key.to_owned()).or_insert(value);
+        }
     }
+    wrapped
 }
 
 /// The env inside srun, streaming always on. srun must stay outermost, or the env is entered on the submit host.
@@ -378,6 +393,19 @@ mod tests {
             ]
         );
         assert_eq!(wrapped.current_dir, Some(PathBuf::from("/repo")));
+    }
+
+    /// An env's activate.d hook is written by whichever installer built it, so the fold carries its
+    /// own: through an older env it would otherwise run with neither set.
+    #[test]
+    fn the_fold_carries_the_data_root_and_a_node_local_cache() {
+        let wrapped = activate_env_command(&CommandSpec::default(), &PathBuf::from("/env"));
+
+        assert_eq!(
+            wrapped.env.get("OPENFOLD_DATA_DIR").map(String::as_str),
+            Some(config::data_dir().display().to_string().as_str())
+        );
+        assert!(wrapped.env["TRITON_CACHE_DIR"].starts_with("/tmp/"));
     }
 
     #[test]


### PR DESCRIPTION
Fixes a fold failing with `OPENFOLD_DATA_DIR is unset` on v0.7.0, and releases 0.7.1.

## What happened

A fold read `OPENFOLD_DATA_DIR` only from the environment's `activate.d/openfold.sh` hook. That file is written by whichever installer built the environment, so an environment created before the hook exported it runs the model with the variable unset:

```
run_pretrained_openfold.py: error: OPENFOLD_DATA_DIR is unset
srun: error: gpua089: task 0: Exited with exit code 2
```

`vizfold status` reported `Everything checks out.` throughout, because it reads the config — which has the value.

The same environment also lacked `TRITON_CACHE_DIR`, so deepspeed's autotune cache fell back to NFS `$HOME`:

```
Warning: The cache directory for DeepSpeed Triton autotune, /u/<user>/.triton/autotune,
appears to be on an NFS system.
```

## What changed

`activate_env_command` sets both on the command from the config. Each defers to an inherited value, so an inline override still wins, and the hook keeps its copies for a hand-run `micromamba run`.

+29 / −1, of which 13 is the regression test.

## Test plan

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` — 135 pass, including `the_fold_carries_the_data_root_and_a_node_local_cache`
- `bash -n` over every tracked script; `tests/vocabulary.sh`, `tests/site_config.sh`, `tests/launch_args.sh`
- `cargo build` → `vizfold 0.7.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JeXknd7QzVBysUfuxhuaUz