### PR TITLE
Cut comment redundancy across the CLI, the installers and the dashboard

### DIFF
--- a/backends/esmfold/install/install.sh
+++ b/backends/esmfold/install/install.sh
@@ -1,28 +1,27 @@
 #!/bin/bash
 
 # Install the ESMFold backend: no AF2 databases, no CUDA compilation, weights from HuggingFace at run
-# time. Solving the env needs no compute node, but the site still decides where. Idempotent.
+# time -- so the env solves on any node. Idempotent.
 set -euo pipefail
 
 . "${OPENFOLD_HOME:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)}/lib/slurm.sh"
 
 esmfold::config() {
-    # Cluster, allocation, prefix, saved config. Without it the prefix defaulted to a quota'd $HOME.
+    # Without settle_site the prefix falls back to a quota'd $HOME.
     vizfold::settle_site
     ESM=$REPO/backends/esmfold
     PREFIX=$(vizfold::prefix)
     STATE=$(vizfold::state esmfold)
     ENV=${ESMFOLD_ENV_PREFIX:-$(vizfold::env esmfold)}
     export OPENFOLD_DRIVER_CUDA=${OPENFOLD_DRIVER_CUDA:-$(vizfold::driver_cuda)}
-    # Its own state dir: else pip's wheels land in the ~/.cache/pip quota this install avoids.
+    # Its own state dir: else wheels land in the quota'd ~/.cache/pip.
     export PIP_CACHE_DIR=${PIP_CACHE_DIR:-$STATE/pip}
     test -f "$ESM/environment.yml" || die "no esmfold project at $ESM; is $REPO a vizfold checkout?"
     echo "driver CUDA ${OPENFOLD_DRIVER_CUDA:-unknown}"
 }
 
 # Where a driver exists the env must carry a torch built for a CUDA major it can load -- a newer one
-# imports and then cannot reach the GPU, a CPU-only one never tries. Without this a re-install would
-# keep the very build it exists to replace.
+# imports but cannot reach the GPU, a CPU-only one never tries. Without this a re-install keeps the wrong build.
 esmfold::present() {
     local driver=${OPENFOLD_DRIVER_CUDA:-}; driver=${driver%%.*}
     "$ENV/bin/python" -c "
@@ -30,10 +29,8 @@ import torch, transformers, esmfold
 assert not ${driver:-0} or 0 < int((torch.version.cuda or '0').split('.')[0]) <= ${driver:-0}" 2>/dev/null
 }
 
