### PR TITLE
Bump version to 0.7.2

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "executor"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "async-trait",
  "chrono",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "executor"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2024"
 default-run = "vizfold"
 


### PR DESCRIPTION
Releases #138.

**Patch — nothing user-facing changed.** #138 is test-quality work; its three production edits are behaviour-preserving:

- `removal_plan` extracted from `run_uninstall` (same filtering, now separately testable)
- `database_url_from` extracted from `database_url` (same three sources, same precedence)
- `setup.sh` gained the library guard `lib/*.sh` already have, so sourcing it yields definitions rather than running `main`. Executing it is unchanged, which is how `slurm::run` invokes it.

The tag still earns its place: an install clones the checkout pinned to it, so `tests/link_mirror.sh` and the corrected `site_config` harness reach a checkout only on a release.

## Test plan

- `cargo build` → `vizfold 0.7.2`
- `cargo test` — 127 pass
- Only `cli/Cargo.toml` and `cli/Cargo.lock` change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JeXknd7QzVBysUfuxhuaUz