### PR TITLE
Catch the site snapshot up with the Nexus database move

### DIFF
--- a/tests/site_config.expected
+++ b/tests/site_config.expected
@@ -105,7 +105,7 @@ env=/projects/x-test/vizfold/envs/vizfold-openfold arch=x86_64 max_cuda=12.8 ove
 {
   "ESMFOLD_ENV_PREFIX": "",
   "OPENFOLD_ACCOUNT": "bbka",
-  "OPENFOLD_AF2_ROOT": "/media/volume/data/alphafold2/database",
+  "OPENFOLD_AF2_ROOT": "/projects/alphafold2/database",
   "OPENFOLD_DATA_DIR": "/projects/x-test/vizfold/openfold/data",
   "OPENFOLD_DRIVER_CUDA": "",
   "OPENFOLD_ENV_PREFIX": "/projects/x-test/vizfold/envs/vizfold-openfold",


### PR DESCRIPTION
`main` is red. #141 changed `OPENFOLD_AF2_ROOT` in `sites/nexus-dev.json` to `/projects/alphafold2/database` without regenerating `tests/site_config.expected`, so `install tests` has failed on every commit since:

```
failure  install tests  3278470
```

This regenerates the snapshot. One line, a pure substitution — the other five sites are byte-identical, which is the snapshot doing exactly what it is for.

```diff
-  "OPENFOLD_AF2_ROOT": "/media/volume/data/alphafold2/database",
+  "OPENFOLD_AF2_ROOT": "/projects/alphafold2/database",
```

## Note for whoever changes a site next

`sites/*.json` and `tests/site_config.expected` move together. `bash tests/site_config.sh -u` regenerates it, and the diff should only ever touch the site you changed.

## Test plan

- `tests/site_config.sh` — 6 sites resolve unchanged
- `tests/vocabulary.sh`, `tests/launch_args.sh`, `tests/link_mirror.sh`
- `cargo test` — 127 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JeXknd7QzVBysUfuxhuaUz