### PR TITLE
Complete on tab: `vizfold completions <SHELL>`

### DIFF
--- a/.github/workflows/install_tests.yml
+++ b/.github/workflows/install_tests.yml
@@ -16,3 +16,4 @@ jobs:
       - run: bash tests/vocabulary.sh
       - run: bash tests/link_mirror.sh
       - run: bash tests/esmfold_env.sh
+      - run: bash tests/install_rc.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,8 @@ bash tests/launch_args.sh
 bash tests/site_config.sh   # snapshot of every site's resolved config; -u to accept a change
 bash tests/vocabulary.sh    # rejects env names outside the 19-key config schema
 bash tests/link_mirror.sh   # the three uniclust30 layouts the AF2 mirrors ship
+bash tests/esmfold_env.sh   # the torch build a driver may keep, and the specs it asks for
+bash tests/install_rc.sh    # what the bootstrap appends to a shell rc, and appends only once
 ```
 
 Python is checked with `flake8 . --select=E9,F63,F7,F82`.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ curl -fsSL https://raw.githubusercontent.com/AI2Science/vizfold-foundation/main/
 That fetches the prebuilt binary for your architecture from the latest GitHub release into
 `~/.local/bin` (set `VIZFOLD_VERSION=vX.Y.Z` to pin a release), along with `micromamba` beside it:
 every environment is created and run through it, and everything after this point assumes both are
-on your `PATH`. Then the checkout everything else runs from, and a backend — OpenFold below, or
+on your `PATH`. It also enables tab completion, by adding a line to `~/.bashrc` and to `~/.zshrc`
+where one exists; open a new shell to pick it up. Then the checkout everything else runs from, and a
+backend — OpenFold below, or
 `vizfold install esmfold` (see [docs/esmfold.md](docs/esmfold.md)):
 
 ```bash
@@ -273,6 +275,16 @@ list                List executor records
 show                Show one executor record
 run                 Fold targets in one execution: bundled examples, FASTAs, directories of FASTAs -- or a queued run by id
 register-artifacts  Register known artifacts for a completed run
+completions         Print this shell's tab-completion script. `install.sh` wires it into your shell rc
+```
+
+Completion covers subcommands, flags, and the values of a fixed set — `install <TAB>` offers `base`,
+`openfold`, `esmfold`. The bootstrap eval's the binary's own output rather than writing a script out,
+so a `self-update` cannot leave a stale one behind. To wire it up by hand, or for a shell the
+bootstrap does not touch:
+
+```bash
+eval "$(vizfold completions bash)"          # also: zsh, fish, elvish, powershell
 ```
 
 `vizfold list examples` shows what folds without an MSA search — the bundled monomers whose
@@ -335,7 +347,7 @@ cargo run -- status        # works with no install; everything else needs one
 cargo run -- list models
 ```
 
-Every command except `install`, `uninstall`, `status`, `update` and `self-update` is gated on a
+Every command except `install`, `uninstall`, `status`, `update`, `self-update` and `completions` is gated on a
 config existing at `~/.config/vizfold/vizfold.json` (`VIZFOLD_CONFIG` selects a different file), and
 exits telling you to install a backend first. There is no seed step: migrations run on every
 connect, and the run path seeds the default backends, their `local-*` targets and matching

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -324,6 +324,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8b397918185f0161ff3d6fcaa9e4bfc09b8367caf6e1d4a2848e5477ed027b"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -544,7 +553,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -576,6 +585,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "clap",
+ "clap_complete",
  "sea-orm",
  "sea-orm-migration",
  "serde_json",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -8,6 +8,7 @@ default-run = "vizfold"
 async-trait = "0.1"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 clap = { version = "4", features = ["derive"] }
+clap_complete = "4.6.7"
 
 sea-orm = { version = "1", features = ["sqlx-sqlite", "runtime-tokio-rustls", "macros", "with-chrono"] }
 sea-orm-migration = { version = "1", features = ["runtime-tokio-rustls", "sqlx-sqlite"] }

--- a/cli/src/adapters/cli.rs
+++ b/cli/src/adapters/cli.rs
@@ -1,4 +1,5 @@
-use clap::{ArgAction, Args, Parser, Subcommand, ValueEnum};
+use clap::{ArgAction, Args, CommandFactory, Parser, Subcommand, ValueEnum};
+use clap_complete::Shell;
 use sea_orm::{ColumnTrait, DbErr, EntityTrait, QueryFilter};
 use serde_json::json;
 use std::path::{Path, PathBuf};
