### PR TITLE
One job per update command, and a quiet download

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,14 +54,16 @@ An install is two halves: the `vizfold` binary and the checkout it runs the inst
 dashboard from, pinned to the binary's own release tag.
 
 ```bash
-vizfold self-update      # replace the binary with the newest release, then bring its checkout along
-vizfold update           # move the checkout to this binary's tag (clones it if there is none)
+vizfold self-update      # the binary only
+vizfold update           # the checkout only, to this binary's tag (clones it if there is none)
 ```
 
-`self-update` runs `vizfold update` afterwards because a new binary on an old checkout runs the old
-install scripts — which `status` reports as a broken `repo` if the two ever drift. `vizfold update
---ref <tag-or-branch>` moves the checkout somewhere else; it refuses to touch a checkout with
-uncommitted changes.
+One command each, so run both to move a whole install. Between them the checkout is behind, which
+`status` reports as a broken `repo` — "the scripts are v0.7.1, but this binary is v0.7.2" — and
+which `serve` and `list examples` refuse on, since both read the checkout.
+
+`vizfold update --ref <tag-or-branch>` moves the checkout somewhere else; it refuses to touch a
+checkout with uncommitted changes.
 
 ### Uninstall
 
@@ -239,8 +241,8 @@ install             Install a model backend (openfold or esmfold) on this machin
 download            Download a backend's data (OpenFold AlphaFold2 databases/params)
 status              Show resolved config, which backends are installed, and whether it all checks out
 uninstall           Remove one backend, or everything the install generated
-update              Update the vizfold checkout the installers and dashboard come from
-self-update         Replace this binary with the latest release, then update the checkout to match
+update              Move the checkout the installers and dashboard run from to this binary's release
+self-update         Replace this binary with the latest release. Run `update` after, for the checkout
 serve               Start the workbench dashboard
 list                List executor records
 show                Show one executor record

--- a/cli/src/adapters/cli.rs
+++ b/cli/src/adapters/cli.rs
@@ -45,9 +45,9 @@ enum Command {
     Status,
     /// Remove one backend, or everything the install generated.
     Uninstall(UninstallArgs),
-    /// Update the vizfold checkout the installers and dashboard come from.
+    /// Move the checkout the installers and dashboard run from to this binary's release.
     Update(UpdateArgs),
-    /// Replace this binary with the latest release, then update the checkout to match.
+    /// Replace this binary with the latest release. Run `update` after, for the checkout.
     SelfUpdate(SelfUpdateArgs),
     /// Start the workbench dashboard.
     Serve(ServeArgs),
@@ -1190,16 +1190,9 @@ fn run_self_update(args: SelfUpdateArgs) -> Result<(), DbErr> {
         ))
     })?;
     println!("vizfold {wanted} is installed at {}", exe.display());
-
-    // The new binary, not this one, knows which checkout its own scripts came from.
-    println!();
-    match std::process::Command::new(&exe).arg("update").status() {
-        Ok(status) if status.success() => Ok(()),
-        _ => {
-            println!("The checkout could not be updated; run `vizfold update` yourself.");
-            Ok(())
-        }
-    }
+    // The scripts are pinned per version, so the checkout is now behind until `update` moves it.
+    println!("The checkout still runs {current}'s scripts. Bring it along with: vizfold update");
+    Ok(())
 }
 
 /// Prove the download is a working binary of the version it claims before it replaces anything.
@@ -1207,7 +1200,7 @@ fn fetch_release(url: &str, staged: &Path, wanted: &str) -> Result<(), DbErr> {
     run_to_completion(
         "download",
         std::process::Command::new("curl")
-            .args(["-fSL", url, "-o"])
+            .args(["-fsSL", url, "-o"])
             .arg(staged),
     )?;
     std::fs::set_permissions(staged, std::os::unix::fs::PermissionsExt::from_mode(0o755))


### PR DESCRIPTION
## `self-update` and `update` each do one thing

`self-update` no longer runs `vizfold update` when it finishes. It replaces the binary and says what is left:

```
vizfold 0.7.2 is installed at /u/<you>/.local/bin/vizfold
The checkout still runs 0.7.1's scripts. Bring it along with: vizfold update
```

The invariant the chaining protected still holds — it is just stated rather than fixed behind your back. `status` reports the drift:

```
repo       BROKEN  /u/<you>/vizfold-src at v0.7.1
  the scripts are v0.7.1, but this binary is v0.7.2
  -> vizfold update
```

and `serve` and `list examples` refuse on it, since both read the checkout. `run` and `queue` do not — they gate on the config and the backend.

## The download is quiet

`fetch_release` builds its curl in Rust rather than as a literal string, so #132's `-fsSL` sweep missed it and every `self-update` printed curl's progress meter. `-fSL` → `-fsSL`. `latest_tag` already used `-sIL`.

## Descriptions

| | Was | Now |
|---|---|---|
| `update` | Update the vizfold checkout the installers and dashboard come from | Move the checkout the installers and dashboard run from to this binary's release |
| `self-update` | Replace this binary with the latest release, then update the checkout to match | Replace this binary with the latest release. Run `update` after, for the checkout |

README's *Keeping it current* section and its command block rewritten to match; the block is now byte-identical to `--help` apart from the `help` row it omits.

## Test plan

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` — 127 pass
- `bash -n`; `tests/vocabulary.sh`, `site_config.sh`, `launch_args.sh`, `link_mirror.sh`
- `--help` for both commands read back from the built binary and diffed against README

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JeXknd7QzVBysUfuxhuaUz