### PR TITLE
Bump version to 0.8.0

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "executor"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "executor"
-version = "0.7.2"
+version = "0.8.0"
 edition = "2024"
 default-run = "vizfold"
 


### PR DESCRIPTION
Releases #140, #141 and #142.

**Minor, not patch** — #140 changes what `self-update` does:

- it replaces the binary and stops there; it used to run `vizfold update` afterwards
- anything scripting it needs `vizfold update` as a second step
- between the two, `status` reports the checkout as a broken `repo`, and `serve` / `list examples` refuse on it

Also carries #141's Nexus AlphaFold2 move to `/projects/alphafold2/database`, and #142, which regenerated `tests/site_config.expected` to match — `install tests` had been failing on main between those two commits.

## Test plan

- `cargo build` → `vizfold 0.8.0`
- `cargo test` — 127 pass
- Only `cli/Cargo.toml` and `cli/Cargo.lock` change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JeXknd7QzVBysUfuxhuaUz