### PR TITLE
One dashboard per backend set: `serve [BACKENDS]...`

### DIFF
--- a/DEMO.md
+++ b/DEMO.md
@@ -199,13 +199,15 @@ ID  TYPE ID  FORMAT     STORAGE URI
 ## 5. View it in the dashboard
 
 ```bash
-vizfold serve
+vizfold serve            # every installed backend; name them to serve a subset
 ```
 
 This stages and starts the Next.js workbench (installing its dependencies on first run) at
 `http://localhost:3000`, linking `$OPENFOLD_PREFIX/runs` under the app's `public/` so the browser
 can load each run's outputs. The dashboard renders the predicted structure in an interactive 3D
-viewer and shows the attention maps. From a laptop, forward the port over SSH:
+viewer and shows the attention maps. It folds with, and lists runs from, the backends it serves —
+`vizfold serve openfold` on a host with both installed hides the ESMFold runs. From a laptop,
+forward the port over SSH:
 
 ```bash
 ssh -L 3000:localhost:3000 <you>@delta.ncsa.illinois.edu

--- a/README.md
+++ b/README.md
@@ -252,6 +252,15 @@ execution and land in one run directory, keyed by FASTA tag: `<tag>_model_1_ptm_
 `attention/<tag>/`. `--no-exec` records the run and stops, printing the id to hand back to `run`
 later. `serve` opens the dashboard over the outputs. `vizfold <command> --help` details any one.
 
+```bash
+vizfold serve                     # every installed backend
+vizfold serve esmfold             # one, refused if it is not installed
+vizfold serve openfold esmfold    # both, with a model picker on the Fold card
+```
+
+The dashboard folds with, and lists runs from, the backends it was told to serve; runs from the
+others stay in the database, out of sight.
+
 ```text
 install             Install the checkout everything runs from (`base`), or a model backend from it
 download            Download a backend's data (OpenFold AlphaFold2 databases/params)
@@ -259,7 +268,7 @@ status              Show resolved config, which backends are installed, and whet
 uninstall           Remove one part, or everything the install generated
 update              Move the checkout to this binary's release (`base`), or reinstall a backend from it
 self-update         Replace this binary with the latest release. Run `update base` after, for the checkout
-serve               Start the workbench dashboard
+serve               Start the workbench dashboard, over the given backends (default: all installed)
 list                List executor records
 show                Show one executor record
 run                 Fold targets in one execution: bundled examples, FASTAs, directories of FASTAs -- or a queued run by id
@@ -356,7 +365,7 @@ npm install
 npm run dev            # http://localhost:3000
 ```
 
-`vizfold serve` exports `VIZFOLD_DB`/`OPENFOLD_PREFIX` and links run outputs under `public/runs` so
+`vizfold serve` exports `VIZFOLD_DB`/`OPENFOLD_PREFIX`/`VIZFOLD_BACKENDS` and links run outputs under `public/runs` so
 the 3D viewer and attention images can load them. The workbench reads `process.env` only, never the
 vizfold config, so `npm run dev` by hand needs both passed in — see
 [workbench/README.md](workbench/README.md).