@@ -62,6 +63,15 @@ enum Command {
     Run(RunArgs),
     /// Register known artifacts for a completed run.
     RegisterArtifacts { run_id: i32 },
+    /// Print this shell's tab-completion script. `install.sh` wires it into your shell rc.
+    Completions(CompletionsArgs),
+}
+
+#[derive(Debug, Args)]
+struct CompletionsArgs {
+    /// Shell to emit for. Defaults to the one `$SHELL` names.
+    #[arg(value_enum)]
+    shell: Option<Shell>,
 }
 
 #[derive(Debug, Args)]
@@ -438,7 +448,10 @@ fn prereqs(command: &Command) -> Vec<Component> {
         )
     };
     match command {
-        Command::Status | Command::Uninstall(_) | Command::SelfUpdate(_) => vec![],
+        Command::Status
+        | Command::Uninstall(_)
+        | Command::SelfUpdate(_)
+        | Command::Completions(_) => vec![],
         // A backend installs from the checkout; base's own verbs are what repair it, so they stay off it.
         Command::Install(InstallArgs { part }) | Command::Update(UpdateArgs { part, .. }) => {
             std::iter::once(core_deps_health())
@@ -496,6 +509,7 @@ pub async fn run() -> Result<(), DbErr> {
         Command::Update(args) => return run_update(args),
         Command::SelfUpdate(args) => return run_self_update(args),
         Command::Serve(args) => return run_serve(args),
+        Command::Completions(args) => return run_completions(args.shell),
         Command::List(ListArgs {
             resource: ListResource::Examples { json },
         }) => return list_examples(json),
@@ -522,7 +536,8 @@ pub async fn run() -> Result<(), DbErr> {
         | Command::Uninstall(_)
         | Command::Update(_)
         | Command::SelfUpdate(_)
-        | Command::Serve(_) => {
+        | Command::Serve(_)
+        | Command::Completions(_) => {
             unreachable!("handled before DB connect")
         }
     }
@@ -1444,6 +1459,31 @@ fn confirmed() -> Result<bool, DbErr> {
         .read_line(&mut answer)
         .map_err(|error| DbErr::Custom(format!("could not read confirmation: {error}")))?;
     Ok(matches!(answer.trim(), "y" | "Y" | "yes" | "YES"))
+}
+
+/// zsh registers a completion through `compdef`, which exists only once compinit has run, and a bare
+/// ~/.zshrc never runs it -- so carry the guard here rather than in every place that evals this.
+/// bash needs no prelude: `complete` is a builtin.
+fn completion_script(shell: Shell) -> Vec<u8> {
+    let mut script = match shell {
+        Shell::Zsh => {
+            b"autoload -Uz compinit; (( $+functions[compdef] )) || compinit -C\n".to_vec()
+        }
+        _ => Vec::new(),
+    };
+    clap_complete::generate(shell, &mut Cli::command(), "vizfold", &mut script);
+    script
+}
+
+fn run_completions(shell: Option<Shell>) -> Result<(), DbErr> {
+    let shell = shell.or_else(Shell::from_env).ok_or_else(|| {
+        DbErr::Custom(format!(
+            "cannot tell which shell {} is; name one, e.g. `vizfold completions bash`",
+            std::env::var("SHELL").unwrap_or_else(|_| "$SHELL".to_owned())
+        ))
+    })?;
+    std::io::Write::write_all(&mut std::io::stdout(), &completion_script(shell))
+        .map_err(|error| DbErr::Custom(format!("failed to write completions: {error}")))
 }
 
 /// Start the workbench dashboard, streaming its output to this shell.
@@ -2644,6 +2684,34 @@ mod tests {
         unsafe {
             std::env::remove_var("OPENFOLD_ENV_PREFIX");
             std::env::remove_var("ESMFOLD_ENV_PREFIX");
+        }
+    }
+
+    /// The prelude is the whole of what we add to clap_complete's output, and it is load-bearing:
+    /// without it a ~/.zshrc that never ran compinit prints `command not found: compdef` on every
+    /// shell start and registers nothing. bash must not carry it -- `complete` is a builtin there,
+    /// and the zsh syntax would be an error.
+    #[test]
+    fn only_zsh_carries_the_compinit_prelude() {
+        let script = |shell| String::from_utf8(completion_script(shell)).expect("utf-8");
+        let zsh = script(Shell::Zsh);
+        assert!(
+            zsh.starts_with("autoload -Uz compinit;"),
+            "the prelude must come before the script that needs compdef, got: {}",
+            zsh.lines().next().unwrap_or_default()
+        );
+        for shell in [Shell::Bash, Shell::Fish] {
+            assert!(
+                !script(shell).contains("compinit"),
+                "{shell} has no compdef to arrange for"
+            );
+        }
+        // Proves generation ran at all, rather than the prelude standing in for a script.
+        for shell in [Shell::Zsh, Shell::Bash] {
+            assert!(
+                script(shell).contains("completions"),
+                "{shell} names our subcommands"
+            );
         }
     }
 

--- a/cli/src/adapters/cli.rs
+++ b/cli/src/adapters/cli.rs
@@ -1461,9 +1461,8 @@ fn confirmed() -> Result<bool, DbErr> {
     Ok(matches!(answer.trim(), "y" | "Y" | "yes" | "YES"))
 }
 
-/// zsh registers a completion through `compdef`, which exists only once compinit has run, and a bare
-/// ~/.zshrc never runs it -- so carry the guard here rather than in every place that evals this.
-/// bash needs no prelude: `complete` is a builtin.
+/// clap_complete's zsh script registers through `compdef`, which exists only once compinit has run,
+/// and a bare ~/.zshrc never runs it. Carried here rather than in each place that evals this.
 fn completion_script(shell: Shell) -> Vec<u8> {
     let mut script = match shell {
         Shell::Zsh => {
@@ -2687,10 +2686,8 @@ mod tests {
         }
     }
 
-    /// The prelude is the whole of what we add to clap_complete's output, and it is load-bearing:
-    /// without it a ~/.zshrc that never ran compinit prints `command not found: compdef` on every
-    /// shell start and registers nothing. bash must not carry it -- `complete` is a builtin there,
-    /// and the zsh syntax would be an error.
+    /// The prelude is the whole of what we add to clap_complete's output. Verified load-bearing: a
+    /// zsh that never ran compinit registers nothing without it, and the syntax is an error in bash.
     #[test]
     fn only_zsh_carries_the_compinit_prelude() {
         let script = |shell| String::from_utf8(completion_script(shell)).expect("utf-8");

--- a/cli/src/adapters/cli.rs
+++ b/cli/src/adapters/cli.rs
@@ -2703,13 +2703,16 @@ mod tests {
                 "{shell} has no compdef to arrange for"
             );
         }
-        // Proves generation ran at all, rather than the prelude standing in for a script.
-        for shell in [Shell::Zsh, Shell::Bash] {
-            assert!(
-                script(shell).contains("completions"),
-                "{shell} names our subcommands"
-            );
-        }
+        // The name bound here is what the user's TAB has to match; nothing else in the script
+        // fails visibly if it is wrong -- completion would simply do nothing, for everyone.
+        assert!(
+            zsh.contains("compdef _vizfold vizfold\n"),
+            "zsh binds `vizfold`"
+        );
+        assert!(
+            script(Shell::Bash).contains("-F _vizfold -o bashdefault -o default vizfold\n"),
+            "bash binds `vizfold`"
+        );
     }
 
     /// A bare `uninstall` stays: it is the only thing that removes what no part owns.

--- a/install.sh
+++ b/install.sh
@@ -56,7 +56,10 @@ bootstrap::micromamba() {
 bootstrap::rc() {   # $1 shell, $2 line
     local rc=$HOME/.${1}rc
     [ "$1" = bash ] || [ -f "$rc" ] || return 0
-    grep -qsF "$2" "$rc" || echo "$2" >> "$rc"
+    grep -qsF "$2" "$rc" && return 0
+    # An rc whose last line has no newline would otherwise take ours fused onto the end of it.
+    [ ! -s "$rc" ] || [ -z "$(tail -c1 "$rc")" ] || echo >> "$rc"
+    echo "$2" >> "$rc"
 }
 
 # Put ~/.local/bin on PATH for future shells (idempotent), and note it for this one.
@@ -69,12 +72,14 @@ bootstrap::path() {
 }
 
 # Eval'd from the binary rather than written out as a file, so a self-update leaves nothing stale.
-# Must follow bootstrap::path, which is what puts vizfold on the PATH this line then calls it from;
-# the guard keeps an uninstalled binary from erroring on every shell start.
+# By absolute path, never PATH: Ubuntu's and RHEL's stock profiles source .bashrc *before* they
+# prepend ~/.local/bin, so a PATH lookup is false exactly when this line runs. `-x` keeps an
+# uninstalled binary quiet; 2>/dev/null keeps one too old to know the subcommand quiet too. Only
+# interactive shells have completion to register, and bash sources .bashrc under ssh as well.
 bootstrap::completions() {
     local shell
     for shell in bash zsh; do
-        bootstrap::rc "$shell" "command -v vizfold >/dev/null && eval \"\$(vizfold completions $shell)\""
+        bootstrap::rc "$shell" "case \$- in *i*) [ -x \"$BIN/vizfold\" ] && eval \"\$(\"$BIN/vizfold\" completions $shell 2>/dev/null)\" ;; esac"
     done
     echo "enabled tab completion in your shell rc"
 }

--- a/install.sh
+++ b/install.sh
@@ -51,15 +51,32 @@ bootstrap::micromamba() {
     echo "installed micromamba to $BIN/micromamba"
 }
 
+# Append a line to one shell's rc, once. .zshrc only if it exists (zsh may not be installed);
+# .bashrc regardless, since bash reads it on every interactive shell even on a fresh account.
+bootstrap::rc() {   # $1 shell, $2 line
+    local rc=$HOME/.${1}rc
+    [ "$1" = bash ] || [ -f "$rc" ] || return 0
+    grep -qsF "$2" "$rc" || echo "$2" >> "$rc"
+}
+
 # Put ~/.local/bin on PATH for future shells (idempotent), and note it for this one.
 bootstrap::path() {
     case ":$PATH:" in *":$BIN:"*) return ;; esac
     local line="export PATH=\"$BIN:\$PATH\""
-    for rc in "$HOME/.bashrc" "$HOME/.zshrc"; do
-        if [ "$rc" = "$HOME/.zshrc" ] && [ ! -f "$rc" ]; then continue; fi
-        grep -qsF "$line" "$rc" 2>/dev/null || echo "$line" >> "$rc"
-    done
+    bootstrap::rc bash "$line"
+    bootstrap::rc zsh "$line"
     echo "added $BIN to PATH in your shell rc; restart your shell or run: $line"
+}
+
+# Tab completion, eval'd from the binary rather than written out as a file: it then follows whatever
+# vizfold is on PATH, so a self-update cannot leave a stale script behind. After the PATH line, which
+# is what puts vizfold there; the guard keeps an uninstall from erroring on every shell start.
+bootstrap::completions() {
+    local shell
+    for shell in bash zsh; do
+        bootstrap::rc "$shell" "command -v vizfold >/dev/null && eval \"\$(vizfold completions $shell)\""
+    done
+    echo "enabled tab completion in your shell rc"
 }
 
 main() {
@@ -69,6 +86,11 @@ main() {
     bootstrap::download
     bootstrap::micromamba
     bootstrap::path
+    bootstrap::completions
     echo "vizfold installed at $BIN/vizfold. Run \`vizfold install base\` for the checkout, then \`vizfold install openfold\` (or \`esmfold\`)."
 }
-main
+
+# Sourced (tests/install_rc.sh) this file is just its definitions. Not the backend installers'
+# `BASH_SOURCE = $0` guard: piped through `curl | bash` this script has no BASH_SOURCE at all, and
+# that guard would read the absence as "sourced" and bootstrap nothing.
+if [ -z "${BASH_SOURCE[0]:-}" ] || [ "${BASH_SOURCE[0]}" = "$0" ]; then main; fi

--- a/install.sh
+++ b/install.sh
@@ -51,8 +51,8 @@ bootstrap::micromamba() {
     echo "installed micromamba to $BIN/micromamba"
 }
 
-# Append a line to one shell's rc, once. .zshrc only if it exists (zsh may not be installed);
-# .bashrc regardless, since bash reads it on every interactive shell even on a fresh account.
+# .zshrc only where it exists -- writing one would invent a config for a shell that may not be
+# installed. .bashrc regardless: bash reads it on every interactive shell, fresh account or not.
 bootstrap::rc() {   # $1 shell, $2 line
     local rc=$HOME/.${1}rc
     [ "$1" = bash ] || [ -f "$rc" ] || return 0
@@ -68,9 +68,9 @@ bootstrap::path() {
     echo "added $BIN to PATH in your shell rc; restart your shell or run: $line"
 }
 
-# Tab completion, eval'd from the binary rather than written out as a file: it then follows whatever
-# vizfold is on PATH, so a self-update cannot leave a stale script behind. After the PATH line, which
-# is what puts vizfold there; the guard keeps an uninstall from erroring on every shell start.
+# Eval'd from the binary rather than written out as a file, so a self-update leaves nothing stale.
+# Must follow bootstrap::path, which is what puts vizfold on the PATH this line then calls it from;
+# the guard keeps an uninstalled binary from erroring on every shell start.
 bootstrap::completions() {
     local shell
     for shell in bash zsh; do

--- a/tests/install_rc.sh
+++ b/tests/install_rc.sh
@@ -34,8 +34,8 @@ want() { # $1 rc, $2 fragment, $3 expected count, $4 what it means
 }
 
 PATH_LINE='export PATH='
-BASH_EVAL='vizfold completions bash'
-ZSH_EVAL='vizfold completions zsh'
+BASH_EVAL='completions bash'
+ZSH_EVAL='completions zsh'
 
 run_case fresh
 want .bashrc "$PATH_LINE" 1 "a fresh account gets the PATH line in .bashrc"
@@ -46,13 +46,29 @@ else
     echo "ok   no .zshrc is invented where none existed"
 fi
 
-# Against main, not against a file this test wrote: that would only check the order this test chose.
-CASE=ordering
-if [ "$(grep -n '^ *bootstrap::path$' "$REPO/install.sh" | cut -d: -f1)" -lt \
-     "$(grep -n '^ *bootstrap::completions$' "$REPO/install.sh" | cut -d: -f1)" ]; then
-    echo "ok   main writes the PATH line before the eval that depends on it"
+# Ubuntu's and RHEL's stock profiles source .bashrc before prepending ~/.local/bin, so a line that
+# looked vizfold up on PATH would find nothing exactly when it runs, on the machines this targets.
+run_case absolute
+want .bashrc "$SANDBOX/.local/bin/vizfold" 1 "the eval names the binary by absolute path"
+want .bashrc "command -v vizfold"          0 "and never resolves it through PATH"
+
+# bash sources .bashrc for non-interactive shells too, under ssh -- where there is no completion to
+# register and forking the binary is pure latency on every scp, rsync and `ssh host cmd`.
+want .bashrc 'case $- in *i*)' 1 "the eval runs only in an interactive shell"
+# A binary older than this subcommand answers on stderr; unsilenced, that lands on the user's prompt.
+want .bashrc '2>/dev/null'     1 "and says nothing when the binary is too old to know it"
+
+# An rc whose last byte is not a newline: ours would fuse onto the user's last statement, and since
+# grep -F matches a fragment anywhere in a line the idempotency guard would then hide it forever.
+CASE=no-trailing-newline
+rm -rf "$SANDBOX"; mkdir -p "$SANDBOX"; HOME=$SANDBOX BIN=$SANDBOX/.local/bin
+printf 'export EDITOR=vim' > "$SANDBOX/.bashrc"
+bootstrap::path >/dev/null; bootstrap::completions >/dev/null
+got=$(HOME=$SANDBOX bash -c '. "$HOME/.bashrc" 2>/dev/null; echo "$EDITOR"')
+if [ "$got" = vim ]; then
+    echo "ok   an rc with no trailing newline keeps its last statement intact"
 else
-    echo "FAIL [ordering] main appends the completion eval above the PATH line it needs"; fail=1
+    echo "FAIL [no-trailing-newline] EDITOR became '$got'; the appended line fused onto it"; fail=1
 fi
 
 run_case rerun .zshrc

--- a/tests/install_rc.sh
+++ b/tests/install_rc.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# What the bootstrap writes into a user's shell rc, and what it refuses to write twice.
+# Run: bash tests/install_rc.sh
+#
+# `curl install.sh | bash` is documented as re-runnable, so every line it appends is appended again
+# on the next run unless the guard holds -- and these land in a file the user did not ask us to edit.
+set -uo pipefail
+
+REPO=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+SANDBOX=${TMPDIR:-/tmp}/vizfold-install-rc-$$
+trap 'rm -rf "$SANDBOX"' EXIT
+fail=0
+
+# Definitions only: the guard at the foot of install.sh runs main solely on execution.
+. "$REPO/install.sh"
+set +e                                        # the installer's own set -e, not this harness's
+
+# One bootstrap over a fresh $HOME. $1 pre-creates rc files, so "zsh installed" is expressible.
+run_case() { # $1 case name, $2... rc basenames to create first
+    CASE=$1; shift
+    rm -rf "$SANDBOX"; mkdir -p "$SANDBOX"
+    HOME=$SANDBOX BIN=$SANDBOX/.local/bin
+    for rc; do : > "$SANDBOX/$rc"; done
+    bootstrap::path >/dev/null
+    bootstrap::completions >/dev/null
+}
+
+# grep -c prints 0 itself on no match, so only an absent file needs answering for.
+count() { if [ -f "$SANDBOX/$1" ]; then grep -cF "$2" "$SANDBOX/$1"; else echo 0; fi; }
+
+want() { # $1 rc, $2 fragment, $3 expected count, $4 what it means
+    local got; got=$(count "$1" "$2")
+    if [ "$got" = "$3" ]; then echo "ok   $4"; else
+        echo "FAIL [$CASE] $4"; echo "  want $3 x '$2' in $1"; echo "  got  $got"; fail=1
+    fi
+}
+
+PATH_LINE='export PATH='
+BASH_EVAL='vizfold completions bash'
+ZSH_EVAL='vizfold completions zsh'
+
+# A fresh account has no rc at all. bash reads .bashrc on every interactive shell, so it is created;
+# .zshrc is not, since writing one would be inventing a config for a shell that may not be installed.
+run_case fresh
+want .bashrc "$PATH_LINE" 1 "a fresh account gets the PATH line in .bashrc"
+want .bashrc "$BASH_EVAL" 1 "and the completion eval for its own shell"
+if [ -e "$SANDBOX/.zshrc" ]; then
+    echo "FAIL [fresh] .zshrc was created for a shell that may not be installed"; fail=1
+else
+    echo "ok   no .zshrc is invented where none existed"
+fi
+
+# The eval calls `vizfold`, so the PATH line has to be above it in the rc -- and since each appends,
+# that is decided by the order main calls them in. Asserted against main rather than against a file
+# this test wrote, which would only be checking the order this test chose.
+CASE=ordering
+if [ "$(grep -n '^ *bootstrap::path$' "$REPO/install.sh" | cut -d: -f1)" -lt \
+     "$(grep -n '^ *bootstrap::completions$' "$REPO/install.sh" | cut -d: -f1)" ]; then
+    echo "ok   main writes the PATH line before the eval that depends on it"
+else
+    echo "FAIL [ordering] main appends the completion eval above the PATH line it needs"; fail=1
+fi
+
+# The failure this whole file exists for: a second `curl | bash` doubling every line.
+run_case rerun .zshrc
+bootstrap::path >/dev/null; bootstrap::completions >/dev/null
+want .bashrc "$PATH_LINE" 1 "a re-run appends no second PATH line"
+want .bashrc "$BASH_EVAL" 1 "nor a second completion eval"
+want .zshrc  "$ZSH_EVAL"  1 "and the same holds for .zshrc"
+
+# Each rc gets its own shell's script; a zsh script eval'd by bash completes nothing.
+run_case per-shell .zshrc
+want .zshrc  "$ZSH_EVAL"  1 "an existing .zshrc gets the zsh script"
+want .zshrc  "$BASH_EVAL" 0 "and not the bash one"
+want .bashrc "$ZSH_EVAL"  0 "nor .bashrc the zsh one"
+
+exit $fail

--- a/tests/install_rc.sh
+++ b/tests/install_rc.sh
@@ -11,12 +11,10 @@ SANDBOX=${TMPDIR:-/tmp}/vizfold-install-rc-$$
 trap 'rm -rf "$SANDBOX"' EXIT
 fail=0
 
-# Definitions only: the guard at the foot of install.sh runs main solely on execution.
-. "$REPO/install.sh"
+. "$REPO/install.sh"                          # definitions only; its guard runs main on execution
 set +e                                        # the installer's own set -e, not this harness's
 
-# One bootstrap over a fresh $HOME. $1 pre-creates rc files, so "zsh installed" is expressible.
-run_case() { # $1 case name, $2... rc basenames to create first
+run_case() { # $1 case name, $2... rc files to pre-create -- how "zsh is installed" is expressed
     CASE=$1; shift
     rm -rf "$SANDBOX"; mkdir -p "$SANDBOX"
     HOME=$SANDBOX BIN=$SANDBOX/.local/bin
@@ -39,8 +37,6 @@ PATH_LINE='export PATH='
 BASH_EVAL='vizfold completions bash'
 ZSH_EVAL='vizfold completions zsh'
 
-# A fresh account has no rc at all. bash reads .bashrc on every interactive shell, so it is created;
-# .zshrc is not, since writing one would be inventing a config for a shell that may not be installed.
 run_case fresh
 want .bashrc "$PATH_LINE" 1 "a fresh account gets the PATH line in .bashrc"
 want .bashrc "$BASH_EVAL" 1 "and the completion eval for its own shell"
@@ -50,9 +46,7 @@ else
     echo "ok   no .zshrc is invented where none existed"
 fi
 
-# The eval calls `vizfold`, so the PATH line has to be above it in the rc -- and since each appends,
-# that is decided by the order main calls them in. Asserted against main rather than against a file
-# this test wrote, which would only be checking the order this test chose.
+# Against main, not against a file this test wrote: that would only check the order this test chose.
 CASE=ordering
 if [ "$(grep -n '^ *bootstrap::path$' "$REPO/install.sh" | cut -d: -f1)" -lt \
      "$(grep -n '^ *bootstrap::completions$' "$REPO/install.sh" | cut -d: -f1)" ]; then
@@ -61,14 +55,13 @@ else
     echo "FAIL [ordering] main appends the completion eval above the PATH line it needs"; fail=1
 fi
 
-# The failure this whole file exists for: a second `curl | bash` doubling every line.
 run_case rerun .zshrc
 bootstrap::path >/dev/null; bootstrap::completions >/dev/null
 want .bashrc "$PATH_LINE" 1 "a re-run appends no second PATH line"
 want .bashrc "$BASH_EVAL" 1 "nor a second completion eval"
 want .zshrc  "$ZSH_EVAL"  1 "and the same holds for .zshrc"
 
-# Each rc gets its own shell's script; a zsh script eval'd by bash completes nothing.
+# A zsh script eval'd by bash completes nothing.
 run_case per-shell .zshrc
 want .zshrc  "$ZSH_EVAL"  1 "an existing .zshrc gets the zsh script"
 want .zshrc  "$BASH_EVAL" 0 "and not the bash one"


### PR DESCRIPTION
Native tab completion for the `vizfold` binary, generated from the clap definition rather than
hand-maintained, so the command surface and its completions cannot drift.

```
$ vizfold ins<TAB>
$ vizfold install <TAB>
base  openfold  esmfold
$ vizfold run --backend <TAB>
openfold  esmfold
```

Subcommands, flags, and the values of every `ValueEnum`. Free-form arguments (example ids, run ids,
FASTA paths) fall back to the shell's file completion; completing those needs `clap_complete`'s
dynamic feature and a process spawn per keystroke, which is not worth it for five example ids.

## How it reaches the user's shell

`install.sh` appends one line per shell, beside the PATH line it already writes:

```bash
case $- in *i*) [ -x "$HOME/.local/bin/vizfold" ] && eval "$("$HOME/.local/bin/vizfold" completions bash 2>/dev/null)" ;; esac
```

Every clause is load-bearing, and four of them were added after review found the plain form broken:

- **absolute path, never `PATH`** — Ubuntu's `/etc/skel/.profile` and RHEL's `.bash_profile` source
  `.bashrc` *before* prepending `~/.local/bin`. Worse, `bootstrap::path` early-returns when that
  directory is already on `PATH` in the installing shell (pipx, `pip --user`, cargo and npm all
  create it), so nothing writes a PATH line at all. A `command -v vizfold` guard is then false
  exactly when the line runs: completion silently never loads, while the installer prints success.
- **`case $- in *i*)`** — bash sources `.bashrc` for *non*-interactive shells when `SSH_CLIENT` is
  set, which is the `ssh host cmd` / scp / rsync path. Nothing there has completion to register, so
  the gate keeps a fork of the binary out of every remote command.
- **`2>/dev/null`** — `-x` proves the binary exists, not that it knows this subcommand. Every
  published tag through v0.8.0 predates it, so `VIZFOLD_VERSION=v0.8.0` or
  `self-update --version <older>` would otherwise print clap's `unrecognized subcommand` on every
  interactive shell start, forever, with nothing to ever revisit the line.
- **`-x`** — an uninstalled binary stays quiet.

An eval of the binary's own output rather than a generated file, so a `self-update` cannot leave a
stale script behind. `.bashrc` is written on a fresh account (bash reads it on every interactive
shell); `.zshrc` only where one exists, since writing one would invent a config for a shell that may
not be installed.

`bootstrap::rc` also now appends a newline first where the rc lacks a trailing one. Without it the
line fuses onto the user's last statement (`export EDITOR=vimcase $- in …`), and because `grep -F`
matches the fragment anywhere in a line, the idempotency guard then hides the damage permanently.

## The zsh prelude

`completion_script` prepends one line for zsh only:

```zsh
autoload -Uz compinit; (( $+functions[compdef] )) || compinit -C
```

clap_complete's zsh output registers through `compdef`, which exists only once compinit has run. A
`~/.zshrc` that never runs it is not hypothetical, and without the prelude that shell prints
`command not found: compdef` on every start and registers nothing — verified against `zsh -f`:

```
$ zsh -f -c 'eval "$(vizfold completions zsh | tail -n +2)"; print ${_comps[vizfold]:-NONE}'
(eval):692: command not found: compdef
NONE
$ zsh -f -c 'eval "$(vizfold completions zsh)"; print ${_comps[vizfold]:-NONE}'
_vizfold
```

Carried in the binary rather than in the rc line, so a manual `eval "$(vizfold completions zsh)"`
works too. bash needs no prelude — `complete` is a builtin.

## install.sh is now sourceable

Needed to test what it appends. Deliberately **not** the backend installers'
`[ "${BASH_SOURCE[0]}" = "$0" ] || return 0` guard: piped through `curl … | bash` this script has no
`BASH_SOURCE` at all, so that guard would read the absence as "sourced" and bootstrap nothing.

```
if [ -z "${BASH_SOURCE[0]:-}" ] || [ "${BASH_SOURCE[0]}" = "$0" ]; then main; fi
```

Verified across all four invocation forms: `curl | bash`, `bash install.sh` and `./install.sh` all
reach `main`; `. ./install.sh` defines the functions and runs nothing.

## Test plan

- `tests/install_rc.sh` (new, in `install_tests.yml`), 14 assertions: the fresh-account case, that no
  `.zshrc` is invented, that the eval names the binary absolutely and never through `PATH`, the
  interactivity gate, the stderr silence, that an rc with no trailing newline keeps its last
  statement intact, that a second `curl | bash` doubles nothing, and that each rc gets its own
  shell's script. Every mutation tried is caught: dropping the newline guard, reverting to a `PATH`
  lookup, dropping the interactivity gate, dropping `2>/dev/null`, dropping the idempotency guard,
  creating `.zshrc` unconditionally, and emitting the bash script into both.
- `only_zsh_carries_the_compinit_prelude`: the prelude leads the zsh script and appears in no other,
  plus the command name `generate()` binds — `vizfold` → `vizfoldx` previously kept the suite green
  while completion did nothing for every user. Both mutations now fail the test.
- End to end, in the scenario that would have failed silently: bootstrap with `$BIN` already on
  `PATH` so no PATH line is written, then a fresh interactive bash and zsh started with `$BIN` *off*
  `PATH` — both resolve `vizfold` to `_vizfold`. With the binary removed, and with a binary that
  rejects the subcommand, both shells still start clean. Non-interactive under `SSH_CLIENT`, stdout
  is `PROTOCOL-DATA` and stderr empty.
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (140).
- `bash -n` over all 47 tracked scripts; `launch_args`, `site_config`, `vocabulary`, `link_mirror`,
  `esmfold_env`. `site_config.expected` unchanged.