### PR TITLE
Bump version to 0.9.0

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "executor"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "executor"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2024"
 default-run = "vizfold"
 


### PR DESCRIPTION
Minor, not patch: `queue` was removed and the `install`/`update`/`uninstall` verbs changed shape
since v0.8.0.

Ships #144, #145, #146, #147, #148, #149.