--- a/cli/src/adapters/cli.rs
+++ b/cli/src/adapters/cli.rs
@@ -51,7 +51,7 @@ enum Command {
     Update(UpdateArgs),
     /// Replace this binary with the latest release. Run `update base` after, for the checkout.
     SelfUpdate(SelfUpdateArgs),
-    /// Start the workbench dashboard.
+    /// Start the workbench dashboard, over the given backends (default: all installed).
     Serve(ServeArgs),
     /// List executor records.
     List(ListArgs),
@@ -245,9 +245,33 @@ struct SelfUpdateArgs {
 
 #[derive(Debug, Args)]
 struct ServeArgs {
+    /// Backends the dashboard folds with and lists runs for. Defaults to every one installed.
+    #[arg(value_enum)]
+    backends: Vec<Backend>,
     /// Port for the dashboard dev server. Defaults to 3000.
     #[arg(long)]
     port: Option<u16>,
+}
+
+impl ServeArgs {
+    /// What the dashboard is handed, comma-joined: the backends named, in the order given, else
+    /// every one installed -- never a Fold option that cannot run.
+    fn backends_env(&self) -> String {
+        let served: Vec<Backend> = if self.backends.is_empty() {
+            Backend::value_variants()
+                .iter()
+                .copied()
+                .filter(|backend| backend.is_installed())
+                .collect()
+        } else {
+            self.backends.clone()
+        };
+        served
+            .iter()
+            .map(|backend| backend.slug())
+            .collect::<Vec<_>>()
+            .join(",")
+    }
 }
 
 #[derive(Debug, Args)]
@@ -424,7 +448,11 @@ fn prereqs(command: &Command) -> Vec<Component> {
         Command::List(ListArgs {
             resource: ListResource::Examples { .. },
         }) => vec![repo_health()],
-        Command::Serve(_) => vec![core_deps_health(), repo_health(), config_health()],
+        // Only the backends named: bare `serve` resolves to what is installed, so it can gate on nothing.
+        Command::Serve(args) => [core_deps_health(), repo_health(), config_health()]
+            .into_iter()
+            .chain(args.backends.iter().copied().map(backend_health))
+            .collect(),
         Command::Download(args) => {
             vec![repo_health(), config_health(), backend(Some(args.backend))]
         }
@@ -1441,22 +1469,31 @@ fn run_serve(args: ServeArgs) -> Result<(), DbErr> {
 
     let node_bin = ensure_node()?;
 
+    let backends = args.backends_env();
+
     let node_modules = workbench.join("node_modules");
     let empty =
         std::fs::read_dir(&node_modules).map_or(true, |mut entries| entries.next().is_none());
     if empty {
         println!("Installing workbench dependencies (npm install)...");
-        run_npm(&workbench, &node_bin, &["install"])?;
+        run_npm(&workbench, &node_bin, &["install"], &backends)?;
     }
 
     let port = args.port.unwrap_or(3000);
-    println!("Starting workbench at http://localhost:{port}");
+    println!(
+        "Starting workbench at http://localhost:{port} ({})",
+        if backends.is_empty() {
+            "no backend installed"
+        } else {
+            &backends
+        }
+    );
     let port_arg = port.to_string();
     let mut npm_args = vec!["run", "dev"];
     if args.port.is_some() {
         npm_args.extend(["--", "--port", &port_arg]);
     }
-    run_npm(&workbench, &node_bin, &npm_args)
+    run_npm(&workbench, &node_bin, &npm_args, &backends)
 }
 
 /// Where the dashboard runs from: a copy on the prefix's filesystem, so node_modules never lands on home.
@@ -1560,7 +1597,7 @@ fn ensure_node() -> Result<PathBuf, DbErr> {
     Ok(bin)
 }
 
-fn run_npm(dir: &Path, node_bin: &Path, args: &[&str]) -> Result<(), DbErr> {
+fn run_npm(dir: &Path, node_bin: &Path, args: &[&str], backends: &str) -> Result<(), DbErr> {
     let mut command = std::process::Command::new(node_bin.join("npm"));
     command.current_dir(dir).args(args);
     // npm's shebang and `next`'s spawn both resolve `node` off PATH, so the env has to lead it.
@@ -1581,6 +1618,8 @@ fn run_npm(dir: &Path, node_bin: &Path, args: &[&str]) -> Result<(), DbErr> {
         config::env_dir("workbench").join(".npm"),
     );
     command.env("OPENFOLD_PREFIX", config::prefix());
+    // The resolved set, always explicit, so the dashboard needs no notion of what "all" means.
+    command.env("VIZFOLD_BACKENDS", backends);
     // node:sqlite cannot open database_url()'s sqlite://...?mode=rwc wrapper; hand it the plain path.
     if let Some(database) = config::database_path() {
         command.env("VIZFOLD_DB", database);
@@ -2555,26 +2594,57 @@ mod tests {
         );
     }
 
-    /// Each backend reads its own key, so a stray `ESMFOLD_ENV_PREFIX` cannot move OpenFold's env.
+    /// Each backend reads its own key, so a stray `ESMFOLD_ENV_PREFIX` cannot move OpenFold's env
+    /// -- and that reading is exactly what bare `serve` hands the dashboard. Both keys are pinned
+    /// here rather than in a second test, which would race this one over the same variables.
     #[test]
     fn backend_is_installed_tracks_its_own_env_prefix_key() {
         let base = std::env::temp_dir().join(format!("vizfold-backend-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&base);
-        std::fs::create_dir_all(&base).unwrap();
+        std::fs::create_dir_all(base.join("openfold")).unwrap();
+        std::fs::create_dir_all(base.join("esmfold")).unwrap();
         // SAFETY: single-threaded test; pinned so env_prefix() does not read the real config.
-        unsafe { std::env::set_var("ESMFOLD_ENV_PREFIX", &base) };
-        assert_eq!(Backend::Esmfold.env_prefix(), base);
-        assert_ne!(Backend::Openfold.env_prefix(), base);
+        unsafe {
+            std::env::set_var("OPENFOLD_ENV_PREFIX", base.join("openfold"));
+            std::env::set_var("ESMFOLD_ENV_PREFIX", base.join("esmfold"));
+        }
+        assert_eq!(Backend::Esmfold.env_prefix(), base.join("esmfold"));
+        assert_ne!(Backend::Openfold.env_prefix(), base.join("esmfold"));
         assert!(
             Backend::Esmfold.is_installed(),
             "an existing env dir reads as installed"
         );
-        std::fs::remove_dir_all(&base).unwrap();
+
+        let served = |argv: &[&str]| match Cli::try_parse_from(argv)
+            .expect("argv should parse")
+            .command
+        {
+            Command::Serve(args) => args.backends_env(),
+            other => panic!("expected serve, got {other:?}"),
+        };
+        assert_eq!(served(&["vizfold", "serve"]), "openfold,esmfold");
+        // Named backends are honoured as given -- order included, since it picks the Fold default.
+        assert_eq!(served(&["vizfold", "serve", "esmfold"]), "esmfold");
+        assert_eq!(
+            served(&["vizfold", "serve", "esmfold", "openfold"]),
+            "esmfold,openfold"
+        );
+
+        std::fs::remove_dir_all(base.join("esmfold")).unwrap();
         assert!(
             !Backend::Esmfold.is_installed(),
             "a missing env dir reads as not installed"
         );
-        unsafe { std::env::remove_var("ESMFOLD_ENV_PREFIX") };
+        assert_eq!(
+            served(&["vizfold", "serve"]),
+            "openfold",
+            "bare serve offers what is installed, not what exists"
+        );
+        std::fs::remove_dir_all(&base).unwrap();
+        unsafe {
+            std::env::remove_var("OPENFOLD_ENV_PREFIX");
+            std::env::remove_var("ESMFOLD_ENV_PREFIX");
+        }
     }
 
     /// A bare `uninstall` stays: it is the only thing that removes what no part owns.
@@ -2759,6 +2829,12 @@ mod tests {
             names(&["vizfold", "serve"]),
             ["core deps", "repo", "config"]
         );
+        // Named backends are gated; bare `serve` resolves to the installed ones, so it gates on none.
+        assert_eq!(
+            names(&["vizfold", "serve", "openfold", "esmfold"]),
+            ["core deps", "repo", "config", "openfold", "esmfold"]
+        );
+        assert!(Cli::try_parse_from(["vizfold", "serve", "base"]).is_err());
         assert_eq!(
             names(&["vizfold", "download", "openfold"]),
             ["repo", "config", "openfold"]

--- a/workbench/README.md
+++ b/workbench/README.md
@@ -6,7 +6,8 @@ and shells out to the `vizfold` binary (`list examples`, `run <id> --no-exec`, `
 ## Running it
 
 ```bash
-vizfold serve                # http://localhost:3000
+vizfold serve                     # every installed backend, http://localhost:3000
+vizfold serve openfold esmfold    # only these two
 vizfold serve --port 4000
 ```
 
@@ -15,7 +16,9 @@ vizfold serve --port 4000
   `OPENFOLD_HOME`); it never clones a missing checkout
 - provisions Node if the host has none (>= 22.13, for `node:sqlite`)
 - runs `npm install` on first use, then `npm run dev`
-- exports `VIZFOLD_BIN`, `OPENFOLD_PREFIX` and `VIZFOLD_DB`
+- exports `VIZFOLD_BIN`, `OPENFOLD_PREFIX`, `VIZFOLD_DB` and `VIZFOLD_BACKENDS` (the served slugs,
+  comma-separated: the run list is filtered to them, and the Fold card picks between them when there
+  is more than one). Unset — `npm run dev` by hand — filters nothing and lets the CLI choose.
 - symlinks `<OPENFOLD_PREFIX>/runs` to `public/runs`, so the 3D viewer and attention images resolve
 
 `npm run dev` by hand needs that env passed in — the workbench reads `process.env` only, never the

--- a/workbench/app/FoldCard.tsx
+++ b/workbench/app/FoldCard.tsx
@@ -4,9 +4,16 @@ import { useRouter } from "next/navigation";
 import { useState } from "react";
 import type { Example } from "@/lib/vizfold";
 
-export default function FoldCard({ examples }: { examples: Example[] }) {
+export default function FoldCard({
+  examples,
+  backends,
+}: {
+  examples: Example[];
+  backends: string[];
+}) {
   const router = useRouter();
   const [inputId, setInputId] = useState(examples[0]?.id ?? "");
+  const [backend, setBackend] = useState(backends[0] ?? "");
   const [attn, setAttn] = useState(true);
   const [folding, setFolding] = useState(false);
   const [error, setError] = useState("");
@@ -33,7 +40,7 @@ export default function FoldCard({ examples }: { examples: Example[] }) {
       const response = await fetch("/api/runs", {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ inputId, attn }),
+        body: JSON.stringify({ inputId, attn, backend }),
       });
       const body = await response.json();
       if (!response.ok) throw new Error(body.error ?? "Could not start the fold.");
@@ -68,6 +75,23 @@ export default function FoldCard({ examples }: { examples: Example[] }) {
             ))}
           </select>
         </label>
+
+        {backends.length > 1 ? (
+          <label className="field">
+            <span>Model</span>
+            <select
+              value={backend}
+              onChange={(event) => setBackend(event.target.value)}
+              disabled={folding}
+            >
+              {backends.map((slug) => (
+                <option key={slug} value={slug}>
+                  {slug}
+                </option>
+              ))}
+            </select>
+          </label>
+        ) : null}
 
         <label className="field">
           <span className="check">

--- a/workbench/app/api/runs/route.ts
+++ b/workbench/app/api/runs/route.ts
@@ -13,7 +13,7 @@ export async function POST(request: Request) {
     );
   }
   // Same: only a backend this dashboard serves reaches the CLI's argv.
-  if (backend && !BACKENDS.includes(backend)) {
+  if (backend && BACKENDS && !BACKENDS.includes(backend)) {
     return NextResponse.json(
       { error: `Backend "${backend}" is not being served.` },
       { status: 400 },

--- a/workbench/app/api/runs/route.ts
+++ b/workbench/app/api/runs/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from "next/server";
-import { foldInBackground, listExamples, queueRun } from "@/lib/vizfold";
+import { BACKENDS, foldInBackground, listExamples, queueRun } from "@/lib/vizfold";
 
 export async function POST(request: Request) {
-  const { inputId, attn = true } = await request.json();
+  const { inputId, attn = true, backend = "" } = await request.json();
 
   // Trust boundary: only an id the CLI itself listed is ever handed back to it.
   const example = (await listExamples()).find((one) => one.id === inputId);
@@ -12,9 +12,16 @@ export async function POST(request: Request) {
       { status: 400 },
     );
   }
+  // Same: only a backend this dashboard serves reaches the CLI's argv.
+  if (backend && !BACKENDS.includes(backend)) {
+    return NextResponse.json(
+      { error: `Backend "${backend}" is not being served.` },
+      { status: 400 },
+    );
+  }
 
   try {
-    const runId = await queueRun(example, Boolean(attn));
+    const runId = await queueRun(example, Boolean(attn), backend);
     foldInBackground(runId);
     return NextResponse.json({ runId }, { status: 201 });
   } catch (error) {

--- a/workbench/app/page.tsx
+++ b/workbench/app/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { listRuns } from "@/lib/db";
-import { listExamples } from "@/lib/vizfold";
+import { BACKENDS, listExamples } from "@/lib/vizfold";
 import FoldCard from "@/app/FoldCard";
 import Poller from "@/app/Poller";
 
@@ -26,7 +26,7 @@ export default async function HomePage() {
         </div>
       </section>
 
-      <FoldCard examples={examples} />
+      <FoldCard examples={examples} backends={BACKENDS} />
 
       <section className="panel">
         <div className="panel-header">

--- a/workbench/app/page.tsx
+++ b/workbench/app/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { listRuns } from "@/lib/db";
-import { BACKENDS, listExamples } from "@/lib/vizfold";
+import { FOLDABLE, listExamples } from "@/lib/vizfold";
 import FoldCard from "@/app/FoldCard";
 import Poller from "@/app/Poller";
 
@@ -26,7 +26,7 @@ export default async function HomePage() {
         </div>
       </section>
 
-      <FoldCard examples={examples} backends={BACKENDS} />
+      <FoldCard examples={examples} backends={FOLDABLE} />
 
       <section className="panel">
         <div className="panel-header">

--- a/workbench/lib/db.ts
+++ b/workbench/lib/db.ts
@@ -56,16 +56,19 @@ const ARTIFACT_SELECT = `SELECT a.id, a.format, a.storage_uri,
   WHERE a.run_id = ? ORDER BY a.id`;
 
 // Runs from a backend this dashboard does not serve are hidden, not deleted.
-const SERVED = BACKENDS.length ? ` WHERE b.slug IN (${BACKENDS.map(() => "?").join(",")})` : "";
+const SERVED = BACKENDS?.length ? ` WHERE b.slug IN (${BACKENDS.map(() => "?").join(",")})` : "";
 
 export const listRuns = (): RunRow[] =>
-  query(
-    (db) =>
-      db
-        .prepare(`${RUN_SELECT}${SERVED} ORDER BY r.submitted_at DESC`)
-        .all(...BACKENDS) as RunRow[],
-    [],
-  );
+  // Serving nothing lists nothing; `IN ()` is not valid SQL, so this never reaches the database.
+  BACKENDS?.length === 0
+    ? []
+    : query(
+        (db) =>
+          db
+            .prepare(`${RUN_SELECT}${SERVED} ORDER BY r.submitted_at DESC`)
+            .all(...(BACKENDS ?? [])) as RunRow[],
+        [],
+      );
 
 export const getRun = (id: number): RunRow | null =>
   query((db) => (db.prepare(`${RUN_SELECT} WHERE r.id = ?`).get(id) as RunRow) ?? null, null);

--- a/workbench/lib/db.ts
+++ b/workbench/lib/db.ts
@@ -1,5 +1,6 @@
 import { DatabaseSync } from "node:sqlite";
 import { existsSync } from "node:fs";
+import { BACKENDS } from "@/lib/vizfold";
 
 // The Rust executor owns this file; the dashboard reads it directly, read-only. `vizfold serve`
 // exports VIZFOLD_DB (the plain sqlite path); the fallback covers running `next dev` by hand.
@@ -54,8 +55,17 @@ const ARTIFACT_SELECT = `SELECT a.id, a.format, a.storage_uri,
   JOIN artifact_types at ON at.id = a.artifact_type_id
   WHERE a.run_id = ? ORDER BY a.id`;
 
+// Runs from a backend this dashboard does not serve are hidden, not deleted.
+const SERVED = BACKENDS.length ? ` WHERE b.slug IN (${BACKENDS.map(() => "?").join(",")})` : "";
+
 export const listRuns = (): RunRow[] =>
-  query((db) => db.prepare(`${RUN_SELECT} ORDER BY r.submitted_at DESC`).all() as RunRow[], []);
+  query(
+    (db) =>
+      db
+        .prepare(`${RUN_SELECT}${SERVED} ORDER BY r.submitted_at DESC`)
+        .all(...BACKENDS) as RunRow[],
+    [],
+  );
 
 export const getRun = (id: number): RunRow | null =>
   query((db) => (db.prepare(`${RUN_SELECT} WHERE r.id = ?`).get(id) as RunRow) ?? null, null);

--- a/workbench/lib/vizfold.ts
+++ b/workbench/lib/vizfold.ts
@@ -9,7 +9,15 @@ const PREFIX = process.env.OPENFOLD_PREFIX ?? "";
 
 /** What `vizfold serve` was asked to serve. Empty means unset — `next dev` by hand, which filters
  *  nothing and lets the CLI pick the backend, as it did before serve took any. */
-export const BACKENDS = (process.env.VIZFOLD_BACKENDS ?? "").split(",").filter(Boolean);
+// null means the variable is unset -- `next dev` run by hand, where filtering by a set nobody chose
+// would hide every run. Set-but-empty is a real answer: `serve` found no backend installed.
+const served = process.env.VIZFOLD_BACKENDS;
+export const BACKENDS: string[] | null =
+  served === undefined ? null : served.split(",").filter(Boolean);
+
+/** What the Fold card offers. Unset, the dashboard cannot know what is installed, so it offers both
+ *  and lets the CLI's own prereq gate refuse one that is not. */
+export const FOLDABLE = BACKENDS ?? ["openfold", "esmfold"];
 
 const run = promisify(execFile);
 

--- a/workbench/lib/vizfold.ts
+++ b/workbench/lib/vizfold.ts
@@ -7,6 +7,10 @@ import { promisify } from "node:util";
 const BIN = process.env.VIZFOLD_BIN ?? "vizfold";
 const PREFIX = process.env.OPENFOLD_PREFIX ?? "";
 
+/** What `vizfold serve` was asked to serve. Empty means unset — `next dev` by hand, which filters
+ *  nothing and lets the CLI pick the backend, as it did before serve took any. */
+export const BACKENDS = (process.env.VIZFOLD_BACKENDS ?? "").split(",").filter(Boolean);
+
 const run = promisify(execFile);
 
 export type Example = {
@@ -22,13 +26,19 @@ export async function listExamples(): Promise<Example[]> {
 }
 
 /** Record the run and return its id. `--no-exec` only writes the row, so this is near-instant. */
-export async function queueRun(example: Example, attn: boolean): Promise<number> {
+export async function queueRun(
+  example: Example,
+  attn: boolean,
+  backend?: string,
+): Promise<number> {
   // --attn takes a value and defaults to true, so it has to be passed either way; the CLI reads
   // the id and the sequence out of the example's FASTA itself.
-  const args = ["run", example.id, "--backend", "openfold", `--attn=${attn}`, "--no-exec"];
+  const args = ["run", example.id, `--attn=${attn}`, "--no-exec"];
+  if (backend) args.push("--backend", backend);
   const { stdout } = await run(BIN, args);
-  const id = stdout.match(/Queued OpenFold run (\d+)/)?.[1];
-  if (!id) throw new Error(`no run id in queue output: ${stdout.trim()}`);
+  // Each backend queues under its own label, so match the shape of the line, not the name in it.
+  const id = stdout.match(/Queued \S+ run (\d+)/)?.[1];
+  if (!id) throw new Error(`no run id in run output: ${stdout.trim()}`);
   return Number(id);
 }
 


### PR DESCRIPTION
`vizfold serve` started a dashboard that could only fold with OpenFold: the Fold card shelled out
with the backend hardcoded, and the run list showed every backend's runs regardless. `serve esmfold`
had nothing to mean. It now takes zero or more backends.

## argv

```
vizfold serve [BACKENDS]... [--port PORT]
```

On `Backend`, not the `Part` enum `install`/`update`/`uninstall` use, so `vizfold serve base` is a
parse error (exit 2) rather than a run-time rejection -- the reasoning that kept `download` on
`Backend`.

- **Bare `serve` resolves to every backend installed**, not every backend that exists. Offering a
  Fold option that cannot run is worse than not offering it, and a fresh install has exactly one.
- **Named backends are honoured in the order given** -- the first is the Fold card's default -- and
  gated: `prereqs` chains `backend_health` for each one named, so `serve esmfold` with ESMFold
  absent refuses (exit 1) instead of serving a dashboard that cannot fold. Bare `serve` gates on
  nothing beyond `core deps`/`repo`/`config`, so the UI is viewable before anything is installed.

## Wiring

`run_serve` exports one more variable of the kind it already exports (`VIZFOLD_BIN`,
`OPENFOLD_PREFIX`, `VIZFOLD_DB`): `VIZFOLD_BACKENDS=openfold,esmfold`, the resolved slugs.

The workbench reads only that:

- **Run list** -- `RUN_SELECT` already joins `model_backends`, so the filter is a
  `WHERE b.slug IN (?,...)` with the slugs **bound as parameters**, never interpolated. Other
  backends' runs are hidden, not deleted; a run's own page still resolves by id.
- **Fold card** -- a Model select when more than one backend is served, nothing when one, and the
  chosen slug goes back through `POST /api/runs`, which rejects a backend outside the served set
  before it reaches argv (the same trust boundary that already validates `inputId`).
- `queueRun` drops the hardcoded `--backend openfold` and matches `/Queued \S+ run (\d+)/`, since
  each backend queues under its own label.

Unset `VIZFOLD_BACKENDS` -- `npm run dev` by hand, which `workbench/README.md` documents -- filters
nothing and leaves the backend to the CLI's own default, as before.

## Test plan

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (139 passed) -- all
  clean.
- `every_command_gates_on_the_prereqs_it_actually_needs` extended with the two-backend gate row and
  a `serve base` parse-error assert; `backend_is_installed_tracks_its_own_env_prefix_key` extended
  to cover what bare and named `serve` resolve to (both env keys pinned in the one test rather than
  a second one, which would race it over the same variables).
- Mutation-checked: dropping the `backend_health` chain, ignoring `is_installed` for bare `serve`,
  resolving bare `serve` to nothing, swapping the `,` separator, exporting labels instead of slugs,
  and reversing the named order each fail a test.
- Built binary against a fixture install: `serve base` -> exit 2 (clap), `serve esmfold` with
  ESMFold absent -> exit 1 on the esmfold gate, bare `serve` -> `openfold` / `openfold,esmfold` /
  `no backend installed` as the env dirs come and go, with `VIZFOLD_BACKENDS` observed on the
  spawned process.
- Workbench: `tsc --noEmit` clean, `eslint` 0 errors (1 pre-existing `no-img-element` warning),
  `next build` clean. The run-list filter exercised through the real `lib/db.ts` against a
  two-backend fixture DB: `[]`/unset -> both, `[esmfold]` -> esmfold only, `[openfold,esmfold]` ->
  both.

## Known gap

With **no** backend installed, `VIZFOLD_BACKENDS` is exported empty, which the workbench cannot tell
from unset -- so the dashboard lists every run left in the database rather than none. Reachable only
by uninstalling a backend and keeping its runs; distinguishing the two would mean threading a
`string[] | null` through the run list, the Fold card and the API route for that one state.