-# What a GPU driver justifies asking for, and nothing where there is none: the solver then picks the
-# CPU (or on a Mac, MPS) build the host can run. Two specs the driver alone does not get us -- the
-# unqualified pytorch resolves to a CPU build even where a GPU is present, and __cuda bounds only the
-# CUDA major while the driver is the real ceiling.
+# No driver -> no specs, and the solver picks the CPU (or on a Mac, MPS) build. Both specs are needed:
+# unqualified pytorch resolves to a CPU build even with a GPU, and __cuda bounds only the CUDA major.
 esmfold::cuda_specs() {
     [ -n "${OPENFOLD_DRIVER_CUDA:-}" ] || return 0
     echo "pytorch=*=cuda* cuda-version<=$OPENFOLD_DRIVER_CUDA"
@@ -44,29 +41,24 @@ esmfold::env() {
     rm -rf "$ENV"   # clear a partial env; create fails on a non-empty dir
     export MAMBA_ROOT_PREFIX=$PREFIX/mamba
     mkdir -p "$(dirname "$ENV")"
-    # A driver the config knows but this node cannot see (detected on a compute node) still has to
-    # reach the solver, or the CUDA specs below have no __cuda to satisfy them.
+    # A driver the config knows but this node cannot see must still reach the solver, or the specs below have no __cuda.
     [ -z "${OPENFOLD_DRIVER_CUDA:-}" ] || export CONDA_OVERRIDE_CUDA=$OPENFOLD_DRIVER_CUDA
-    # Unquoted on purpose: cuda_specs emits two specs or none. --no-rc so a user ~/.condarc
-    # envs_dirs/channels cannot redirect it.
+    # Unquoted on purpose: cuda_specs emits two specs or none. --no-rc so a user ~/.condarc cannot redirect it.
     micromamba create -y --no-rc -p "$ENV" -f "$ESM/environment.yml" $(esmfold::cuda_specs)
 }
 
-# The env resolved torch and transformers already; this adds the `esmfold` package and its entrypoint.
 esmfold::install() {
     log package
     "$ENV/bin/pip" install "$ESM"
 }
 
-# Not merely that pip exited zero: every import the backend makes, and the entrypoint it runs.
 esmfold::verify() {
     log verify
     "$ENV/bin/python" - <<'PY'
 import shutil, sys, torch, transformers
 from esmfold.cli import main
 print("python", sys.version.split()[0])
-# torch.version.cuda, not just is_available(): a login node carries the driver but no GPU, so the
-# build it resolved to is the only thing this can actually check.
+# torch.version.cuda, not just is_available(): a login node has the driver but no GPU, so the resolved build is all we can check.
 print("torch", torch.__version__, "cuda", torch.version.cuda, "available", torch.cuda.is_available())
 print("transformers", transformers.__version__)
 entrypoint = shutil.which("esmfold", path=f"{sys.prefix}/bin")
@@ -75,7 +67,7 @@ print("entrypoint", entrypoint)
 PY
 }
 
-# Only what something settled: recording this backend's own fallback would pin a prefix nobody picked.
+# Only what something settled: recording our own fallback would pin a prefix nobody picked.
 esmfold::config_save() {
     log config
     export OPENFOLD_HOME=$REPO ESMFOLD_ENV_PREFIX=$ENV

--- a/backends/openfold/install/setup.sh
+++ b/backends/openfold/install/setup.sh
@@ -4,21 +4,21 @@
 set -euo pipefail
 
 . "${OPENFOLD_HOME:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)}/lib/config.sh"
-# For a direct run: under `vizfold install` install.sh already exported these, and config::fill never overwrites.
+# For a direct run; under `vizfold install` these are already exported and config::fill never overwrites.
 config::load
 
 have()   { test -e "$1" || compgen -G "${1}_*.ffindex" >/dev/null; }   # ffindex sets are prefixes
 sealed() { [ -e "$sentinel/$1" ]; }
 seal()   { mkdir -p "$sentinel"; touch "$sentinel/$1"; }
 older()  { [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | head -1)" = "$1" ] && [ "$1" != "$2" ]; }
-# A step seals only after finishing, so an interrupted create/clone/download is redone next run, not skipped.
+# Sealed only after the step finishes, so an interrupted one is redone next run, not skipped.
 step()   { log "$1"; sealed "$1" && { echo "  cached"; return; }; "$2"; seal "$1"; }
 
 setup::config() {
     PREFIX=$(vizfold::prefix)
-    STATE=$(vizfold::state openfold)                 # everything this backend plants under the prefix
+    STATE=$(vizfold::state openfold)
     AF2=${OPENFOLD_AF2_ROOT:-}                       # set by a site with a database mirror
-    # aarch64 (Grace-Hopper) needs its own env: py3.13, GH200-only sm_90, cuda<=12.9 -- the 13.x aarch64 pytorch build won't compile OpenFold's extension.
+    # aarch64 (Grace-Hopper) needs its own env -- py3.13, sm_90 only, cuda<=12.9: the 13.x aarch64 pytorch build won't compile OpenFold's extension.
     case $(uname -m) in
         aarch64|arm64) ENV_YML=$OF/environment-aarch64.yml; ARCH_DEFAULT=9.0; MAX_CUDA=${OPENFOLD_MAX_CUDA:-12.9} ;;
         *)             ENV_YML=$OF/environment.yml; ARCH_DEFAULT="7.0;8.0;8.6;9.0"; MAX_CUDA=${OPENFOLD_MAX_CUDA:-12.8} ;;
@@ -103,7 +103,7 @@ setup::nvrtc_create() {
     micromamba create -y --no-rc -p "$nvrtc" -c conda-forge "cuda-nvrtc<=$DRIVER_CUDA"
 }
 
-# Append every run: setup::activate rewrites openfold.sh from scratch, so this must not sit behind the create's sentinel.
+# Appended every run: setup::activate rewrites openfold.sh from scratch, so this can't sit behind the create's sentinel.
 setup::nvrtc_preload() {
     local lib; lib=$(ls "$STATE/nvrtc-$DRIVER_CUDA"/lib/libnvrtc.so.* 2>/dev/null | sort -V | tail -1)
     test -n "$lib" || die "no libnvrtc in $STATE/nvrtc-$DRIVER_CUDA"
@@ -133,14 +133,14 @@ setup::link_mirror() {
         # Explicit link name: GNU ln -sfn onto a real dir errors instead of linking inside it.
         ln -sfn "$d" "$DATA/${d##*/}"
     done
-    # uniclust30_2018_08 goes in a writable canonical dir (not the read-only mirror symlink): the mirror's real set if present (single- or double-nested), else aliased from uniref30.
+    # uniclust30_2018_08 needs a writable canonical dir, not a read-only mirror symlink: the mirror's real set if present (single- or double-nested), else aliased from uniref30.
     mkdir -p "$UNICLUST"
     local src="" c
     for c in "$AF2/uniclust30/uniclust30_2018_08" "$AF2/uniclust30"; do
         compgen -G "$c/uniclust30_2018_08_*" >/dev/null 2>&1 && { src=$c; break; }
     done
     if [ -n "$src" ]; then
-        # Per-file explicit link name, for the reason the $DATA loop above gives.
+        # Explicit link name per file, same reason as above.
         for u in "$src"/uniclust30_2018_08_*; do ln -sfn "$u" "$UNICLUST/${u##*/}"; done
     else
         for f in "$AF2"/uniref30/UniRef30_[0-9][0-9][0-9][0-9]_[0-9][0-9]*; do
@@ -150,7 +150,7 @@ setup::link_mirror() {
     fi
 }
 
-# No mirror: fetch params (4 GB) into the one data root, where `vizfold download` also puts them.
+# No mirror: fetch the 4 GB params into $DATA, where `vizfold download` also puts them.
 setup::fetch_params() {
     rm -rf "$DATA/params"   # a half-extracted tar would pass a single-file check
     bash "$REPO/downloaders/openfold/download_alphafold_params.sh" "$DATA"
@@ -159,8 +159,8 @@ setup::fetch_params() {
 setup::fetch_templates() {
     log templates
     mkdir -p "$DATA/pdb_mmcif/mmcif_files"
-    # env -u LD_LIBRARY_PATH: else system curl binds conda's feature-poor libcurl and fails. No -S here:
-    # a 404 is expected per-entry and || true tolerates it; the count assert catches total failure.
+    # env -u LD_LIBRARY_PATH: else system curl binds conda's feature-poor libcurl and fails. No -S:
+    # per-entry 404s are expected and || true tolerates them; the count assert catches total failure.
     grep -ohE "^ *[0-9]+ [0-9A-Za-z]{4}_" "$REPO"/examples/monomer/alignments/*/*.hhr |
         awk '{ print tolower(substr($2, 1, 4)) }' | sort -u |
         xargs -P 8 -I{} sh -c \
@@ -216,7 +216,7 @@ setup::config_save() {
     export OPENFOLD_HOME=$REPO OPENFOLD_PREFIX=$PREFIX VIZFOLD_ENV_BASE=$(vizfold::env_base)
     export OPENFOLD_ENV_PREFIX=$CONDA_PREFIX OPENFOLD_DATA_DIR=$DATA OPENFOLD_MAX_CUDA=$MAX_CUDA
     export OPENFOLD_GPU_RESOURCES=$GPU_RES OPENFOLD_EXAMPLE=$EXAMPLE OPENFOLD_GPU_GRES=$GPU_GRES
-    # VIZFOLD_DB defers to whatever is set, as esmfold's installer does: overwriting it would move someone's run history.
+    # VIZFOLD_DB defers to whatever is set (as esmfold does): overwriting it would move someone's run history.
     export OPENFOLD_GPU_TIME=$GPU_TIME VIZFOLD_DB=${VIZFOLD_DB:-$PREFIX/vizfold.db}
     config::save
 }
@@ -262,6 +262,6 @@ main() {
 # Sourced (tests/link_mirror.sh) this file is just its definitions; only an execution installs.
 [ "${BASH_SOURCE[0]}" = "$0" ] || return 0
 
-# A site's hooks are pure function defs; sourcing them here lets it override any setup:: step above.
+# A site's hooks are pure function defs; sourcing them here lets it override any setup:: step.
 [ -n "${OPENFOLD_SITE:-}" ] && [ -f "$REPO/sites/$OPENFOLD_SITE.sh" ] && . "$REPO/sites/$OPENFOLD_SITE.sh"
 main "$@"

--- a/cli/src/adapters/cli.rs
+++ b/cli/src/adapters/cli.rs
@@ -37,7 +37,7 @@ pub struct Cli {
 }
 
 #[derive(Debug, Subcommand)]
-// `run` carries every fold flag, so its variant dwarfs the rest. One is parsed, once, per process.
+// `run` carries every fold flag; one enum is parsed, once, per process.
 #[allow(clippy::large_enum_variant)]
 enum Command {
     /// Install the checkout everything runs from (`base`), or a model backend from it.
@@ -131,7 +131,6 @@ struct DownloadArgs {
     dataset: String,
 }
 
-/// A model backend vizfold supports.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
 enum Backend {
     Openfold,
@@ -146,8 +145,7 @@ impl Backend {
         }
     }
 
-    /// Installer script, relative to the vizfold checkout: each backend owns one under
-    /// `backends/<name>/install/`.
+    /// Installer script, relative to the checkout: each backend owns one under `backends/<name>/install/`.
     fn installer(self) -> &'static str {
         match self {
             Self::Openfold => config::INSTALLER,
@@ -155,8 +153,7 @@ impl Backend {
         }
     }
 
-    /// Data-download entrypoint, relative to the checkout. `None` for ESMFold: it pulls its
-    /// weights from HuggingFace at run time.
+    /// Downloader dir, relative to the checkout. `None` for ESMFold: it fetches weights at run time.
     fn downloader_dir(self) -> Option<&'static str> {
         match self {
             Self::Openfold => Some("downloaders/openfold"),
@@ -182,7 +179,6 @@ impl Backend {
         }
     }
 
-    /// This backend's subtree of the checkout: its project, its installer, its build droppings.
     fn dir(self, home: &Path) -> PathBuf {
         home.join("backends").join(self.slug())
     }
@@ -264,8 +260,7 @@ struct ServeArgs {
 }
 
 impl ServeArgs {
-    /// What the dashboard is handed, comma-joined: the backends named, in the order given, else
-    /// every one installed -- never a Fold option that cannot run.
+    /// For the dashboard: the named backends in order, else all installed -- never one that cannot run.
     fn backends_env(&self) -> String {
         let served: Vec<Backend> = if self.backends.is_empty() {
             Backend::value_variants()
@@ -434,12 +429,10 @@ fn clamp_cpus(cpus: i64, available_resources_json: &str) -> i64 {
     cpus.min(max_cpus)
 }
 
-/// What each command needs sound before it starts, in `health`'s vocabulary -- the one place a
-/// prerequisite is refused, so no command grows its own check. `Status` names none: it reports.
+/// The one place a prerequisite is refused, so no command grows its own check.
 fn prereqs(command: &Command) -> Vec<Component> {
-    // `run <id>` replays the run's own backend, which this gate cannot read without the DB; it
-    // checks the default instead, so uninstalling a backend out from under a queued run still
-    // reaches the runner -- which then names the missing interpreter by path.
+    // `run <id>` cannot read the run's own backend without the DB, so it gates on the default:
+    // uninstalling a backend under a queued run still reaches the runner, which names what is missing.
     let backend = |explicit: Option<Backend>| {
         backend_health(
             explicit
@@ -500,7 +493,6 @@ pub async fn run() -> Result<(), DbErr> {
         }
     }
 
-    // These touch the filesystem only; they need no database connection.
     match cli.command {
         Command::Install(args) => return run_install(args.part),
         Command::Download(args) => return run_download(args.backend, args.dataset),
@@ -579,7 +571,6 @@ fn install_backend(backend: Backend) -> Result<(), DbErr> {
     )
 }
 
-/// Run a child to completion with inherited stdio, naming it in either failure.
 fn run_to_completion(what: &str, command: &mut std::process::Command) -> Result<(), DbErr> {
     let status = command
         .status()
@@ -591,7 +582,6 @@ fn run_to_completion(what: &str, command: &mut std::process::Command) -> Result<
         .ok_or_else(|| DbErr::Custom(format!("{what}: {status}")))
 }
 
-/// Download a backend's data into `config::data_dir()`.
 fn run_download(backend: Backend, dataset: String) -> Result<(), DbErr> {
     let Some(dir) = backend.downloader_dir() else {
         println!(
@@ -685,7 +675,7 @@ fn run_status() -> Result<(), DbErr> {
     Ok(())
 }
 
-/// One independently breakable part. `health` derives `Broken` from the problem list, so no builder tracks both.
+/// One independently breakable part.
 #[derive(Default)]
 struct Component {
     name: &'static str,
@@ -759,8 +749,7 @@ fn on_path(program: &str) -> Option<PathBuf> {
         .find(|path| executable(path))
 }
 
-/// What `install.sh` puts beside the vizfold binary. Every environment is created and run through it.
-/// The one binary `install.sh` bootstraps and everything downstream resolves off PATH.
+/// The one binary `install.sh` bootstraps; every environment is created and run through it.
 const CORE_DEP: &str = "micromamba";
 
 fn core_deps_health() -> Component {
@@ -838,7 +827,7 @@ const CHECKED_PATHS: &[(&str, &str)] = &[
 /// The same, but only while OpenFold is installed: its own uninstall must not read as a broken config.
 const OPENFOLD_PATHS: &[(&str, &str)] = &[("OPENFOLD_DATA_DIR", "")];
 
-/// Config keys only the scheduler can settle, grouped by the one question that answers them.
+/// Config keys only the scheduler can settle, grouped by the question that answers them.
 const CHECKED_PARTITIONS: &[&str] = &["OPENFOLD_PARTITION", "OPENFOLD_GPU_PARTITION"];
 const CHECKED_ACCOUNTS: &[&str] = &["OPENFOLD_ACCOUNT", "OPENFOLD_GPU_ACCOUNT"];
 
@@ -920,7 +909,6 @@ fn path_problem(key: &str, marker: &str) -> Option<String> {
     })
 }
 
-/// A backend's own installation: its environment runs, and its fold inputs are where they belong.
 fn backend_health(backend: Backend) -> Component {
     let env = backend.env_prefix();
     if !backend.is_installed() {
@@ -935,7 +923,6 @@ fn backend_health(backend: Backend) -> Component {
     let mut problems: Vec<String> = missing("interpreter", env.join("bin/python"))
         .into_iter()
         .collect();
-    // The backend's own CLI, in the environment that runs it.
     problems.extend(missing("entrypoint", env.join("bin").join(backend.slug())));
     if backend == Backend::Openfold {
         problems.extend(checkout_problem());
@@ -951,8 +938,7 @@ fn backend_health(backend: Backend) -> Component {
     }
 }
 
-/// OpenFold is an editable install into the checkout, so losing it breaks every fold at import --
-/// which the environment itself, entrypoint and all, still looks healthy through.
+/// An editable install into the checkout: losing it breaks every fold at import, env still healthy.
 fn checkout_problem() -> Option<String> {
     let src = config::vizfold_src();
     (!src.join(config::INSTALLER).is_file()).then(|| {
@@ -1101,7 +1087,6 @@ fn unknown_to_scheduler(
         .then(|| format!("{key} names {noun} {value}, which this cluster does not have"))
 }
 
-/// The last line of `status`: what to do, in one sentence.
 fn summary(components: &[Component]) -> String {
     let broken: Vec<&str> = components
         .iter()
@@ -1145,7 +1130,6 @@ fn clone_checkout(src: &std::path::Path) -> Result<(), DbErr> {
     }
 }
 
-/// Bring a part current: the checkout to a ref, a backend to the checkout as it now stands.
 fn run_update(args: UpdateArgs) -> Result<(), DbErr> {
     match args.part.backend() {
         None => update_base(args.r#ref.as_deref()),
@@ -1157,8 +1141,7 @@ fn run_update(args: UpdateArgs) -> Result<(), DbErr> {
     }
 }
 
-/// Neither installer reruns on drift -- openfold seals each step in `$STATE/.done`, esmfold gates on
-/// an import check -- so the scripts a fresh checkout brought only reach the env through this.
+/// Neither installer reruns on drift, so a fresh checkout's scripts reach the env only through this.
 fn reinstall(backend: Backend, yes: bool) -> Result<(), DbErr> {
     let targets = removal_plan(reinstall_paths(
         backend,
@@ -1173,9 +1156,8 @@ fn reinstall(backend: Backend, yes: bool) -> Result<(), DbErr> {
     install_backend(backend)
 }
 
-/// Reinstall takes back everything install planted except downloads: params are ~4 GB, or a mirror
-/// symlink tree, and neither is install state. `data` defaults to a subdirectory of the state dir
-/// install also plants, so a directory holding it is spent entry by entry, never removed whole.
+/// Everything install planted except downloads: params are ~4 GB, or a mirror symlink tree, and
+/// neither is install state. `data` may sit under a planted directory, spent entry by entry instead.
 fn reinstall_paths(backend: Backend, prefix: &Path, home: &Path, data: &Path) -> Vec<PathBuf> {
     backend
         .install_paths(prefix, home)
@@ -1195,7 +1177,7 @@ fn reinstall_paths(backend: Backend, prefix: &Path, home: &Path, data: &Path) ->
         .collect()
 }
 
-/// Move the checkout to a ref, by default this binary's own release tag. Install droppings are gitignored.
+/// Move the checkout to a ref, by default this binary's own release tag.
 fn update_base(wanted: Option<&str>) -> Result<(), DbErr> {
     let src = config::vizfold_src();
     let target = wanted.unwrap_or(&release::tag()).to_owned();
@@ -1254,7 +1236,7 @@ fn git_cmd(dir: &Path, args: &[&str]) -> std::process::Command {
     command
 }
 
-/// One read-only git question as trimmed stdout. `None` when git cannot answer at all.
+/// One read-only git question as trimmed stdout; `None` when git cannot answer.
 fn git(dir: &Path, args: &[&str]) -> Option<String> {
     let output = git_cmd(dir, args).output().ok()?;
     output
@@ -1263,7 +1245,6 @@ fn git(dir: &Path, args: &[&str]) -> Option<String> {
         .then(|| String::from_utf8_lossy(&output.stdout).trim().to_owned())
 }
 
-/// What the checkout is actually on: its tag if it sits exactly on one, else a short commit.
 fn checkout_ref(src: &Path) -> Option<String> {
     git(src, &["describe", "--tags", "--exact-match"])
         .or_else(|| git(src, &["rev-parse", "--short", "HEAD"]))
@@ -1306,7 +1287,6 @@ fn run_self_update(args: SelfUpdateArgs) -> Result<(), DbErr> {
         ))
     })?;
     println!("vizfold {wanted} is installed at {}", exe.display());
-    // The scripts are pinned per version, so the checkout is now behind until `update` moves it.
     println!(
         "The checkout still runs {current}'s scripts. Bring it along with: vizfold update base"
     );
@@ -1339,8 +1319,8 @@ fn fetch_release(url: &str, staged: &Path, wanted: &str) -> Result<(), DbErr> {
 /// Undo `vizfold install`. Not a script, because the checkout holding it is one of the things removed.
 fn run_uninstall(args: UninstallArgs) -> Result<(), DbErr> {
     let (prefix, home) = (config::prefix(), config::openfold_home());
-    // One plan for all parts: `removal_plan` folds the backend paths that live inside the checkout
-    // under it, which removing part by part would instead drop as already gone.
+    // One plan for all parts: `removal_plan` folds paths inside the checkout under it, which
+    // removing part by part would instead drop as already gone.
     let targets = match args.part {
         Some(part) => part.install_paths(&prefix, &home),
         None => Part::value_variants()
@@ -1385,7 +1365,7 @@ fn run_uninstall(args: UninstallArgs) -> Result<(), DbErr> {
     Ok(())
 }
 
-/// Print what goes, confirm it unless `yes`, remove it. `false` means the user declined and nothing went.
+/// Print, confirm unless `yes`, remove. `false`: the user declined and nothing went.
 fn remove_confirmed(headline: &str, targets: &[PathBuf], yes: bool) -> Result<bool, DbErr> {
     println!("{headline}");
     for target in targets {
@@ -1404,8 +1384,7 @@ fn remove_confirmed(headline: &str, targets: &[PathBuf], yes: bool) -> Result<bo
     Ok(true)
 }
 
-/// What `uninstall` removes, and prints for confirmation. A relative path means an empty config
-/// value resolved into one -- never delete off the cwd.
+/// A relative path means an empty config value resolved into one -- never delete off the cwd.
 fn removal_plan(mut targets: Vec<PathBuf>) -> Vec<PathBuf> {
     targets.retain(|path| path.is_absolute() && std::fs::symlink_metadata(path).is_ok());
     targets.sort();
@@ -1427,7 +1406,7 @@ fn shared_paths(prefix: &Path, home: &Path) -> Vec<PathBuf> {
         config::env_dir("workbench"),
         prefix.join("vizfold.db"),
         config::config_file(),
-        // The package cache outlives any one backend; the binary is bootstrap state, beside `vizfold` itself.
+        // The package cache outlives any one backend.
         prefix.join("mamba"),
     ];
     // The staged copy only; with no prefix settled the two are one path, the source tree.
@@ -1485,7 +1464,6 @@ fn run_completions(shell: Option<Shell>) -> Result<(), DbErr> {
         .map_err(|error| DbErr::Custom(format!("failed to write completions: {error}")))
 }
 
-/// Start the workbench dashboard, streaming its output to this shell.
 fn run_serve(args: ServeArgs) -> Result<(), DbErr> {
     let workbench = serve_dir()?;
 
@@ -1590,7 +1568,6 @@ fn node_is_new_enough(version: &str) -> bool {
     (major, minor) >= MIN_NODE
 }
 
-/// The bin directory of a usable Node already on PATH, if there is one.
 fn system_node_bin() -> Option<PathBuf> {
     let output = std::process::Command::new("node")
         .args([
@@ -1606,7 +1583,7 @@ fn system_node_bin() -> Option<PathBuf> {
         .flatten()
 }
 
-/// Node from PATH when new enough, else its own env -- kept out of every backend env. Returns the bin dir.
+/// Node from PATH when new enough, else its own env -- kept out of every backend env.
 fn ensure_node() -> Result<PathBuf, DbErr> {
     let env_dir = config::env_dir("workbench");
     let bin = env_dir.join("bin");
@@ -1806,8 +1783,7 @@ fn list_examples(json: bool) -> Result<(), DbErr> {
     Ok(())
 }
 
-/// Fold every target in one execution, or replay a queued run by id -- one verb. Re-registers
-/// artifacts (idempotent).
+/// Fold every target in one execution, or replay a queued run by id. Re-registers artifacts (idempotent).
 async fn run_run(database: &sea_orm::DatabaseConnection, args: RunArgs) -> Result<(), DbErr> {
     let run_id = match queued_run_id(&args.targets)? {
         Some(run_id) => run_id,
@@ -1904,7 +1880,7 @@ fn unknown_target(target: &str) -> DbErr {
     })
 }
 
-/// A lone integer target replays that run. Mixed with anything else it is ambiguous, not a batch.
+/// A lone integer target replays that run; mixed with anything else it is ambiguous.
 fn queued_run_id(targets: &[String]) -> Result<Option<i32>, DbErr> {
     let ids: Vec<i32> = targets
         .iter()
@@ -1919,7 +1895,6 @@ fn queued_run_id(targets: &[String]) -> Result<Option<i32>, DbErr> {
     }
 }
 
-/// One FASTA to fold: where it is, what it holds, and whether it came from the bundled examples.
 #[derive(Debug)]
 struct Target {
     fasta: PathBuf,
@@ -1934,8 +1909,7 @@ fn tags(resolved: &[Target]) -> Vec<&str> {
         .collect()
 }
 
-/// Every FASTA the targets name, in the order given: an example id resolves to its bundled FASTA,
-/// a path to itself, and a directory to every FASTA in it.
+/// Every FASTA the targets name, in order: an example id, a path, or a directory of FASTAs.
 fn resolve_targets(targets: &[String]) -> Result<Vec<Target>, DbErr> {
     let mut resolved: Vec<Target> = Vec::new();
     for target in targets {
@@ -1997,8 +1971,7 @@ fn batch_inputs_dir() -> PathBuf {
     config::prefix().join("runs/inputs")
 }
 
-/// cwd first, then the checkout -- a relative target means what the shell means by it, as
-/// `canonicalize_local_path` does for the flags.
+/// cwd first, then the checkout: a relative target means what the shell means by it.
 fn local_path(target: &str) -> PathBuf {
     let path = Path::new(target);
     std::env::current_dir()
@@ -2032,10 +2005,9 @@ fn stage_batch(inputs_dir: &Path, resolved: &[Target]) -> Result<PathBuf, DbErr>
     Ok(dir)
 }
 
-/// `<tags>-<hash of the files behind them>`: the same batch always stages into the same directory,
-/// and two batches sharing a tag set but not their sources never share one -- otherwise a second
-/// submit would relink the inputs of a batch already recorded and waiting to fold. The tag list is
-/// dropped for a first tag and a count once it outgrows a directory name.
+/// `<tags>-<hash of the files behind them>`: same batch, same directory; same tags over different
+/// files, a different one -- so a submit cannot relink a batch already recorded and waiting to fold.
+/// Long tag lists collapse to first+count.
 fn batch_name(resolved: &[Target]) -> String {
     use std::hash::{Hash, Hasher};
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
@@ -2051,7 +2023,7 @@ fn batch_name(resolved: &[Target]) -> String {
     format!("{head}-{:x}", hasher.finish())
 }
 
-/// The seeded records a local run is built from. Both backends differ only in which they name.
+/// The seeded records a local run is built from; both backends differ only in which they name.
 struct LocalCatalog {
     backend_id: i32,
     target_id: i32,
@@ -2254,7 +2226,6 @@ async fn submit_esmfold_run(
     Ok(run)
 }
 
-/// The backend a bare `vizfold run` uses: the only one installed, else OpenFold. `--backend` always wins.
 fn default_backend() -> Result<Backend, DbErr> {
     match (
         Backend::Openfold.is_installed(),
@@ -2344,8 +2315,7 @@ fn read_fasta(path: &Path) -> Result<examples::Example, DbErr> {
     })
 }
 
-/// Seeding runs immediately before every lookup, so a miss here means the database is not one
-/// vizfold wrote -- naming the file is the only thing that helps.
+/// Seeding runs immediately before every lookup, so a miss means the database is not one vizfold wrote.
 fn seed_required_error() -> DbErr {
     DbErr::Custom(format!(
         "the run's backend, local execution target, or matching profile is missing from {} \
@@ -2513,8 +2483,6 @@ mod tests {
 
     use crate::core::{db, seed};
 
-    /// Everything the three old argument surfaces carried now hangs off `run`, and the clap
-    /// defaults it applies are the only defaults there are.
     fn run_args(argv: &[&str]) -> RunArgs {
         let full: Vec<&str> = ["vizfold", "run"]
             .into_iter()
@@ -2541,7 +2509,6 @@ mod tests {
                 .expect("install <part> should parse");
             assert!(matches!(cli.command, Command::Install(InstallArgs { part }) if part == want));
         }
-        // The part is required and constrained to the known set.
         assert!(Cli::try_parse_from(["vizfold", "install"]).is_err());
         assert!(Cli::try_parse_from(["vizfold", "install", "rosetta"]).is_err());
     }
@@ -2582,7 +2549,6 @@ mod tests {
         );
     }
 
-    /// The one path partition reinstall makes: params are ~4 GB, or a mirror symlink tree.
     #[test]
     fn a_reinstall_keeps_the_downloads_and_takes_everything_else() {
         let base = std::env::temp_dir().join(format!("vizfold-reinstall-{}", std::process::id()));
@@ -2605,8 +2571,7 @@ mod tests {
         assert_eq!(kept.len(), full.len() - 1, "only the data dir is spared");
     }
 
-    /// The data dir defaults to a subdirectory of the state dir install also plants, so leaving it
-    /// out of the list is not enough: removing the state dir whole takes the databases with it.
+    /// The data dir sits inside the state dir install also plants: removing that whole takes the databases.
     #[test]
     fn a_reinstall_removes_no_directory_the_downloads_live_under() {
         let base = std::env::temp_dir().join(format!("vizfold-nested-data-{}", std::process::id()));
@@ -2625,7 +2590,7 @@ mod tests {
             !kept.iter().any(|path| data.starts_with(path)),
             "a removal target holds the downloads: {kept:?}"
         );
-        // What makes the installer redo its work: without these it short-circuits on the sentinel.
+        // Without these the installer short-circuits on the sentinel.
         assert!(kept.contains(&state.join(".done")), "the sentinel must go");
         assert!(
             kept.contains(&state.join("pkgs")),
@@ -2633,9 +2598,8 @@ mod tests {
         );
     }
 
-    /// Each backend reads its own key, so a stray `ESMFOLD_ENV_PREFIX` cannot move OpenFold's env
-    /// -- and that reading is exactly what bare `serve` hands the dashboard. Both keys are pinned
-    /// here rather than in a second test, which would race this one over the same variables.
+    /// Each backend reads its own key: a stray `ESMFOLD_ENV_PREFIX` cannot move OpenFold's env, and
+    /// that reading is what bare `serve` hands the dashboard. One test, not two: they would race.
     #[test]
     fn backend_is_installed_tracks_its_own_env_prefix_key() {
         let base = std::env::temp_dir().join(format!("vizfold-backend-{}", std::process::id()));
@@ -2686,8 +2650,7 @@ mod tests {
         }
     }
 
-    /// The prelude is the whole of what we add to clap_complete's output. Verified load-bearing: a
-    /// zsh that never ran compinit registers nothing without it, and the syntax is an error in bash.
+    /// Verified load-bearing: a zsh that never ran compinit registers nothing, and it errors in bash.
     #[test]
     fn only_zsh_carries_the_compinit_prelude() {
         let script = |shell| String::from_utf8(completion_script(shell)).expect("utf-8");
@@ -2703,8 +2666,7 @@ mod tests {
                 "{shell} has no compdef to arrange for"
             );
         }
-        // The name bound here is what the user's TAB has to match; nothing else in the script
-        // fails visibly if it is wrong -- completion would simply do nothing, for everyone.
+        // Nothing fails visibly if this name is wrong -- completion would simply do nothing.
         assert!(
             zsh.contains("compdef _vizfold vizfold\n"),
             "zsh binds `vizfold`"
@@ -2762,7 +2724,6 @@ mod tests {
         let (prefix, home) = (base.join("prefix"), base.join("checkout"));
         let _ = std::fs::remove_dir_all(&base);
         std::fs::create_dir_all(prefix.join("outputs")).unwrap();
-        // The editable install's extension, named for the Python ABI and arch that built it.
         let backend = home.join("backends/openfold");
         std::fs::create_dir_all(&backend).unwrap();
         let extension = backend.join("attn_core_inplace_cuda.cpython-311-x86_64-linux-gnu.so");
@@ -2780,7 +2741,7 @@ mod tests {
             assert!(paths.contains(&expected), "missing {}", expected.display());
         }
         assert!(!paths.contains(&prefix.join("outputs")), "run outputs kept");
-        // The package cache serves the workbench env too; one backend's uninstall must not take it.
+        // The cache serves the workbench env too.
         assert!(
             !paths.contains(&prefix.join("mamba")),
             "the cache is shared"
@@ -2815,7 +2776,6 @@ mod tests {
                 owned.display()
             );
         }
-        // Only the clone vizfold made itself: a user-supplied checkout is never `uninstall`'s to take.
         assert!(
             super::base_paths(&prefix) == vec![config::default_src()]
                 || config::vizfold_src() != config::default_src(),
@@ -2839,14 +2799,12 @@ mod tests {
             shared.contains(&prefix.join("workbench")),
             "a staged workbench is shared"
         );
-        // With no prefix settled the two are one path, and that one is the source tree.
         assert!(
             !super::shared_paths(&home, &home).contains(&home.join("workbench")),
             "the checkout's own workbench must survive"
         );
     }
 
-    /// The checks name keys as strings; one outside the schema reports on a value nothing writes.
     /// `uninstall` is `rm -rf`: no relative path may reach it, and no path an outer target covers.
     #[test]
     fn the_removal_plan_keeps_only_absolute_uncovered_paths_that_exist() {
@@ -2857,18 +2815,17 @@ mod tests {
         let plan = super::removal_plan(vec![
             // Exists relative to the cwd tests run in: without the guard, uninstall deletes it.
             PathBuf::from("Cargo.toml"),
-            base.join("does-not-exist"), // nothing to remove
-            base.join("outer/inner"),    // covered by its parent below
+            base.join("does-not-exist"),
+            base.join("outer/inner"),
             base.join("outer"),
-            base.join("outer"), // duplicate
+            base.join("outer"), // duplicate: dedup is what keeps the plan one entry
         ]);
 
         assert_eq!(plan, vec![base.join("outer")]);
         std::fs::remove_dir_all(&base).ok();
     }
 
-    /// The gate table by the names it produces. `status` and base's own verbs stay off `repo` --
-    /// they are what a missing or drifted checkout is repaired with.
+    /// The gate table by the names it produces: `status` and base's own verbs stay off `repo`.
     #[test]
     fn every_command_gates_on_the_prereqs_it_actually_needs() {
         let names = |argv: &[&str]| {
@@ -2883,7 +2840,6 @@ mod tests {
         assert_eq!(names(&["vizfold", "uninstall"]), Vec::<&str>::new());
         assert_eq!(names(&["vizfold", "install", "base"]), ["core deps"]);
         assert_eq!(names(&["vizfold", "update", "base"]), ["core deps"]);
-        // A backend is installed out of the checkout, so it is refused until there is one.
         assert_eq!(
             names(&["vizfold", "install", "openfold"]),
             ["core deps", "repo"]
@@ -2897,7 +2853,6 @@ mod tests {
             names(&["vizfold", "serve"]),
             ["core deps", "repo", "config"]
         );
-        // Named backends are gated; bare `serve` resolves to the installed ones, so it gates on none.
         assert_eq!(
             names(&["vizfold", "serve", "openfold", "esmfold"]),
             ["core deps", "repo", "config", "openfold", "esmfold"]
@@ -2924,7 +2879,6 @@ mod tests {
             ["config", "esmfold"]
         );
 
-        // The one binary the bootstrap installs, named in the detail whether or not it is found.
         let core = super::core_deps_health();
         assert!(
             core.detail.ends_with("micromamba"),
@@ -2933,8 +2887,7 @@ mod tests {
         );
     }
 
-    /// Never cloned and drifted are different problems with different fixes; before this, both read
-    /// BROKEN and both pointed at the updater, which cannot create a checkout.
+    /// Never cloned and drifted need different fixes; both once read BROKEN and pointed at the updater.
     #[test]
     fn an_absent_checkout_is_not_a_broken_one() {
         let dir = std::env::temp_dir().join(format!("vizfold-repo-{}", std::process::id()));
@@ -2959,7 +2912,6 @@ mod tests {
         assert_eq!(present.remedy, "vizfold update base");
     }
 
-    /// The rule `refuses` encodes: Unverified is not a failure.
     #[test]
     fn only_absent_and_broken_refuse() {
         assert!(super::refuses(State::Absent));
@@ -3044,7 +2996,6 @@ mod tests {
         );
     }
 
-    /// Broken exactly when it carries a problem, so no builder keeps two fields in step by hand.
     #[test]
     fn health_promotes_any_component_with_a_problem() {
         for component in super::health() {
@@ -3059,8 +3010,7 @@ mod tests {
         }
     }
 
-    /// A failed micromamba fetch leaves a truncated, non-executable file; reading that as installed
-    /// sends the user into `Permission denied` from inside an installer instead of at the gate.
+    /// A failed fetch leaves a non-executable file; reading it as installed fails deep in an installer.
     #[test]
     fn a_present_but_non_executable_file_is_not_the_dependency() {
         let dir = std::env::temp_dir().join(format!("vizfold-exec-{}", std::process::id()));
@@ -3117,15 +3067,14 @@ mod tests {
 
         assert!(dst.join("package.json").is_file());
         assert!(dst.join("app/page.tsx").is_file());
-        assert!(!dst.join(".next").exists()); // excluded at top level
-        assert!(dst.join("node_modules/installed.js").is_file()); // preserved
-        assert!(!dst.join("node_modules/dep.js").exists()); // src node_modules not copied
+        assert!(!dst.join(".next").exists());
+        assert!(dst.join("node_modules/installed.js").is_file());
+        assert!(!dst.join("node_modules/dep.js").exists());
         std::fs::remove_dir_all(&base).ok();
     }
 
     #[test]
     fn copy_tree_skips_a_symlinked_directory() {
-        // public/runs is a symlink; fs::copy would follow it into a directory and hit EISDIR.
         let base =
             std::env::temp_dir().join(format!("vizfold-copytree-link-{}", std::process::id()));
         let (src, dst, outputs) = (base.join("src"), base.join("dst"), base.join("outputs"));
@@ -3138,7 +3087,7 @@ mod tests {
         super::copy_tree(&src, &dst, &[]).unwrap();
 
         assert!(dst.join("package.json").is_file());
-        assert!(!dst.join("public/runs").exists()); // the symlink is not staged
+        assert!(!dst.join("public/runs").exists());
         std::fs::remove_dir_all(&base).ok();
     }
 
@@ -3155,15 +3104,13 @@ mod tests {
         assert!(!node_is_new_enough("garbage"));
     }
 
-    /// One positional list, both backends' flags on it, and the default-true bools taking
-    /// `--flag=false`. A lone integer is still how `run_run` spots a queued run.
+    /// One positional list, both backends' flags on it, and the default-true bools taking `--flag=false`.
     #[test]
     fn parses_run() {
         let one = run_args(&["1"]);
         assert_eq!(one.targets, ["1"]);
         assert!(one.backend.is_none());
         assert!(!one.no_exec && !one.json);
-        // Unless asked otherwise: attention maps on, raw outputs kept, one recycle saved.
         assert!(one.attn && one.save_outputs);
         assert_eq!((one.residue_idx, one.num_recycles_save), (1, 1));
         // Unset, not false: whether alignments are precomputed depends on what the targets are.
@@ -3187,11 +3134,10 @@ mod tests {
         assert_eq!(batch.use_precomputed_alignments, Some(false));
         assert_eq!(batch.trace_mode, "attention");
 
-        // The positional is required: a bare `run` is a parse error, not an empty batch.
+        // A bare `run` is a parse error, not an empty batch.
         assert!(Cli::try_parse_from(["vizfold", "run"]).is_err());
     }
 
-    /// A run id names one queued execution; mixing it with a target would be two different asks.
     #[test]
     fn a_run_id_refuses_to_share_the_command_line() {
         let ids = |argv: &[&str]| super::queued_run_id(&run_args(argv).targets);
@@ -3214,8 +3160,7 @@ mod tests {
         }
     }
 
-    /// A batch of two names itself; a batch of twenty cannot, so it keeps a stable short name. The
-    /// same batch always lands in the same directory, and two batches never share one by tag alone.
+    /// Two tags name the directory; twenty collapse to a stable short name.
     #[test]
     fn a_batch_directory_is_named_after_its_tags_and_its_files() {
         let pair = [
@@ -3333,8 +3278,7 @@ mod tests {
         Ok(())
     }
 
-    /// ESMFold's `--fasta` and its preflight both take a file, and a bundled example names the
-    /// directory holding one. Regression: it used to record the directory and could never fold.
+    /// Regression: a bundled example names a directory, and ESMFold's `--fasta` needs the file in it.
     #[test]
     fn an_example_resolves_to_its_fasta_file_not_its_directory() {
         let resolved = super::resolve_targets(&["6KWC_1".to_owned()]).expect("6KWC_1 resolves");
@@ -3348,7 +3292,6 @@ mod tests {
         );
     }
 
-    /// Two targets, one execution: one row naming both, and one directory OpenFold can be pointed at.
     #[tokio::test]
     async fn two_targets_submit_one_run_over_a_staged_directory() -> Result<(), DbErr> {
         let database = seeded_database().await?;
@@ -3394,7 +3337,6 @@ mod tests {
         Ok(())
     }
 
-    /// ESMFold loads its model inside the fold and reads one file, so a batch has nowhere to go.
     #[tokio::test]
     async fn esmfold_refuses_more_than_one_target() -> Result<(), DbErr> {
         let database = seeded_database().await?;
@@ -3409,7 +3351,7 @@ mod tests {
         Ok(())
     }
 
-    /// A directory target folds everything in it, and a repeat is refused rather than overwritten.
+    /// A repeated tag is refused, not overwritten.
     #[test]
     fn a_directory_target_resolves_to_every_fasta_in_it() {
         let dir = crate::core::examples::monomer_dir().join("fasta_dir_6KWC");
@@ -3427,8 +3369,7 @@ mod tests {
         );
     }
 
-    /// A tag names a staged directory and a link, so a path inside a FASTA header must not reach
-    /// the filesystem. It is also the only shape preflight accepts.
+    /// A tag names a staged directory and a link, so a path in a FASTA header must not reach the disk.
     #[test]
     fn a_header_that_is_not_a_tag_is_refused() {
         let dir = std::env::temp_dir().join(format!("vizfold-tag-{}", std::process::id()));
@@ -3474,7 +3415,6 @@ mod tests {
         Ok(())
     }
 
-    /// A target that is neither a run id, a bundled example, nor a path names what is on offer.
     #[test]
     fn an_unknown_target_is_refused_before_anything_is_submitted() {
         assert!(super::resolve_targets(&["not-a-thing".into()]).is_err());
@@ -3503,7 +3443,6 @@ mod tests {
 
     #[test]
     fn model_device_prefers_the_configured_gpu_partition_without_probing() {
-        // A GPU partition with no allocation held: cuda:0 is right even though no GPU is visible here.
         assert_eq!(
             super::model_device_for(config::SlurmContext::None, Some("gpuA100x4"), None),
             "cuda:0"
@@ -3512,14 +3451,13 @@ mod tests {
 
     #[test]
     fn model_device_inside_an_allocation_trusts_the_local_probe() {
-        // Already on the node the fold runs on, so the local probe decides, not the partition config.
         assert_eq!(
             super::model_device_for(config::SlurmContext::InAllocation, Some("gpuA100x4"), None),
             "cpu"
         );
     }
 
-    /// No declared maximum, or unparseable resources, must not clamp the request to something arbitrary.
+    /// An absent or unparseable maximum must not clamp the request to something arbitrary.
     #[test]
     fn cpus_clamp_only_where_the_target_declares_a_maximum() {
         let with_max = json!({"properties": {"cpus": {"maximum": 14}}}).to_string();

--- a/cli/src/core/commands.rs
+++ b/cli/src/core/commands.rs
@@ -8,7 +8,7 @@ pub struct CommandSpec {
     pub args: Vec<String>,
     pub current_dir: Option<PathBuf>,
     pub env: BTreeMap<String, String>,
-    /// Relay the child's output to the parent instead of capturing it, so a long run reports progress live.
+    /// Relay the child's output instead of capturing it, so a long run reports progress live.
     pub stream: bool,
 }
 

--- a/cli/src/core/config.rs
+++ b/cli/src/core/config.rs
@@ -2,7 +2,7 @@ use serde_json::{Map, Value};
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
-/// The install-time config `config::save` writes: one flat JSON map, the source of every resolved path.
+/// The flat JSON map `config::save` writes at install time: source of every resolved path.
 pub fn config_file() -> PathBuf {
     if let Ok(explicit) = std::env::var("VIZFOLD_CONFIG")
         && !explicit.is_empty()
@@ -20,7 +20,7 @@ pub fn is_initialized() -> bool {
     config_file().is_file()
 }
 
-/// Mirrors `VIZFOLD_CONFIG_KEYS` in `lib/config.sh`; `tests/vocabulary.sh` fails if the two differ.
+/// Mirrors `VIZFOLD_CONFIG_KEYS` in `lib/config.sh`; `tests/vocabulary.sh` fails on drift.
 pub const CONFIG_KEYS: &[&str] = &[
     "ESMFOLD_ENV_PREFIX",
     "OPENFOLD_ACCOUNT",
@@ -62,7 +62,7 @@ fn vizfold_config() -> &'static Map<String, Value> {
     })
 }
 
-/// Empty is unset: the key set is fixed, so an unsettled name is present-but-empty and must fall through.
+/// Empty is unset: the key set is fixed, so an unsettled name is present-but-empty.
 fn non_empty(value: Option<&str>) -> Option<String> {
     value.filter(|v| !v.is_empty()).map(str::to_owned)
 }
@@ -105,7 +105,7 @@ pub fn data_dir() -> PathBuf {
         .unwrap_or_else(|| default_data_dir(&prefix()))
 }
 
-/// The install's own default for it, kept separate so the literal can be pinned.
+/// The install's own default, split out so a test can pin the literal.
 fn default_data_dir(prefix: &Path) -> PathBuf {
     prefix.join("openfold/data")
 }
@@ -117,26 +117,26 @@ pub fn env_base() -> PathBuf {
         .unwrap_or_else(|| prefix().join("envs"))
 }
 
-/// `<env base>/vizfold-<backend>`: a fixed name per backend, so nothing has to be told where one is.
+/// `<env base>/vizfold-<backend>`: fixed per backend, so nothing has to be told where one is.
 pub fn env_dir(name: &str) -> PathBuf {
     env_base().join(format!("vizfold-{name}"))
 }
 
-/// OpenFold's env. The install records it; the fallback covers a config where only ESMFold was installed.
+/// The install records the prefix; the fallback covers a config where only ESMFold was installed.
 pub fn openfold_env_prefix() -> PathBuf {
     resolved("OPENFOLD_ENV_PREFIX")
         .map(PathBuf::from)
         .unwrap_or_else(|| env_dir("openfold"))
 }
 
-/// Environment prefix for the ESMFold backend, same story as `openfold_env_prefix`.
+/// Same story as `openfold_env_prefix`.
 pub fn esmfold_env_prefix() -> PathBuf {
     resolved("ESMFOLD_ENV_PREFIX")
         .map(PathBuf::from)
         .unwrap_or_else(|| env_dir("esmfold"))
 }
 
-/// The install-resolved config map as sorted (key, value) string pairs, for `vizfold status`.
+/// Sorted (key, value) pairs, for `vizfold status`.
 pub fn config_entries() -> Vec<(String, String)> {
     let mut entries: Vec<(String, String)> = vizfold_config()
         .iter()
@@ -146,14 +146,14 @@ pub fn config_entries() -> Vec<(String, String)> {
     entries
 }
 
-/// Mirrors `vizfold::prefix`, fallback included -- otherwise `status` describes a directory no install uses.
+/// Mirrors `vizfold::prefix`, fallback included, or `status` names a directory no install uses.
 pub fn prefix() -> PathBuf {
     resolved("OPENFOLD_PREFIX")
         .map(PathBuf::from)
         .unwrap_or_else(|| default_prefix(&home_dir()))
 }
 
-/// `vizfold::prefix`'s own default, kept separate so the literal can be pinned.
+/// `vizfold::prefix`'s own default, split out so a test can pin the literal.
 fn default_prefix(home: &str) -> PathBuf {
     PathBuf::from(format!("{home}/openfold"))
 }
@@ -177,7 +177,6 @@ impl SlurmContext {
     }
 }
 
-/// Empty string counts as absent, same as an unset env var.
 fn or_default<'a>(value: Option<&'a str>, default: &'a str) -> &'a str {
     value.filter(|v| !v.is_empty()).unwrap_or(default)
 }
@@ -207,7 +206,7 @@ pub fn gpu_launch(
     args.push("-p".to_owned());
     args.push(partition.to_owned());
     args.push(format!("--gres={}", or_default(gres, "gpu:1")));
-    // Several space-separated flags in one value: setup::fold_vars relies on word splitting too.
+    // One value, several flags: setup::fold_vars word-splits it too.
     args.extend(
         or_default(resources, "--cpus-per-task=8 --mem=32G")
             .split_whitespace()
@@ -229,7 +228,7 @@ pub fn gpu_launch_args() -> Vec<String> {
     )
 }
 
-/// The GPU partition `gpu_launch_args` would srun onto, resolved the same env-var-or-config way.
+/// The partition `gpu_launch_args` would srun onto.
 pub fn gpu_partition() -> Option<String> {
     resolved("OPENFOLD_GPU_PARTITION")
 }
@@ -246,8 +245,7 @@ pub fn database_url() -> String {
     )
 }
 
-/// VIZFOLD_DB > OPENFOLD_PREFIX > XDG data home; a `sqlite:` value passes through, a bare path gets
-/// `?mode=rwc`. Callers resolve, as `gpu_launch` does.
+/// VIZFOLD_DB > OPENFOLD_PREFIX > XDG data home; `sqlite:` passes through, a bare path gets `?mode=rwc`.
 fn database_url_from(db: Option<String>, prefix: Option<String>, data_home: &str) -> String {
     if let Some(db) = db {
         return if db.starts_with("sqlite:") {
@@ -269,7 +267,7 @@ pub fn database_path() -> Option<PathBuf> {
     (!path.is_empty() && path != ":memory:").then(|| PathBuf::from(path))
 }
 
-/// The dev checkout, one level up from this crate. Baked in at build time, so use it only if it exists.
+/// The dev checkout one level up. Baked in at build time, so use it only if it exists.
 fn repository_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .parent()
@@ -292,7 +290,6 @@ mod tests {
         );
     }
 
-    /// The fixed key set writes "" for what the install did not settle; that must read as missing.
     #[test]
     fn an_empty_config_value_reads_as_unset() {
         assert_eq!(non_empty(Some("")), None);
@@ -308,8 +305,8 @@ mod tests {
         assert_eq!(env_base().file_name().unwrap(), "envs");
     }
 
-    /// Mirrors `setup::config`'s `DATA=${OPENFOLD_DATA_DIR:-$STATE/data}`. It moved once already, and
-    /// drift makes `status` and `uninstall` name a directory no install uses.
+    /// Mirrors `setup::config`'s `DATA=${OPENFOLD_DATA_DIR:-$STATE/data}`; it moved once, and drift
+    /// makes `status` and `uninstall` name a directory no install uses.
     #[test]
     fn the_data_dir_default_sits_under_the_backend_state_dir() {
         assert_eq!(
@@ -322,8 +319,7 @@ mod tests {
         );
     }
 
-    /// The three sources in order. A configured database being ignored does not fail loudly -- it
-    /// silently opens a different file, and the run history looks gone.
+    /// Getting the order wrong fails silently: a different file opens, and the run history looks gone.
     #[test]
     #[rustfmt::skip]
     fn the_database_url_prefers_vizfold_db_then_the_prefix() {
@@ -337,7 +333,6 @@ mod tests {
         assert_eq!(url(None, None), "sqlite:///xdg/vizfold/vizfold.db?mode=rwc");
     }
 
-    // (name, context, partition, account, gres, resources, time, expected args)
     #[test]
     #[rustfmt::skip]
     fn gpu_launch_cases() {

--- a/cli/src/core/db.rs
+++ b/cli/src/core/db.rs
@@ -32,7 +32,7 @@ pub async fn migrate_database(db: &DatabaseConnection) -> Result<(), DbErr> {
         .map_err(name_pre_baseline_database)
 }
 
-/// The migrator's "Migration file of version ... is missing" names no remedy; point at the actual fix.
+/// The migrator's "Migration file of version ..." error names no remedy; point at the fix.
 fn name_pre_baseline_database(error: DbErr) -> DbErr {
     match &error {
         DbErr::Custom(message) if message.contains("Migration file of version") => {
@@ -60,7 +60,7 @@ mod tests {
         let db = Database::connect("sqlite::memory:").await?;
         migrate_database(&db).await?;
 
-        // A version recorded as applied that this binary no longer has a migration file for.
+        // A version recorded as applied that no migration file backs.
         seaql_migrations::ActiveModel {
             version: Set("m20200101_000001_stale".to_owned()),
             applied_at: Set(0),

--- a/cli/src/core/examples.rs
+++ b/cli/src/core/examples.rs
@@ -26,12 +26,11 @@ pub fn find(id: &str) -> Option<Example> {
     scan_default().into_iter().find(|example| example.id == id)
 }
 
-/// The single sequence at `path` -- the FASTA or a directory holding one -- read from the file, not passed in.
+/// The single sequence at `path`: the FASTA, or a directory holding one.
 pub fn from_path(path: &Path) -> Option<Example> {
     parse(&std::fs::read_to_string(fasta_file(path)?).ok()?)
 }
 
-/// The FASTA `path` names: itself, or the first one inside it when it is a directory.
 pub fn fasta_file(path: &Path) -> Option<PathBuf> {
     if path.is_dir() {
         first_fasta(path)
@@ -40,7 +39,7 @@ pub fn fasta_file(path: &Path) -> Option<PathBuf> {
     }
 }
 
-/// Every complete example in `dir`, cheapest first: residue count is what someone is choosing on.
+/// Every complete example in `dir`, cheapest first -- residue count is what someone chooses on.
 pub fn scan(dir: &Path) -> Vec<Example> {
     let alignments = dir.join("alignments");
     let Ok(entries) = std::fs::read_dir(dir) else {
@@ -160,7 +159,6 @@ mod tests {
         std::fs::remove_dir_all(&dir).unwrap();
     }
 
-    /// Without `alignments/<id>` the fold falls back to the full MSA pipeline, so it is not offerable.
     #[test]
     fn excludes_an_example_with_no_alignment_directory() {
         let dir = tree(

--- a/cli/src/core/model_runners/esmfold.rs
+++ b/cli/src/core/model_runners/esmfold.rs
@@ -14,7 +14,7 @@ use crate::core::{
     services::validation::require_json_object,
 };
 
-/// Single-sequence, so none of OpenFold's MSA checks: the command, a readable `--fasta`, a writable output.
+/// Single-sequence, so none of OpenFold's MSA checks: just command, `--fasta`, and output.
 pub fn preflight_esmfold(
     command: &CommandSpec,
     invocation_profile: &model_invocation_profiles::Model,
@@ -37,7 +37,7 @@ pub fn preflight_esmfold(
     Ok(PreflightReport::new(checks))
 }
 
-/// ESMFold folds a single FASTA *file* (`--fasta`), unlike OpenFold's `fasta_dir`.
+/// A single FASTA *file* (`--fasta`), unlike OpenFold's `fasta_dir`.
 fn fasta_file_check(execution_parameters: &Value) -> PreflightCheck {
     let Some(fasta) = execution_parameters
         .get("fasta")
@@ -143,7 +143,7 @@ mod tests {
             status(&report, "output_dir parent"),
             PreflightStatus::Passed
         );
-        // No MSA/template checks exist for ESMFold.
+        // No MSA/template checks for ESMFold.
         assert!(!report.checks.iter().any(|check| check.name == "data_dir"));
     }
 

--- a/cli/src/core/model_runners/openfold.rs
+++ b/cli/src/core/model_runners/openfold.rs
@@ -70,7 +70,7 @@ fn fasta_input_check(parameters: &Value, input_id: &str) -> PreflightCheck {
     };
 
     let fasta_dir = Path::new(&fasta_dir);
-    // A file or a directory: the script takes either, and a one-target run passes the file itself.
+    // A one-target run passes the FASTA file itself, so a file counts as much as a directory.
     let fasta_files = if fasta_dir.is_file() {
         vec![fasta_dir.to_path_buf()]
     } else if fasta_dir.is_dir() {
@@ -99,7 +99,7 @@ fn fasta_input_check(parameters: &Value, input_id: &str) -> PreflightCheck {
 
     let mut found: BTreeSet<String> = BTreeSet::new();
     for fasta_path in &fasta_files {
-        // Monomer mode SKIPS a multi-record file with only a print, so the target would vanish.
+        // Monomer mode skips a multi-record file with only a print, so the target would vanish.
         match parse_single_fasta_tag(fasta_path) {
             Ok(tag) => {
                 found.insert(tag);
@@ -135,7 +135,7 @@ fn fasta_input_check(parameters: &Value, input_id: &str) -> PreflightCheck {
         );
     }
 
-    // The batch is exactly what input_id names: `+`-joined tags, one target or many.
+    // input_id names the whole batch: `+`-joined tags.
     let expected: BTreeSet<&str> = input_id.split('+').collect();
     let found: BTreeSet<&str> = found.iter().map(String::as_str).collect();
     if found != expected {
@@ -223,7 +223,7 @@ fn precomputed_alignment_key_check(parameters: &Value, input_id: &str) -> Prefli
         );
     }
 
-    // One key per tag in the batch, so a target with no alignments fails before the GPU is touched.
+    // One key per tag, so a target with no alignments fails before the GPU is touched.
     let missing: Vec<String> = input_id
         .split('+')
         .map(|tag| alignment_dir.join(tag))
@@ -638,7 +638,6 @@ mod tests {
 
     #[test]
     fn available_resources_flags_come_from_execution_parameters() {
-        // (execution_parameters field, override value, model_parameters, expected flag, expected value)
         let cases = [
             (
                 "model_device",
@@ -718,8 +717,6 @@ mod tests {
         assert!(error.to_string().contains("cpus must be an integer"));
     }
 
-    /// A configured data_dir may carry a trailing separator; the joined database path must not
-    /// double it.
     #[test]
     fn a_trailing_separator_on_data_dir_does_not_double_up() {
         let mut execution = execution_parameters();
@@ -740,7 +737,6 @@ mod tests {
         );
     }
 
-    /// `residue_idx` reaches the script under a different name than the parameter carries.
     #[test]
     fn residue_idx_is_emitted_as_triangle_residue_idx() {
         let mut execution = execution_parameters();
@@ -1006,7 +1002,6 @@ mod tests {
         assert!(check_message(&report, "fasta_dir").contains("contains no .fasta or .fa files"));
     }
 
-    /// A batch: several FASTAs in one directory, named by the `+`-joined input_id.
     #[test]
     fn preflight_passes_when_every_fasta_in_the_directory_is_named_by_input_id() {
         let layout = TestLayout::new("1UBQ_1|Chain A");
@@ -1024,7 +1019,6 @@ mod tests {
 
         assert_eq!(check_status(&report, "fasta_dir"), PreflightStatus::Passed);
 
-        // A tag the batch does not hold is named, rather than folding a smaller batch than asked for.
         let report = preflight_openfold(
             &layout.command(),
             &preflight_run_with_input_id("1UBQ_1+2OMF_1+6KWC_1", layout.execution_parameters()),
@@ -1035,8 +1029,7 @@ mod tests {
         assert!(check_message(&report, "fasta_dir").contains("missing: '6KWC_1'"));
     }
 
-    /// Monomer mode skips a multi-record file wherever it sits, so every file is checked, not the
-    /// first: the batch would otherwise fold one target short with only a print to say so.
+    /// Every file is checked, not just the first, or the batch folds one target short.
     #[test]
     fn preflight_fails_when_a_later_fasta_holds_multiple_records() {
         let layout = TestLayout::new("1UBQ_1|Chain A");
@@ -1076,7 +1069,6 @@ mod tests {
         assert!(check_message(&report, "fasta_dir").contains("distinct tags"));
     }
 
-    /// One target passes its FASTA straight through, so preflight must take a file as well.
     #[test]
     fn preflight_passes_when_fasta_dir_is_a_single_file() {
         let layout = TestLayout::new("1UBQ_1|Chain A");
@@ -1140,8 +1132,7 @@ mod tests {
         assert_eq!(check_status(&report, "data_dir"), PreflightStatus::Failed);
     }
 
-    /// The output directory comes from the profile, so a stale `output_dir` execution parameter
-    /// pointing at a path that does not exist must not be what preflight checks.
+    /// The profile decides the output directory, so a stale execution parameter is not what is checked.
     #[test]
     fn preflight_ignores_an_output_dir_in_execution_parameters() {
         let layout = TestLayout::new("1UBQ_1|Chain A");
@@ -1178,8 +1169,7 @@ mod tests {
         );
     }
 
-    /// An unresolvable output location aborts preflight outright rather than landing as a failed
-    /// check among the others.
+    /// An unresolvable output location aborts preflight rather than landing as one failed check.
     #[test]
     fn preflight_returns_clear_error_for_missing_output_location() {
         let layout = TestLayout::new("1UBQ_1|Chain A");

--- a/cli/src/core/model_runners/plan.rs
+++ b/cli/src/core/model_runners/plan.rs
@@ -1,5 +1,4 @@
-//! The schema-driven command planner: a backend declares its CLI in JSON, this turns that plus a
-//! run's parameters into a CommandSpec. Shared by every backend.
+//! Shared planner: turns a backend's JSON-declared CLI plus a run's parameters into a CommandSpec.
 
 use std::collections::BTreeMap;
 use std::path::PathBuf;
@@ -390,8 +389,7 @@ pub(crate) fn data_path(data_dir: &str, suffix: &str) -> String {
 mod tests {
     use serde_json::json;
 
-    /// Positionals are emitted in `position` order, not alphabetically -- the model's argv is
-    /// positional, so ordering by name would hand it the arguments swapped.
+    /// Ordering positionals by name instead of `position` would hand the model swapped arguments.
     #[test]
     fn positionals_order_by_position_and_the_rest_by_name() {
         let schema = json!({"properties": {

--- a/cli/src/core/output_locations.rs
+++ b/cli/src/core/output_locations.rs
@@ -5,7 +5,6 @@ use sea_orm::DbErr;
 
 use crate::core::entities::{model_invocation_profiles, runs};
 
-/// Resolves the workspace where a run's outputs are stored.
 pub fn resolve_output_location(
     invocation_profile: &model_invocation_profiles::Model,
     run: &runs::Model,
@@ -17,8 +16,7 @@ pub fn resolve_output_location(
     Ok(PathBuf::from(output_location).join(run.id.to_string()))
 }
 
-/// Prefer the run's immutable snapshot; fall back to the live profile for runs queued before
-/// snapshots existed.
+/// Prefer the run's immutable snapshot; fall back to the live profile for pre-snapshot runs.
 pub fn output_location_from(
     provenance_json: Option<&str>,
     profile_config_json: &str,

--- a/cli/src/core/preflight.rs
+++ b/cli/src/core/preflight.rs
@@ -66,7 +66,7 @@ use std::path::Path;
 
 use crate::core::commands::CommandSpec;
 
-/// Mirrors the fold's own `nvidia-smi --query-gpu=name --format=csv,noheader` probe.
+/// Mirrors `setup::preflight`'s `--query-gpu=name` probe, so both name the GPU the same way.
 pub fn detect_gpu() -> Option<String> {
     let output = std::process::Command::new("nvidia-smi")
         .args(["--query-gpu=name", "--format=csv,noheader"])
@@ -216,8 +216,7 @@ pub fn output_dir_check(output_path: &Path) -> PreflightCheck {
 mod tests {
     use super::{PreflightCheck, PreflightReport, PreflightStatus};
 
-    /// Only `Failed` blocks a run: a warning must reach neither `failures()`
-    /// (the list printed as "preflight failed: ...") nor `has_failures()`.
+    /// Only `Failed` blocks a run: a warning reaches neither `failures()` nor `has_failures()`.
     #[test]
     fn warnings_do_not_block_but_failures_do() {
         let report = PreflightReport::new(vec![

--- a/cli/src/core/release.rs
+++ b/cli/src/core/release.rs
@@ -101,7 +101,6 @@ mod tests {
         );
     }
 
-    /// The three answers, against whatever version this build actually is.
     #[test]
     fn the_version_line_says_which_of_the_three_states_this_is() {
         let current = super::current();

--- a/cli/src/core/seed.rs
+++ b/cli/src/core/seed.rs
@@ -227,7 +227,7 @@ pub async fn seed_defaults(db: &DatabaseConnection) -> Result<(), DbErr> {
     Ok(())
 }
 
-/// ESMFold catalog rows. Single-sequence, so no AlphaFold2 schema -- model/trace flags and a `--device`.
+/// Single-sequence, so no AlphaFold2 database schema -- model/trace flags and a `--device`.
 async fn seed_esmfold(db: &DatabaseConnection) -> Result<(), DbErr> {
     if model_backends::Entity::find()
         .filter(model_backends::Column::Slug.eq("esmfold"))

--- a/cli/src/core/services/run_artifacts.rs
+++ b/cli/src/core/services/run_artifacts.rs
@@ -7,7 +7,7 @@ use crate::core::{
 
 use super::artifacts::{self as artifact_service, RecordArtifactByTypeSlugInput};
 
-/// The directories a registration considers. `register-artifacts` reports against this, not a second copy.
+/// Single source of truth: `register-artifacts` reports against this, not a second copy.
 pub fn known_directories(workspace: &std::path::Path) -> [(&'static str, std::path::PathBuf); 2] {
     [
         ("run_output_directory", workspace.to_path_buf()),
@@ -15,7 +15,7 @@ pub fn known_directories(workspace: &std::path::Path) -> [(&'static str, std::pa
     ]
 }
 
-/// Registers a run's existing output directories and returns its full artifact list. Idempotent.
+/// Idempotent; returns the run's whole artifact list, not just what this call registered.
 pub async fn register_known_run_artifacts(
     db: &DatabaseConnection,
     run_id: i32,

--- a/cli/src/core/services/run_execution.rs
+++ b/cli/src/core/services/run_execution.rs
@@ -37,14 +37,13 @@ impl BackendKind {
     }
 }
 
-/// Outcome of planning, preflighting, and (if preflight passed) executing a run.
+/// `output` is None when preflight failed, so nothing ran.
 #[derive(Debug)]
 pub struct ExecutionOutcome {
     pub report: PreflightReport,
     pub output: Option<CommandOutput>,
 }
 
-/// Plans and executes a run stored in the executor database.
 pub async fn execute_run(
     db: &DatabaseConnection,
     run_id: i32,
@@ -73,7 +72,7 @@ pub async fn execute_run(
                 .await?
                 .ok_or_else(|| DbErr::Custom("model invocation profile does not exist".into()))?;
 
-        // Create the workspace so a fresh install needs no mkdir; OpenFold also seeds its attention/ dir.
+        // Created up front, so a fresh install needs no mkdir; OpenFold also seeds its attention/ dir.
         let workspace = resolve_output_location(&invocation_profile, &run)?;
         let to_create = match kind {
             BackendKind::Openfold => workspace.join("attention"),
@@ -88,8 +87,8 @@ pub async fn execute_run(
 
         let command = plan_command(&model_backend, &execution_target, &invocation_profile, &run)?;
 
-        // Preflight sees the bare command, the runner an env-wrapped one. The CLI's prereq gate
-        // refuses an uninstalled backend before this, so there is no unwrapped fallback to pick.
+        // Preflight sees the bare command, the runner the env-wrapped one; the CLI's prereq gate
+        // already refused an uninstalled backend, so there is no unwrapped fallback to pick.
         let exec_command = match kind {
             BackendKind::Openfold => compose_exec_command(
                 &command,
@@ -166,7 +165,7 @@ pub async fn execute_run(
                     },
                 )
                 .await?;
-                // Inline, so a completed run has its artifacts without a second command. Idempotent.
+                // Inline and idempotent: a completed run has its artifacts without a second command.
                 super::run_artifacts::register_known_run_artifacts(db, run_id).await?;
             } else {
                 let message = if output.stderr.trim().is_empty() {
@@ -211,7 +210,7 @@ async fn mark_failed(
 }
 
 /// `micromamba run -p` applies the env's activate.d hook, where every runtime variable a fold needs
-/// is set -- the same one command `setup::ready` hands the user.
+/// is set -- the same command `setup::ready` hands the user.
 fn activate_env_command(command: &CommandSpec, env_prefix: &Path) -> CommandSpec {
     let mut args = vec![
         "run".to_owned(),
@@ -226,8 +225,7 @@ fn activate_env_command(command: &CommandSpec, env_prefix: &Path) -> CommandSpec
         args,
         ..command.clone()
     };
-    // Carried, not left to the env's activate.d hook: that hook is written by whichever installer
-    // built the env, so a fold through an older one runs without them. Triton's default is NFS $HOME.
+    // Carried, not left to activate.d: an older installer's hook sets neither. Triton defaults to NFS $HOME.
     let user = std::env::var("USER").unwrap_or_else(|_| "vizfold".to_owned());
     for (key, value) in [
         (
@@ -243,7 +241,7 @@ fn activate_env_command(command: &CommandSpec, env_prefix: &Path) -> CommandSpec
     wrapped
 }
 
-/// The env inside srun, streaming always on. srun must stay outermost, or the env is entered on the submit host.
+/// srun stays outermost, or the env is entered on the submit host. Streaming always on.
 fn compose_exec_command(
     command: &CommandSpec,
     env_prefix: &Path,
@@ -278,7 +276,6 @@ fn compose_esmfold_command(
     }
 }
 
-/// Prefix a command with the SLURM launcher.
 fn srun_command(command: CommandSpec, launch: &[String]) -> CommandSpec {
     let Some((program, prefix)) = launch.split_first() else {
         return command;
@@ -297,7 +294,7 @@ fn srun_command(command: CommandSpec, launch: &[String]) -> CommandSpec {
 
 #[cfg(test)]
 mod tests {
-    /// The var has to be on the command that folds, not merely recorded: HuggingFace writes ~2.6 GB.
+    /// The var has to be on the command that folds, not merely recorded.
     #[test]
     fn an_installed_esmfold_command_caches_its_weights_under_the_env() {
         let env = PathBuf::from("/scratch/me/vizfold/envs/vizfold-esmfold");
@@ -378,7 +375,7 @@ mod tests {
         let wrapped =
             activate_env_command(&command, &PathBuf::from("/work/of/envs/vizfold-openfold"));
 
-        // No shell, so nothing is re-quoted; `run -p` applies the env's activate.d hook.
+        // No shell, so nothing is re-quoted.
         assert_eq!(wrapped.program, "micromamba");
         assert_eq!(
             wrapped.args,
@@ -395,8 +392,7 @@ mod tests {
         assert_eq!(wrapped.current_dir, Some(PathBuf::from("/repo")));
     }
 
-    /// An env's activate.d hook is written by whichever installer built it, so the fold carries its
-    /// own: through an older env it would otherwise run with neither set.
+    /// Through an env built by an older installer, neither would be set.
     #[test]
     fn the_fold_carries_the_data_root_and_a_node_local_cache() {
         let wrapped = activate_env_command(&CommandSpec::default(), &PathBuf::from("/env"));
@@ -422,7 +418,6 @@ mod tests {
             &["srun".to_owned(), "-p".to_owned(), "gpu".to_owned()],
         );
 
-        // srun outermost: the reverse enters the env on the submit host, not the compute node.
         assert_eq!(composed.program, "srun");
         assert_eq!(
             composed.args,
@@ -525,7 +520,7 @@ mod tests {
         .await
     }
 
-    /// An `esmfold` run: the slug routes it through the ESMFold path, one `--fasta` and no data_dir.
+    /// The `esmfold` slug routes the run through the ESMFold path: one `--fasta`, no data_dir.
     async fn create_esmfold_run(
         db: &sea_orm::DatabaseConnection,
         layout: &TestLayout,
@@ -616,7 +611,6 @@ mod tests {
             .expect("command lock")
             .clone()
             .expect("planned command");
-        // The plan is always wrapped: the CLI's gate refuses an uninstalled backend before this.
         assert_eq!(command.program, "micromamba");
         assert_eq!(
             command.args,
@@ -638,11 +632,10 @@ mod tests {
         assert!(updated.started_at.is_some());
         assert!(updated.completed_at.is_some());
         assert_eq!(updated.error_message, None);
-        // The run workspace and its attention/ subdir are created before execution.
         let workspace = layout.output_location.join(run.id.to_string());
         assert!(workspace.is_dir());
         assert!(workspace.join("attention").is_dir());
-        // A completed run registers its output directories inline (no separate command).
+        // Output directories register inline on completion.
         let artifacts =
             crate::core::services::artifacts::list_artifacts_for_run(&db, run.id).await?;
         assert_eq!(artifacts.len(), 2);
@@ -678,7 +671,7 @@ mod tests {
             .await?
             .expect("run exists");
         assert_eq!(updated.status, "completed");
-        // ESMFold seeds no attention/ dir, so only the run output directory registers.
+        // ESMFold seeds no attention/ dir, so only the output directory registers.
         let workspace = layout.output_location.join(run.id.to_string());
         assert!(workspace.is_dir());
         assert!(!workspace.join("attention").exists());

--- a/cli/src/core/services/runs.rs
+++ b/cli/src/core/services/runs.rs
@@ -44,7 +44,6 @@ pub async fn list_runs(db: &DatabaseConnection) -> Result<Vec<runs::Model>, DbEr
 }
 
 /// Immutable record of what produced a run; catalog rows can be edited later, this cannot.
-/// Takes resolved paths as parameters, as `gpu_launch` does.
 #[allow(clippy::too_many_arguments)]
 pub fn provenance_snapshot(
     backend_slug: &str,
@@ -263,8 +262,7 @@ mod tests {
         .await
     }
 
-    /// `Option<Option<T>>`: outer `None` leaves the column alone, `Some(None)` writes NULL. Conflating
-    /// them would silently NULL these columns rather than fail, so this asserts the values survive.
+    /// `Option<Option<T>>`: outer `None` leaves the column alone, `Some(None)` writes NULL.
     #[tokio::test]
     async fn update_run_status_leaves_untouched_columns_alone() -> Result<(), DbErr> {
         let db = test_db().await?;
@@ -283,7 +281,6 @@ mod tests {
         )
         .await?;
 
-        // Outer `None` for started_at and error_message: neither column should be touched.
         let updated = update_run_status(
             &db,
             run.id,
@@ -316,8 +313,7 @@ mod tests {
         )
     }
 
-    /// The profile config is embedded parsed, not stringified, so the reader can find it at
-    /// `profile.config.output_location`.
+    /// The profile config is embedded parsed, not stringified, so it reads back as JSON.
     #[test]
     fn the_snapshot_reads_back_through_output_location_from() {
         let snapshot = snapshot_of(r#"{"output_location":"/work/runs"}"#);
@@ -327,8 +323,6 @@ mod tests {
         assert_eq!(resolved, "/work/runs");
     }
 
-    /// A profile whose config never parsed still yields a usable snapshot, with a null config
-    /// rather than a panic or a raw string.
     #[test]
     fn an_unparseable_profile_config_becomes_null() {
         let value: serde_json::Value =

--- a/cli/src/core/tests.rs
+++ b/cli/src/core/tests.rs
@@ -325,8 +325,7 @@ async fn rejects_non_object_json_parameters() -> Result<(), DbErr> {
     Ok(())
 }
 
-/// The schema declares `ON DELETE RESTRICT`, and `db::connect` turns foreign keys on: together they
-/// stop a backend disappearing out from under the runs that reference it.
+/// `ON DELETE RESTRICT` in the schema plus foreign keys on per connection is what enforces this.
 #[tokio::test]
 async fn a_backend_with_runs_cannot_be_deleted() -> Result<(), DbErr> {
     let db = test_db().await?;

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Bootstrap vizfold's core dependencies into ~/.local/bin -- the release binary and micromamba, which every environment is created and run through. Then `vizfold install base` fetches the checkout those live in, and `vizfold install <backend>` installs a model backend (OpenFold, ESMFold; each a pip/conda-installable package under backends/<name>/ with its own installer).
+# Bootstrap the vizfold binary and micromamba into ~/.local/bin; everything else installs from there.
 set -euo pipefail
 
 die() { echo "FATAL: $*" >&2; exit 1; }
@@ -12,8 +12,7 @@ bootstrap::config() {
     mkdir -p "$BIN"
 }
 
-# One OS/arch detection for every binary this bootstrap installs. Linux only: that is what
-# release.yml publishes, and a model backend needs CUDA and a scheduler anyway.
+# Linux only: what release.yml publishes, and a backend needs CUDA and a scheduler anyway.
 bootstrap::arch() {
     [ "$(uname -s)" = Linux ] || die "vizfold releases are Linux-only (this is $(uname -s))"
     case "$(uname -m)" in
@@ -40,29 +39,28 @@ bootstrap::download() {
     echo "installed vizfold to $BIN/vizfold"
 }
 
-# micromamba creates and runs every environment; everything downstream assumes it is on PATH.
+# Everything downstream creates and runs its envs through it, so it has to be on PATH.
 bootstrap::micromamba() {
     if [ -x "$BIN/micromamba" ] || command -v micromamba >/dev/null; then return; fi
     echo "downloading micromamba ($MAMBA_BUILD) ..."
-    # A failed fetch leaves a non-executable file, so the guard above self-heals on the next run.
+    # A failed fetch leaves a non-executable file, so the guard above self-heals next run.
     curl -fsSL "https://micro.mamba.pm/api/micromamba/$MAMBA_BUILD/latest" |
         tar -xj -O bin/micromamba > "$BIN/micromamba" || die "micromamba download failed"
     chmod +x "$BIN/micromamba"
     echo "installed micromamba to $BIN/micromamba"
 }
 
-# .zshrc only where it exists -- writing one would invent a config for a shell that may not be
-# installed. .bashrc regardless: bash reads it on every interactive shell, fresh account or not.
+# .bashrc always -- bash reads it on every interactive shell; .zshrc only where it exists, since
+# writing one invents a config for a shell that may not be installed.
 bootstrap::rc() {   # $1 shell, $2 line
     local rc=$HOME/.${1}rc
     [ "$1" = bash ] || [ -f "$rc" ] || return 0
     grep -qsF "$2" "$rc" && return 0
-    # An rc whose last line has no newline would otherwise take ours fused onto the end of it.
+    # Else ours fuses onto an rc whose last line carries no newline.
     [ ! -s "$rc" ] || [ -z "$(tail -c1 "$rc")" ] || echo >> "$rc"
     echo "$2" >> "$rc"
 }
 
-# Put ~/.local/bin on PATH for future shells (idempotent), and note it for this one.
 bootstrap::path() {
     case ":$PATH:" in *":$BIN:"*) return ;; esac
     local line="export PATH=\"$BIN:\$PATH\""
@@ -71,11 +69,9 @@ bootstrap::path() {
     echo "added $BIN to PATH in your shell rc; restart your shell or run: $line"
 }
 
-# Eval'd from the binary rather than written out as a file, so a self-update leaves nothing stale.
-# By absolute path, never PATH: Ubuntu's and RHEL's stock profiles source .bashrc *before* they
-# prepend ~/.local/bin, so a PATH lookup is false exactly when this line runs. `-x` keeps an
-# uninstalled binary quiet; 2>/dev/null keeps one too old to know the subcommand quiet too. Only
-# interactive shells have completion to register, and bash sources .bashrc under ssh as well.
+# Eval'd from the binary, not a written file, so a self-update leaves nothing stale. Absolute path, never PATH:
+# Ubuntu's and RHEL's profiles source .bashrc *before* prepending ~/.local/bin, so a lookup there fails exactly here.
+# -x quiets an uninstalled binary, 2>/dev/null one too old for the subcommand, *i* the non-interactive ssh shells bash reads .bashrc in too.
 bootstrap::completions() {
     local shell
     for shell in bash zsh; do
@@ -95,7 +91,6 @@ main() {
     echo "vizfold installed at $BIN/vizfold. Run \`vizfold install base\` for the checkout, then \`vizfold install openfold\` (or \`esmfold\`)."
 }
 
-# Sourced (tests/install_rc.sh) this file is just its definitions. Not the backend installers'
-# `BASH_SOURCE = $0` guard: piped through `curl | bash` this script has no BASH_SOURCE at all, and
-# that guard would read the absence as "sourced" and bootstrap nothing.
+# Not the backend installers' `BASH_SOURCE = $0` guard: under `curl | bash` there is no BASH_SOURCE at
+# all, which that guard would read as "sourced" and bootstrap nothing. Sourced by tests/install_rc.sh.
 if [ -z "${BASH_SOURCE[0]:-}" ] || [ "${BASH_SOURCE[0]}" = "$0" ]; then main; fi

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -1,20 +1,19 @@
 #!/bin/bash
-# ~/.config/vizfold/vizfold.json: what the install resolved, for whatever drives it later. Flat map; sourcing fills unset vars (inline wins).
+# ~/.config/vizfold/vizfold.json: a flat map of what the install resolved. Sourcing fills unset vars (inline wins).
 
 [ "${BASH_SOURCE[0]}" = "$0" ] && { echo "config.sh is a library" >&2; exit 1; }
 [ -n "${CONFIG_SH:-}" ] && return 0
 CONFIG_SH=1
 
-# The checkout root every backend shares; OPENFOLD_HOME is exported by `vizfold install`.
+# Checkout root shared by every backend; OPENFOLD_HOME is exported by `vizfold install`.
 REPO=${OPENFOLD_HOME:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}
-# OpenFold-only subtree (setup.py, environment.yml, install/); shared assets like examples/ stay at the root.
+# OpenFold-only subtree; shared assets like examples/ stay at the root.
 OF=$REPO/backends/openfold
 die() { echo "FATAL: $*" >&2; exit 1; }
 
-# Progress line, shared so every installer's output reads the same.
 log() { echo "== $* (+$((SECONDS))s)"; }
 
-# The install root, one env base under it, and one state dir per backend. Mirrored in cli/src/core/config.rs.
+# Mirrored in cli/src/core/config.rs.
 vizfold::prefix() { echo "${OPENFOLD_PREFIX:-$HOME/openfold}"; }
 vizfold::env_base() { echo "${VIZFOLD_ENV_BASE:-$(vizfold::prefix)/envs}"; }
 vizfold::env() { echo "$(vizfold::env_base)/vizfold-$1"; }
@@ -24,8 +23,7 @@ config::file() {
     echo "${VIZFOLD_CONFIG:-${XDG_CONFIG_HOME:-$HOME/.config}/vizfold/vizfold.json}"
 }
 
-# Fill unset vars from a JSON file, never overwriting. Values are $VAR templates resolved against the
-# environment first, then the file's own keys, in any order. No commands run; an unknown name is empty.
+# Fill unset vars from JSON. Values are $VAR templates resolved against the environment, then the file's own keys, in any order. No commands run; an unknown name expands empty.
 config::fill() {
     local file=$1 label=${2:-config} key value
     [ -r "$file" ] || return 0
@@ -34,7 +32,7 @@ config::fill() {
     echo "$label: $file" >&2
     # `if`, not `&&`: a skipped last line would return non-zero and abort a set -e caller.
     while IFS='=' read -r key value; do
-        # An empty value is "not settled", never an answer: it must not mask the layer below it.
+        # Empty is "not settled", never an answer: it must not mask the layer below.
         if [ -n "$key" ] && [ -n "$value" ] && [ -z "${!key:-}" ]; then export "$key=$value"; fi
     done < <(python3 -c '
 import json, os, re, sys
@@ -55,7 +53,7 @@ for k, v in scope.items():
     return 0
 }
 
-# The GPU driver's CUDA version, e.g. 12.8. Empty where no driver is loaded, so callers pick a floor.
+# e.g. 12.8; empty where no driver is loaded, so callers pick a floor.
 vizfold::driver_cuda() {
     python3 -c "
 import ctypes
@@ -64,26 +62,24 @@ ctypes.CDLL('libcuda.so.1').cuDriverGetVersion(ctypes.byref(v))
 print(f'{v.value // 1000}.{v.value % 1000 // 10}')" 2>/dev/null || true
 }
 
-# Activate a micromamba env ($1, a name or path). set +u: the conda gcc hook reads SYS_SYSROOT unset.
+# set +u: the conda gcc hook reads SYS_SYSROOT unset.
 mamba::activate() { set +u; eval "$(micromamba shell hook --shell bash)"; micromamba activate "$1"; set -u; }
 
-# The previous install's answers. Never at source time: that would land them ahead of live discovery.
-# Called after <site>.json, fixing the precedence at
-#   inline env > slurm::discover > <site>.json > saved vizfold.json > built-in default
+# The previous install's answers, loaded after <site>.json, never at source time (that would land them
+# ahead of live discovery): inline env > slurm::discover > <site>.json > saved vizfold.json > default.
 config::load() { config::fill "$(config::file)" "config"; }
 
 # <site>.sh loads its own <site>.json: same basename, beside it.
 config::site_defaults() { config::fill "${1%.sh}.json" "site defaults"; }
 
-# The config's schema: the same binary reads it everywhere, so the key set is fixed -- same on every cluster, whichever backend installed last.
+# Fixed schema: the same binary reads it on every cluster, whichever backend installed last.
 VIZFOLD_CONFIG_KEYS="OPENFOLD_HOME OPENFOLD_PREFIX OPENFOLD_SITE OPENFOLD_DATA_DIR OPENFOLD_AF2_ROOT
 VIZFOLD_ENV_BASE OPENFOLD_ENV_PREFIX ESMFOLD_ENV_PREFIX OPENFOLD_MAX_CUDA OPENFOLD_DRIVER_CUDA
 OPENFOLD_ACCOUNT OPENFOLD_PARTITION OPENFOLD_GPU_ACCOUNT OPENFOLD_GPU_PARTITION
 OPENFOLD_GPU_RESOURCES OPENFOLD_GPU_GRES OPENFOLD_GPU_TIME OPENFOLD_EXAMPLE
 VIZFOLD_DB"
 
-# Every key, every time -- empty for what this install did not settle. config::load has already put the
-# earlier values in the environment, so a second backend rewrites them rather than dropping them.
+# Every key, every time -- empty for what this install did not settle. config::load already restored the earlier values, so a second backend rewrites them rather than dropping them.
 config::save() {
     local file
     file=$(config::file)

--- a/lib/interactive.sh
+++ b/lib/interactive.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# interactive.sh -- library. interactive::resolve echoes a value (the site default, or a /dev/tty answer), so callers always proceed.
+# interactive::resolve always echoes a value -- the site default, or a /dev/tty answer -- so callers always proceed.
 
 [ "${BASH_SOURCE[0]}" = "$0" ] && { echo "interactive.sh is a library" >&2; exit 1; }
 [ -n "${INTERACTIVE_SH:-}" ] && return 0

--- a/lib/slurm.sh
+++ b/lib/slurm.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# slurm.sh -- shared SLURM flow. Base declares slurm::* hooks as no-ops; a sourced sites/<name>.sh overrides the ones it needs; slurm::run assembles and executes them.
+# Shared SLURM flow: slurm::* hooks default to no-ops, a sourced sites/<name>.sh overrides the ones it needs, slurm::run assembles and executes them.
 
 [ "${BASH_SOURCE[0]}" = "$0" ] && { echo "slurm.sh is a library" >&2; exit 1; }
 [ -n "${SLURM_SH:-}" ] && return 0
@@ -8,13 +8,13 @@ SLURM_SH=1
 . "$(dirname "${BASH_SOURCE[0]}")/config.sh"        # REPO, OF, die
 . "$(dirname "${BASH_SOURCE[0]}")/interactive.sh"
 
-# The site profiles, beside the libs that read them: nothing here is about any one backend.
+# Site profiles sit beside the libs that read them: nothing here is backend-specific.
 SITES=$REPO/sites
 
 # A site overrides this to export the atoms its <site>.json templates reference, before they are filled.
 slurm::discover() { :; }
 
-# Delta-family: pick an allocation under $1 whose accounts (suffixes $2..) all exist, preferring one that holds an install.
+# An allocation under $1 whose accounts (suffixes $2..) all exist, preferring one that holds an install.
 slurm::allocation() {
     local root=$1; shift
     local dir alloc accounts s ok found=()
@@ -32,7 +32,7 @@ slurm::allocation() {
     echo "${found[0]}"
 }
 
-# The /work/nvme allocation whose accounts (suffixes $@) all exist, naming those accounts off the same suffixes.
+# The /work/nvme allocation whose accounts (suffixes $@) all exist; names those accounts off the same suffixes.
 slurm::nvme_alloc() {
     if [ -z "${OPENFOLD_ALLOCATION:-}" ]; then
         OPENFOLD_ALLOCATION=$(interactive::resolve OPENFOLD_ALLOCATION allocation "$(slurm::allocation /work/nvme "$@" || true)")
@@ -44,7 +44,6 @@ slurm::nvme_alloc() {
     return 0
 }
 
-# The user's Slurm default account, overridable inline.
 slurm::default_account() { echo "${OPENFOLD_ACCOUNT:-$(sacctmgr -nP show user "$USER" format=DefaultAccount 2>/dev/null)}"; }
 
 # Three sources: Delta's login nodes cannot always reach slurmctld. Lower-cased to match sites/.
@@ -56,10 +55,10 @@ slurm::cluster() {
     echo "$name" | tr '[:upper:]' '[:lower:]'
 }
 
-# The prefix when nothing else settles one. No site overrides this hook; delta-gh.json sets OPENFOLD_PREFIX instead (it shares /work/nvme with x86 Delta and must not share the env).
+# The prefix when nothing else settles one. No site overrides this hook; delta-gh.json sets OPENFOLD_PREFIX directly instead.
 slurm::default_prefix() { echo "${OPENFOLD_BASE:+$OPENFOLD_BASE/vizfold}"; }
 
-# Resolve ~/scratch (a symlink on PACE) to the user's scratch root, dropping any subdir it points into.
+# Resolve ~/scratch (a PACE symlink) to the user's scratch root, dropping any subdir it points into.
 slurm::scratch_root() {
     local s; [ -d "$HOME/scratch" ] || return 1; s=$(readlink -f "$HOME/scratch")
     case "$s" in */"$USER"/*) echo "${s%%/"$USER"/*}/$USER" ;; *) echo "$s" ;; esac
@@ -84,7 +83,7 @@ slurm::launch_args() {
     return 0
 }
 
-# Pick the site and settle the layers under it -- every installer starts here. Exports OPENFOLD_SITE.
+# Pick the site and settle the layers under it -- every installer starts here.
 vizfold::settle_site() {
     local cluster site prefix
     cluster=$(slurm::cluster)
@@ -106,10 +105,10 @@ vizfold::settle_site() {
     return 0
 }
 
-# Run the assembled hooks, then run setup.sh on the scheduler (or here when there is none).
+# Run the assembled hooks, then setup.sh on the scheduler (or here when there is none).
 slurm::run() {
     if [ -z "${SLURM_JOB_ID:-}" ] && ! command -v srun >/dev/null 2>&1; then
-        exec bash "$OF/install/setup.sh"          # no scheduler: install here
+        exec bash "$OF/install/setup.sh"
     fi
     local PREFIX ACCOUNT PARTITION SETUP PTY
     PREFIX=${OPENFOLD_PREFIX:-}

--- a/sites/bridges2.sh
+++ b/sites/bridges2.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-# PSC Bridges-2 ("bridges2"). AF2 mirror in <site>.json; account (= default assoc) is also the /ocean project dir the prefix templates off.
+# PSC Bridges-2. AF2 mirror in <site>.json; the account (= default assoc) is also the /ocean project dir the prefix templates off.
 
 slurm::discover() { export OPENFOLD_ACCOUNT=${OPENFOLD_ACCOUNT:-$(slurm::default_account)}; }

--- a/sites/delta-gh.sh
+++ b/sites/delta-gh.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# NCSA Delta-AI ("delta-gh"). Grace-Hopper aarch64, GH200 build node, no CPU queue. /work/nvme is shared
-# with x86 Delta, so <site>.json suffixes the prefix -gh: the aarch64 env must not clobber Delta's.
+# NCSA Delta-AI: GH200 aarch64, no CPU queue. /work/nvme is shared with x86 Delta, so <site>.json
+# suffixes the prefix -gh -- the aarch64 env must not clobber Delta's.
 
 slurm::discover() { slurm::nvme_alloc -dtai-gh; }

--- a/sites/delta.sh
+++ b/sites/delta.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-# NCSA Delta ("delta"). Per-allocation /work/nvme, and a separate account per queue (named by slurm::nvme_alloc from its own suffixes); delta.json templates the base off the discovered $OPENFOLD_ALLOCATION.
+# NCSA Delta. Per-allocation /work/nvme, a separate account per queue; delta.json templates the base off the discovered $OPENFOLD_ALLOCATION.
 
 slurm::discover() { slurm::nvme_alloc -delta-cpu -delta-gpu; }

--- a/sites/ice-slurm.sh
+++ b/sites/ice-slurm.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-# GT PACE ICE ("ice-slurm"). AF2 mirror + A100 gres in <site>.json; the prefix defaults to $OPENFOLD_BASE/vizfold (slurm::default_prefix), with OPENFOLD_BASE = the user's /storage/ice1 scratch root (purged at semester end).
+# GT PACE ICE. AF2 mirror + A100 gres in <site>.json; OPENFOLD_BASE = the user's /storage/ice1 scratch root (purged at semester end).
 
 slurm::discover() { OPENFOLD_BASE=$(slurm::scratch_root) || die "cannot resolve ~/scratch"; export OPENFOLD_BASE; }

--- a/sites/local.sh
+++ b/sites/local.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-# No batch scheduler: contributes no hooks, so slurm::run finds no srun and installs in place via setup.sh.
+# No batch scheduler: no hooks, so slurm::run finds no srun and installs in place.

--- a/sites/nexus-dev.sh
+++ b/sites/nexus-dev.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Nexus ("nexus-dev"). AF2 mirror on the staging volume; 10 GB A100 vGPU on a 535 driver (setup.sh pins NVRTC); the prefix defaults to $OPENFOLD_BASE/vizfold (slurm::default_prefix), with OPENFOLD_BASE = a writable /projects dir, not $HOME.
+# Nexus. AF2 mirror on the staging volume; 10 GB A100 vGPU on a 535 driver (setup.sh pins NVRTC); OPENFOLD_BASE = a writable /projects dir, not $HOME.
 
 slurm::discover() {
     local c

--- a/sites/phoenix-slurm.sh
+++ b/sites/phoenix-slurm.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-# GT PACE Phoenix ("phoenix-slurm"). AF2 mirror + A100 gres in <site>.json; the prefix defaults to $OPENFOLD_BASE/vizfold (slurm::default_prefix), with OPENFOLD_BASE = the user's /storage/scratch1 root (purged after 60 idle days).
+# GT PACE Phoenix. AF2 mirror + A100 gres in <site>.json; OPENFOLD_BASE = the user's /storage/scratch1 root (purged after 60 idle days).
 
 slurm::discover() { OPENFOLD_BASE=$(slurm::scratch_root) || die "cannot resolve ~/scratch"; export OPENFOLD_BASE; }

--- a/tests/install_rc.sh
+++ b/tests/install_rc.sh
@@ -55,7 +55,7 @@ want .bashrc "command -v vizfold"          0 "and never resolves it through PATH
 # bash sources .bashrc for non-interactive shells too, under ssh -- where there is no completion to
 # register and forking the binary is pure latency on every scp, rsync and `ssh host cmd`.
 want .bashrc 'case $- in *i*)' 1 "the eval runs only in an interactive shell"
-# A binary older than this subcommand answers on stderr; unsilenced, that lands on the user's prompt.
+# An older binary answers on stderr, which unsilenced lands on the user's prompt.
 want .bashrc '2>/dev/null'     1 "and says nothing when the binary is too old to know it"
 
 # An rc whose last byte is not a newline: ours would fuse onto the user's last statement, and since

--- a/tests/launch_args.sh
+++ b/tests/launch_args.sh
@@ -24,14 +24,12 @@ check "bash " "$got" "step id means bash"
 got=$(SLURM_JOB_ID=1 slurm::launch_args acct part --pty | tr '\n' ' ')
 check "srun --ntasks=1 " "$got" "job id means plain srun"
 
-# No allocation: full srun with resources.
 base="srun -u %s--job-name=vizfold-install --account=acct --partition=part --nodes=1 --ntasks=1 --cpus-per-task=8 --mem=24G --time=02:00:00 "
 
 got=$( (unset SLURM_STEP_ID SLURM_JOB_ID; slurm::launch_args acct part --pty) | tr '\n' ' ')
 want=$(printf "$base" "--pty ")
 check "$want" "$got" "no allocation means full srun with pty"
 
-# Not a terminal: identical but without --pty.
 got=$( (unset SLURM_STEP_ID SLURM_JOB_ID; slurm::launch_args acct part "") | tr '\n' ' ')
 want=$(printf "$base" "")
 check "$want" "$got" "no tty means no pty"
@@ -61,7 +59,6 @@ for c in delta delta-gh; do
     [ -f "$SITES/$c.sh" ] && echo "ok   sites/$c.sh exists" || { echo "FAIL no sites/$c.sh"; fail=1; }
 done
 
-# sbatch must be gone entirely.
 grep -q sbatch "$REPO/lib/slurm.sh" && { echo "FAIL sbatch still referenced"; fail=1; } || echo "ok   no sbatch"
 
 # A saved config must not pin the site, or an OPENFOLD_SITE of "local" written where scontrol failed

--- a/tests/link_mirror.sh
+++ b/tests/link_mirror.sh
@@ -11,7 +11,6 @@ REPO=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 SANDBOX=${TMPDIR:-/tmp}/vizfold-link-mirror-$$
 trap 'rm -rf "$SANDBOX"' EXIT
 
-# One mirror, one data dir, link_mirror run over them. $1 populates the mirror.
 run_case() {
     local name=$1 populate=$2
     rm -rf "$SANDBOX"; mkdir -p "$SANDBOX"
@@ -27,7 +26,6 @@ run_case() {
     CASE=$name
 }
 
-# Everything the mirror holds is linked in, except uniclust30 which is staged separately.
 assert_link() {
     local target=$1
     [ -L "$target" ] || { echo "FAIL [$CASE] $target is not a symlink"; exit 1; }
@@ -36,18 +34,18 @@ assert_missing() {
     [ ! -e "$1" ] || { echo "FAIL [$CASE] $1 should not exist"; exit 1; }
 }
 
-populate_flat() {          # uniclust30/uniclust30_2018_08_* -- single-nested
+populate_flat() {
     mkdir -p "$AF2/uniref90" "$AF2/uniclust30"
     : > "$AF2/uniref90/uniref90.fasta"
     : > "$AF2/uniclust30/uniclust30_2018_08_a3m.ffdata"
     : > "$AF2/uniclust30/uniclust30_2018_08_cs219.ffindex"
 }
-populate_nested() {        # uniclust30/uniclust30_2018_08/uniclust30_2018_08_* -- double-nested
+populate_nested() {
     mkdir -p "$AF2/uniref90" "$AF2/uniclust30/uniclust30_2018_08"
     : > "$AF2/uniref90/uniref90.fasta"
     : > "$AF2/uniclust30/uniclust30_2018_08/uniclust30_2018_08_a3m.ffdata"
 }
-populate_uniref30_only() { # no uniclust30 at all -- aliased from uniref30
+populate_uniref30_only() {
     mkdir -p "$AF2/uniref30"
     : > "$AF2/uniref30/UniRef30_2023_02_a3m.ffdata"
     : > "$AF2/uniref30/UniRef30_2023_02_cs219.ffindex"
@@ -71,7 +69,7 @@ assert_link "$UNICLUST/uniclust30_2018_08_cs219.ffindex"
     { echo "FAIL [uniref30-only] the alias does not point at the uniref30 file"; exit 1; }
 echo "ok   with no uniclust30, uniref30 is aliased under the uniclust30 names"
 
-# The mirror is read-only in practice, so nothing may be written into it.
+# The mirror is read-only in practice.
 run_case "mirror-untouched" populate_flat
 [ -z "$(find "$AF2" -type l)" ] || { echo "FAIL [mirror-untouched] a link was created inside the mirror"; exit 1; }
 echo "ok   nothing is written into the mirror itself"

--- a/tests/site_config.sh
+++ b/tests/site_config.sh
@@ -62,7 +62,7 @@ sed '/^main() {/,$d' backends/openfold/install/setup.sh > "$SANDBOX/setup-defs.s
 actual=$(for f in sites/*.json; do f=${f##*/}; (resolve "${f%.json}" 2>/dev/null); done |
     sed "s#\"$REPO\"#\"{REPO}\"#g; s#\"$SANDBOX/#\"{SANDBOX}/#g")
 
-# The same binary reads this file on every cluster, so the key set must not depend on the cluster.
+# One binary reads this file on every cluster, so the key set must not depend on the site.
 shapes=$(for f in "$SANDBOX"/*.json; do
     python3 -c 'import json,sys; print(*sorted(json.load(open(sys.argv[1]))))' "$f"
 done | sort -u)
@@ -70,7 +70,7 @@ if [ "$(printf '%s\n' "$shapes" | wc -l)" -ne 1 ]; then
     echo "FAIL config key set differs by site:"; printf '%s\n' "$shapes"; exit 1
 fi
 
-# ...nor on which backend installed last: a second install rewrites the earlier values, never drops them.
+# ...nor on which backend installed last.
 cp "$SANDBOX/delta.json" "$SANDBOX/before.json"
 (export VIZFOLD_CONFIG=$SANDBOX/delta.json ESMFOLD_ENV_PREFIX=/envs/vizfold-esmfold
  . "$REPO/lib/config.sh" && config::load && config::save) >/dev/null 2>&1
@@ -85,13 +85,12 @@ print("ok   a second backend's install preserves every settled value")
 PY
 
 # The snapshot above walks the layers by hand; settle_site is what both installers actually call.
-# This pins the two together.
 (export USER=x-test HOME=$SANDBOX/home OPENFOLD_ALLOCATION=bbka
  export VIZFOLD_CONFIG=$SANDBOX/settle.json OPENFOLD_HOME=$REPO
  unset OPENFOLD_SITE OPENFOLD_PREFIX OPENFOLD_ACCOUNT OPENFOLD_GPU_ACCOUNT
  . "$REPO/lib/slurm.sh"
  sacctmgr() { echo bbka; }
- slurm::cluster() { echo delta; }                     # as if run on a Delta login node
+ slurm::cluster() { echo delta; }
  vizfold::settle_site >/dev/null 2>&1
  got="$OPENFOLD_SITE $OPENFOLD_PREFIX"
  want="delta /work/nvme/bbka/x-test/vizfold"
@@ -120,7 +119,7 @@ if cfg.get("OPENFOLD_PREFIX"):
     sys.exit(1)
 PY
 
- # Now OpenFold, on Delta. Its own discovery must run and win.
+ # Now OpenFold, on Delta: its own discovery must win.
  (. "$REPO/lib/slurm.sh"
   sacctmgr() { echo bbka; }
   slurm::cluster() { echo delta; }
@@ -134,8 +133,8 @@ PY
       echo "  want: $want"; echo "  got:  $got"; exit 1
   fi)) || exit 1
 
-# Inline beats the site file. The first two keys below are set by every <site>.json, so config::fill
-# has a value of its own to prefer -- keys no site writes would test nothing.
+# The first two keys below are set by every <site>.json, so config::fill has a rival value to prefer
+# -- a key no site writes would test nothing.
 (export OPENFOLD_PARTITION=chosen-partition OPENFOLD_AF2_ROOT=$SANDBOX/chosen-mirror \
         VIZFOLD_DB=$SANDBOX/chosen.db
  resolve delta >/dev/null 2>&1
@@ -143,9 +142,9 @@ PY
 import json, sys
 cfg, sandbox = json.load(open(sys.argv[1])), sys.argv[2]
 want = {
-    "OPENFOLD_PARTITION": "chosen-partition",         # delta.json sets this to "cpu"
-    "OPENFOLD_AF2_ROOT": f"{sandbox}/chosen-mirror",  # delta.json names the real mirror
-    "VIZFOLD_DB": f"{sandbox}/chosen.db",             # no site file sets this one
+    "OPENFOLD_PARTITION": "chosen-partition",
+    "OPENFOLD_AF2_ROOT": f"{sandbox}/chosen-mirror",
+    "VIZFOLD_DB": f"{sandbox}/chosen.db",
 }
 kept = {k: cfg.get(k) for k in want}
 if kept != want:

--- a/tests/vocabulary.sh
+++ b/tests/vocabulary.sh
@@ -19,14 +19,12 @@ report() { # $1 label, $2 newline-separated offenders, $3 remedy
     fi
 }
 
-# Every resolved("X") in the CLI must be a schema key, or the binary expects what no install writes.
 cli=$(grep -oE 'resolved\("[A-Z0-9_]+"\)' "$REPO/cli/src/core/config.rs" |
     sed 's/resolved("//; s/")//' | sort -u)
 report "every name the CLI resolves is in the config schema" \
     "$(comm -23 <(printf '%s\n' $cli) <(printf '%s\n' $schema))" \
     "add it to VIZFOLD_CONFIG_KEYS, or read a name the install already settles"
 
-# Every <site>.json key must be persisted or knowingly install-only -- nothing set and forgotten.
 known=$(printf '%s\n' $schema $install_only | sort -u)
 site_keys=$(python3 -c '
 import json, pathlib

--- a/workbench/app/Poller.tsx
+++ b/workbench/app/Poller.tsx
@@ -5,10 +5,8 @@ import { useEffect } from "react";
 
 const TERMINAL = new Set(["completed", "failed"]);
 
-/**
- * Re-render the server component while any run is still going. Both pages are `force-dynamic`, so
- * a refresh re-reads the executor's database — no client-side run state to keep in sync.
- */
+/** Both pages are `force-dynamic`, so refreshing re-reads the executor's database — no client-side
+ *  run state to keep in sync. */
 export default function Poller({ statuses }: { statuses: string[] }) {
   const router = useRouter();
   const active = statuses.some((status) => !TERMINAL.has(status));

--- a/workbench/app/StructureViewer.tsx
+++ b/workbench/app/StructureViewer.tsx
@@ -2,8 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 
-// 3Dmol drives WebGL and reads `window`, so the library is imported dynamically inside the
-// effect (never during SSR) and the viewer is built after mount.
+// 3Dmol reads `window`, so it is imported dynamically inside the effect, never during SSR.
 
 type Viewer = ReturnType<(typeof import("3dmol"))["createViewer"]>;
 type Representation = "cartoon" | "stick" | "line";

--- a/workbench/app/page.tsx
+++ b/workbench/app/page.tsx
@@ -4,13 +4,13 @@ import { FOLDABLE, listExamples } from "@/lib/vizfold";
 import FoldCard from "@/app/FoldCard";
 import Poller from "@/app/Poller";
 
-// Read the executor db per request; never prerender a stale run list at build time.
+// Read the executor db per request; never prerender a stale run list.
 export const dynamic = "force-dynamic";
 
 export default async function HomePage() {
   const runs = listRuns();
-  // The dashboard is still useful for browsing past runs when the CLI is unreachable, so a failed
-  // lookup degrades to an empty picker (which explains itself) rather than a 500.
+  // Past runs stay browsable when the CLI is unreachable: an empty picker explains itself, a 500
+  // does not.
   const examples = await listExamples().catch(() => []);
 
   return (

--- a/workbench/app/runs/[runId]/page.tsx
+++ b/workbench/app/runs/[runId]/page.tsx
@@ -14,8 +14,8 @@ const IS_STRUCTURE = /\.(pdb|cif|ent)$/i;
 
 type FileEntry = { name: string; url: string; isImage: boolean; isStructure: boolean };
 
-// The run's own directory, <prefix>/runs/<id>. Its parent is the public/runs symlink target, so
-// a file's browser URL is `/runs/` + its path relative to that parent.
+// <prefix>/runs/<id>. Its parent is the public/runs symlink target, so a file's browser URL is
+// `/runs/` + its path relative to that parent.
 function runRoot(artifacts: ArtifactRow[], id: number): string | null {
   const own = artifacts.find((a) => a.type_slug === "run_output_directory");
   if (own) return own.storage_uri;

--- a/workbench/lib/db.ts
+++ b/workbench/lib/db.ts
@@ -2,8 +2,9 @@ import { DatabaseSync } from "node:sqlite";
 import { existsSync } from "node:fs";
 import { BACKENDS } from "@/lib/vizfold";
 
-// The Rust executor owns this file; the dashboard reads it directly, read-only. `vizfold serve`
-// exports VIZFOLD_DB (the plain sqlite path); the fallback covers running `next dev` by hand.
+// The Rust executor owns this file; the dashboard only reads it. `vizfold serve` exports VIZFOLD_DB
+// as a plain path — node:sqlite cannot open the CLI's `sqlite://...?mode=rwc` form. The fallback
+// covers running `next dev` by hand.
 const dbPath =
   process.env.VIZFOLD_DB ?? `${process.env.OPENFOLD_PREFIX ?? ""}/vizfold.db`;
 
@@ -30,7 +31,7 @@ export type ArtifactRow = {
   display_mode: string;
 };
 
-// A fresh install has no db until the first run; treat "not created yet" as "nothing to show".
+// A fresh install has no db until the first run; not created yet means nothing to show.
 function query<T>(read: (db: DatabaseSync) => T, whenAbsent: T): T {
   if (!existsSync(dbPath)) return whenAbsent;
   const db = new DatabaseSync(dbPath, { readOnly: true });
@@ -59,7 +60,7 @@ const ARTIFACT_SELECT = `SELECT a.id, a.format, a.storage_uri,
 const SERVED = BACKENDS?.length ? ` WHERE b.slug IN (${BACKENDS.map(() => "?").join(",")})` : "";
 
 export const listRuns = (): RunRow[] =>
-  // Serving nothing lists nothing; `IN ()` is not valid SQL, so this never reaches the database.
+  // `IN ()` is not valid SQL, so serving nothing short-circuits before the database.
   BACKENDS?.length === 0
     ? []
     : query(

--- a/workbench/lib/vizfold.ts
+++ b/workbench/lib/vizfold.ts
@@ -3,20 +3,18 @@ import { mkdirSync, openSync } from "node:fs";
 import { promisify } from "node:util";
 
 // The CLI owns the executor; the dashboard never parses FASTA or writes the database.
-// `vizfold serve` exports VIZFOLD_BIN so this resolves without relying on ~/.local/bin.
+// `vizfold serve` exports VIZFOLD_BIN, so this resolves without relying on ~/.local/bin.
 const BIN = process.env.VIZFOLD_BIN ?? "vizfold";
 const PREFIX = process.env.OPENFOLD_PREFIX ?? "";
 
-/** What `vizfold serve` was asked to serve. Empty means unset — `next dev` by hand, which filters
- *  nothing and lets the CLI pick the backend, as it did before serve took any. */
-// null means the variable is unset -- `next dev` run by hand, where filtering by a set nobody chose
-// would hide every run. Set-but-empty is a real answer: `serve` found no backend installed.
+// Unset means `next dev` by hand: filter nothing, since filtering by a set nobody chose would hide
+// every run. Set-but-empty is a real answer — `serve` found no backend installed.
 const served = process.env.VIZFOLD_BACKENDS;
 export const BACKENDS: string[] | null =
   served === undefined ? null : served.split(",").filter(Boolean);
 
-/** What the Fold card offers. Unset, the dashboard cannot know what is installed, so it offers both
- *  and lets the CLI's own prereq gate refuse one that is not. */
+/** What the Fold card offers. Unset, offer both and let the CLI's prereq gate refuse an
+ *  uninstalled one. */
 export const FOLDABLE = BACKENDS ?? ["openfold", "esmfold"];
 
 const run = promisify(execFile);
@@ -33,18 +31,18 @@ export async function listExamples(): Promise<Example[]> {
   return JSON.parse(stdout);
 }
 
-/** Record the run and return its id. `--no-exec` only writes the row, so this is near-instant. */
+/** `--no-exec` writes only the run row, so this is near-instant. */
 export async function queueRun(
   example: Example,
   attn: boolean,
   backend?: string,
 ): Promise<number> {
-  // --attn takes a value and defaults to true, so it has to be passed either way; the CLI reads
-  // the id and the sequence out of the example's FASTA itself.
+  // --attn takes a value and defaults to true, so pass it either way; the CLI reads the id and
+  // sequence out of the example's FASTA itself.
   const args = ["run", example.id, `--attn=${attn}`, "--no-exec"];
   if (backend) args.push("--backend", backend);
   const { stdout } = await run(BIN, args);
-  // Each backend queues under its own label, so match the shape of the line, not the name in it.
+  // Each backend queues under its own label — match the line's shape, not the name in it.
   const id = stdout.match(/Queued \S+ run (\d+)/)?.[1];
   if (!id) throw new Error(`no run id in run output: ${stdout.trim()}`);
   return Number(id);
@@ -53,8 +51,7 @@ export async function queueRun(
 /** Detached: a fold runs for minutes, far longer than a request may be held open. The page polls
  *  from there, and `fold` registers the artifacts itself once it lands. */
 export function foldInBackground(runId: number): void {
-  // Without a prefix this used to resolve to "/runs" and try to mkdir at the filesystem root,
-  // 500ing after the run row was already written.
+  // Unset, `${PREFIX}/runs` is "/runs" — mkdir at the filesystem root, after the row is written.
   if (!PREFIX) throw new Error("OPENFOLD_PREFIX is unset; start the dashboard with `vizfold serve`");
   const logs = `${PREFIX}/runs`;
   mkdirSync(logs, { recursive: true });


### PR DESCRIPTION
Comments only — **no code changed**, verified mechanically: every `-`/`+` pair in the diff is
identical once its comment is stripped.

672 → 535 comment lines across 40 files.

| area | before | after |
|---|---|---|
| `cli/src/adapters/cli.rs` | 282 | 220 |
| `cli/src/core/` (config, run_execution, release, examples) | 83 | 67 |
| `cli/src/core/` (runners, services, preflight, db, seed, …) | 60 | 38 |
| installers (`install.sh`, openfold `setup.sh`, esmfold `install.sh`) | 73 | 62 |
| `lib/` + `sites/` | 55 | 48 |
| `tests/*.sh` | 82 | 69 |
| `workbench/` | 37 | 31 |

## The rule applied

Delete when the code already says it, or when an adjacent doc comment, error message, log line,
test assertion message or the README already says it. Keep — compressed — when it explains *why*,
names a non-obvious constraint, or protects a decision a reader would otherwise undo.

## Not cut

- **Vendored and licensed code.** `downloaders/openfold/*.sh` carry DeepMind's Apache headers and
  `backends/openfold/openfold/` is upstream OpenFold — 28 files excluded outright.
- **clap `///` strings**, which render in `vizfold --help`. Echoing the field name is the point there.
- **`// SAFETY:`** on the `unsafe` env block, and the two **`// ponytail:`** markers, which are a
  deliberate-shortcut ledger rather than prose.
- Comments carrying an incident rather than a description — e.g. *\"Removing the base itself once took
  a whole home directory with it\"*, which is why `shared_paths` exists.

## What the review pass caught

Each group was re-read by a second agent against the diff. Real regressions, all fixed:

- Over-compression that left dangling referents — `\"The install records it; …\"` with the subject cut,
  `\"Without this, a re-install keeps it\"` with the antecedent gone.
- A **wrong** pointer introduced by compression: `detect_gpu` was retitled *\"mirrors the fold script's
  own GPU probe\"*, but no fold script probes the GPU — the mirrored probe is `setup::preflight` in
  `backends/openfold/install/setup.sh`. Now named exactly.
- A load-bearing test annotation deleted: the `// duplicate` marker on a repeated `removal_plan`
  input. Unmarked it reads as a copy-paste slip, and removing it would drop the only coverage of
  `targets.dedup()`.
- `install.sh`'s `case \$- in *i*` rationale garbled into something a reader could act on and re-break
  `ssh host cmd` / scp.

Two comments got *better* rather than shorter: `workbench/lib/db.ts` now says why `VIZFOLD_DB` is
forwarded as a plain path (`node:sqlite` cannot open the CLI's `sqlite://…?mode=rwc` form), and
`workbench/lib/vizfold.ts` lost a genuine duplication where a `/** */` doc and a `//` comment stated
the same null-vs-empty rule.

## Test plan

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` (0), `cargo test` (140).
- `bash -n` over all 47 tracked scripts; `launch_args` (13), `site_config` (5), `vocabulary` (4),
  `link_mirror` (4), `esmfold_env` (11), `install_rc` (14). `site_config.expected` unchanged.
- `vizfold --help` re-read: every subcommand line intact.
- Block-comment delimiters balanced in every touched `.ts`/`.tsx`.