### PR TITLE
Give `install repo` the config, and the dashboard the workshop flow

### DIFF
--- a/.github/workflows/install_tests.yml
+++ b/.github/workflows/install_tests.yml
@@ -17,3 +17,4 @@ jobs:
       - run: bash tests/link_mirror.sh
       - run: bash tests/esmfold_env.sh
       - run: bash tests/install_rc.sh
+      - run: bash tests/configure_repo.sh

--- a/DEMO.md
+++ b/DEMO.md
@@ -12,7 +12,7 @@ bootstrap from the [README](README.md#install):
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/AI2Science/vizfold-foundation/main/install.sh | bash
-vizfold install src
+vizfold install repo
 vizfold install openfold
 ```
 
@@ -26,7 +26,7 @@ VizFold status
 COMPONENT  STATUS  DETAIL
 ---------  ------  ------
 cli        ok      0.9.0 (latest)
-src        ok      /u/yjayawardana/vizfold-src at v0.9.0
+repo       ok      /u/yjayawardana/vizfold-repo at v0.9.0
 config     ok      19 keys
 openfold   ok      /work/nvme/bbol/yjayawardana/vizfold/envs/vizfold-openfold
 esmfold    absent  not installed (/work/nvme/bbol/yjayawardana/vizfold/envs/vizfold-esmfold)
@@ -40,7 +40,7 @@ Config: /u/yjayawardana/.config/vizfold/vizfold.json
   OPENFOLD_GPU_ACCOUNT = bbol-delta-gpu
   OPENFOLD_GPU_PARTITION = gpuA100x4-interactive
   OPENFOLD_GPU_TIME = 01:00:00
-  OPENFOLD_HOME = /u/yjayawardana/vizfold-src
+  OPENFOLD_HOME = /u/yjayawardana/vizfold-repo
   OPENFOLD_PREFIX = /work/nvme/bbol/yjayawardana/vizfold
   ...
   database = /work/nvme/bbol/yjayawardana/vizfold/vizfold.db (present)
@@ -130,10 +130,10 @@ Preflight: passed
 [warning] gpu: no GPU visible; the run will fall back to CPU
 [passed] program configured: program 'python3' is configured
 [passed] script argument configured: script argument 'scripts/openfold/run_pretrained_openfold.py' follows -u
-[passed] working directory: '/u/yjayawardana/vizfold-src' exists
-[passed] script file: '/u/yjayawardana/vizfold-src/scripts/openfold/run_pretrained_openfold.py' exists
+[passed] working directory: '/u/yjayawardana/vizfold-repo' exists
+[passed] script file: '/u/yjayawardana/vizfold-repo/scripts/openfold/run_pretrained_openfold.py' exists
 [passed] input_id: run input_id '6KWC_1' is configured
-[passed] fasta_dir: '/u/yjayawardana/vizfold-src/examples/monomer/fasta_dir_6KWC/6KWC.fasta' holds 1 FASTA file(s), tagged '6KWC_1' as run input_id says
+[passed] fasta_dir: '/u/yjayawardana/vizfold-repo/examples/monomer/fasta_dir_6KWC/6KWC.fasta' holds 1 FASTA file(s), tagged '6KWC_1' as run input_id says
 ...
 
 Command exit_code: 0

--- a/DEMO.md
+++ b/DEMO.md
@@ -12,7 +12,7 @@ bootstrap from the [README](README.md#install):
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/AI2Science/vizfold-foundation/main/install.sh | bash
-vizfold install source
+vizfold install src
 vizfold install openfold
 ```
 
@@ -26,7 +26,7 @@ VizFold status
 COMPONENT  STATUS  DETAIL
 ---------  ------  ------
 cli        ok      0.9.0 (latest)
-source     ok      /u/yjayawardana/vizfold-src at v0.9.0
+src        ok      /u/yjayawardana/vizfold-src at v0.9.0
 config     ok      19 keys
 openfold   ok      /work/nvme/bbol/yjayawardana/vizfold/envs/vizfold-openfold
 esmfold    absent  not installed (/work/nvme/bbol/yjayawardana/vizfold/envs/vizfold-esmfold)

--- a/DEMO.md
+++ b/DEMO.md
@@ -12,7 +12,7 @@ bootstrap from the [README](README.md#install):
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/AI2Science/vizfold-foundation/main/install.sh | bash
-vizfold install base
+vizfold install source
 vizfold install openfold
 ```
 
@@ -25,8 +25,8 @@ VizFold status
 
 COMPONENT  STATUS  DETAIL
 ---------  ------  ------
-binary     ok      0.6.0 (latest)
-repo       ok      /u/yjayawardana/vizfold-src at v0.6.0
+cli        ok      0.9.0 (latest)
+source     ok      /u/yjayawardana/vizfold-src at v0.9.0
 config     ok      19 keys
 openfold   ok      /work/nvme/bbol/yjayawardana/vizfold/envs/vizfold-openfold
 esmfold    absent  not installed (/work/nvme/bbol/yjayawardana/vizfold/envs/vizfold-esmfold)
@@ -52,7 +52,7 @@ unset. Anything unhealthy is listed under `Problems:` with the command that fixe
 ## The short version
 
 ```bash
-vizfold list examples
+vizfold list proteins
 vizfold run 6KWC_1
 ```
 

--- a/README.md
+++ b/README.md
@@ -29,13 +29,16 @@ backend — OpenFold below, or
 `vizfold install esmfold` (see [docs/esmfold.md](docs/esmfold.md)):
 
 ```bash
-vizfold install src
+vizfold install repo
 vizfold install openfold
 ```
 
-The binary ships only itself, so `install src` clones the matching checkout to `$HOME/vizfold-src`
-for the installer scripts and the dashboard. Nothing clones as a side effect: every command that
-reads the checkout refuses until it is there, naming `vizfold install src`. A cold backend install
+The binary ships only itself, so `install repo` clones the matching checkout to `$HOME/vizfold-repo`
+for the installer scripts, the bundled proteins and the dashboard. It then settles the site and
+writes `~/.config/vizfold/vizfold.json` — which cluster, which prefix, which AlphaFold2 mirror holds
+the protein databases, what the scheduler takes — so `status` reads `config ok` before any backend is
+installed, and a backend install only has to build its environment. Nothing clones as a side effect:
+every command that reads the checkout refuses until it is there, naming `vizfold install repo`. A cold backend install
 takes ~8 minutes on a cluster with an AlphaFold2 mirror (measured on NCSA Delta), ~25 minutes on one
 where the databases are downloaded instead — see the cluster table below for which is which.
 
@@ -59,15 +62,15 @@ dashboard from, pinned to the binary's own release tag.
 
 ```bash
 vizfold self-update      # the binary only
-vizfold update src      # the checkout only, to this binary's tag
+vizfold update repo      # the checkout only, to this binary's tag
 ```
 
 One command each, so run both to move a whole install. Between them the checkout is behind, which
 `status` reports as a broken `repo` — "the scripts are v0.7.1, but this binary is v0.7.2" — and
 which `serve` and `list proteins` refuse on, since both read the checkout.
 
-`vizfold update src --ref <tag-or-branch>` moves the checkout somewhere else; it refuses to touch a
-checkout with uncommitted changes, and it requires a checkout — `vizfold install src` makes one.
+`vizfold update repo --ref <tag-or-branch>` moves the checkout somewhere else; it refuses to touch a
+checkout with uncommitted changes, and it requires a checkout — `vizfold install repo` makes one.
 
 A moved checkout is scripts, not an installed environment: both backend installers skip work they
 have already done, so re-running `install <backend>` over a stale environment is a no-op.
@@ -91,7 +94,7 @@ vizfold uninstall openfold
 ```
 
 The config, the run database, the checkout, the shared package cache and any other backend stay,
-so `vizfold install openfold` puts it back where it was. `vizfold uninstall src` is the checkout
+so `vizfold install openfold` puts it back where it was. `vizfold uninstall repo` is the checkout
 alone, and only the one vizfold cloned itself.
 
 ```bash
@@ -100,7 +103,7 @@ vizfold uninstall
 
 With no part named it takes every part and, on top, the workbench environment, the package
 cache, `vizfold.db`, `~/.config/vizfold/vizfold.json`, the staged workbench, and the checkout
-vizfold cloned into `$HOME/vizfold-src`. It lists what it will remove and asks first (`--yes` skips
+vizfold cloned into `$HOME/vizfold-repo`. It lists what it will remove and asks first (`--yes` skips
 the prompt). Fold outputs, a checkout you pointed it at yourself with `OPENFOLD_HOME`, and the
 bootstrapped binaries are left alone; drop those with `rm ~/.local/bin/vizfold ~/.local/bin/micromamba`.
 
@@ -159,7 +162,7 @@ COMPONENT   STATUS  DETAIL
 ----------  ------  ------
 micromamba  ok      /u/you/.local/bin/micromamba
 cli         ok      0.9.0 (latest)
-src         ok      /u/you/vizfold-src at v0.9.0
+repo        ok      /u/you/vizfold-repo at v0.9.0
 config      ok      19 keys
 openfold    BROKEN  /work/nvme/bbol/you/vizfold/envs/vizfold-openfold
 esmfold     absent  not installed (/work/nvme/bbol/you/vizfold/envs/vizfold-esmfold)
@@ -270,7 +273,7 @@ download            Download a backend's data (OpenFold AlphaFold2 databases/par
 status              Show resolved config, which backends are installed, and whether it all checks out
 uninstall           Remove one part, or everything the install generated
 update              Move the checkout to this binary's release (`base`), or reinstall a backend from it
-self-update         Replace this binary with the latest release. Run `update src` after, for the checkout
+self-update         Replace this binary with the latest release. Run `update repo` after, for the checkout
 serve               Start the workbench dashboard, over the given backends (default: all installed)
 list                List executor records
 show                Show one executor record

--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ backend — OpenFold below, or
 `vizfold install esmfold` (see [docs/esmfold.md](docs/esmfold.md)):
 
 ```bash
-vizfold install source
+vizfold install src
 vizfold install openfold
 ```
 
-The binary ships only itself, so `install source` clones the matching checkout to `$HOME/vizfold-src`
+The binary ships only itself, so `install src` clones the matching checkout to `$HOME/vizfold-src`
 for the installer scripts and the dashboard. Nothing clones as a side effect: every command that
-reads the checkout refuses until it is there, naming `vizfold install source`. A cold backend install
+reads the checkout refuses until it is there, naming `vizfold install src`. A cold backend install
 takes ~8 minutes on a cluster with an AlphaFold2 mirror (measured on NCSA Delta), ~25 minutes on one
 where the databases are downloaded instead — see the cluster table below for which is which.
 
@@ -59,15 +59,15 @@ dashboard from, pinned to the binary's own release tag.
 
 ```bash
 vizfold self-update      # the binary only
-vizfold update source      # the checkout only, to this binary's tag
+vizfold update src      # the checkout only, to this binary's tag
 ```
 
 One command each, so run both to move a whole install. Between them the checkout is behind, which
 `status` reports as a broken `repo` — "the scripts are v0.7.1, but this binary is v0.7.2" — and
 which `serve` and `list proteins` refuse on, since both read the checkout.
 
-`vizfold update source --ref <tag-or-branch>` moves the checkout somewhere else; it refuses to touch a
-checkout with uncommitted changes, and it requires a checkout — `vizfold install source` makes one.
+`vizfold update src --ref <tag-or-branch>` moves the checkout somewhere else; it refuses to touch a
+checkout with uncommitted changes, and it requires a checkout — `vizfold install src` makes one.
 
 A moved checkout is scripts, not an installed environment: both backend installers skip work they
 have already done, so re-running `install <backend>` over a stale environment is a no-op.
@@ -91,7 +91,7 @@ vizfold uninstall openfold
 ```
 
 The config, the run database, the checkout, the shared package cache and any other backend stay,
-so `vizfold install openfold` puts it back where it was. `vizfold uninstall source` is the checkout
+so `vizfold install openfold` puts it back where it was. `vizfold uninstall src` is the checkout
 alone, and only the one vizfold cloned itself.
 
 ```bash
@@ -159,7 +159,7 @@ COMPONENT   STATUS  DETAIL
 ----------  ------  ------
 micromamba  ok      /u/you/.local/bin/micromamba
 cli         ok      0.9.0 (latest)
-source      ok      /u/you/vizfold-src at v0.9.0
+src         ok      /u/you/vizfold-src at v0.9.0
 config      ok      19 keys
 openfold    BROKEN  /work/nvme/bbol/you/vizfold/envs/vizfold-openfold
 esmfold     absent  not installed (/work/nvme/bbol/you/vizfold/envs/vizfold-esmfold)
@@ -270,7 +270,7 @@ download            Download a backend's data (OpenFold AlphaFold2 databases/par
 status              Show resolved config, which backends are installed, and whether it all checks out
 uninstall           Remove one part, or everything the install generated
 update              Move the checkout to this binary's release (`base`), or reinstall a backend from it
-self-update         Replace this binary with the latest release. Run `update source` after, for the checkout
+self-update         Replace this binary with the latest release. Run `update src` after, for the checkout
 serve               Start the workbench dashboard, over the given backends (default: all installed)
 list                List executor records
 show                Show one executor record

--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ backend — OpenFold below, or
 `vizfold install esmfold` (see [docs/esmfold.md](docs/esmfold.md)):
 
 ```bash
-vizfold install base
+vizfold install source
 vizfold install openfold
 ```
 
-The binary ships only itself, so `install base` clones the matching checkout to `$HOME/vizfold-src`
+The binary ships only itself, so `install source` clones the matching checkout to `$HOME/vizfold-src`
 for the installer scripts and the dashboard. Nothing clones as a side effect: every command that
-reads the checkout refuses until it is there, naming `vizfold install base`. A cold backend install
+reads the checkout refuses until it is there, naming `vizfold install source`. A cold backend install
 takes ~8 minutes on a cluster with an AlphaFold2 mirror (measured on NCSA Delta), ~25 minutes on one
 where the databases are downloaded instead — see the cluster table below for which is which.
 
@@ -59,15 +59,15 @@ dashboard from, pinned to the binary's own release tag.
 
 ```bash
 vizfold self-update      # the binary only
-vizfold update base      # the checkout only, to this binary's tag
+vizfold update source      # the checkout only, to this binary's tag
 ```
 
 One command each, so run both to move a whole install. Between them the checkout is behind, which
 `status` reports as a broken `repo` — "the scripts are v0.7.1, but this binary is v0.7.2" — and
-which `serve` and `list examples` refuse on, since both read the checkout.
+which `serve` and `list proteins` refuse on, since both read the checkout.
 
-`vizfold update base --ref <tag-or-branch>` moves the checkout somewhere else; it refuses to touch a
-checkout with uncommitted changes, and it requires a checkout — `vizfold install base` makes one.
+`vizfold update source --ref <tag-or-branch>` moves the checkout somewhere else; it refuses to touch a
+checkout with uncommitted changes, and it requires a checkout — `vizfold install source` makes one.
 
 A moved checkout is scripts, not an installed environment: both backend installers skip work they
 have already done, so re-running `install <backend>` over a stale environment is a no-op.
@@ -91,7 +91,7 @@ vizfold uninstall openfold
 ```
 
 The config, the run database, the checkout, the shared package cache and any other backend stay,
-so `vizfold install openfold` puts it back where it was. `vizfold uninstall base` is the checkout
+so `vizfold install openfold` puts it back where it was. `vizfold uninstall source` is the checkout
 alone, and only the one vizfold cloned itself.
 
 ```bash
@@ -155,14 +155,15 @@ those layers settled on below it:
 ```text
 VizFold status
 
-COMPONENT  STATUS  DETAIL
----------  ------  ------
-binary     ok      0.6.0 (latest)
-repo       ok      /u/you/vizfold-src at v0.6.0
-config     ok      19 keys
-openfold   BROKEN  /work/nvme/bbol/you/vizfold/envs/vizfold-openfold
-esmfold    absent  not installed (/work/nvme/bbol/you/vizfold/envs/vizfold-esmfold)
-scheduler  ok      cpu, gpuA100x4-interactive, bbol-delta-cpu, bbol-delta-gpu
+COMPONENT   STATUS  DETAIL
+----------  ------  ------
+micromamba  ok      /u/you/.local/bin/micromamba
+cli         ok      0.9.0 (latest)
+source      ok      /u/you/vizfold-src at v0.9.0
+config      ok      19 keys
+openfold    BROKEN  /work/nvme/bbol/you/vizfold/envs/vizfold-openfold
+esmfold     absent  not installed (/work/nvme/bbol/you/vizfold/envs/vizfold-esmfold)
+scheduler   ok      cpu, gpuA100x4-interactive, bbol-delta-cpu, bbol-delta-gpu
 
 Problems:
   openfold: AlphaFold2 parameters missing or a dangling link: …/params_model_1_ptm.npz
@@ -269,7 +270,7 @@ download            Download a backend's data (OpenFold AlphaFold2 databases/par
 status              Show resolved config, which backends are installed, and whether it all checks out
 uninstall           Remove one part, or everything the install generated
 update              Move the checkout to this binary's release (`base`), or reinstall a backend from it
-self-update         Replace this binary with the latest release. Run `update base` after, for the checkout
+self-update         Replace this binary with the latest release. Run `update source` after, for the checkout
 serve               Start the workbench dashboard, over the given backends (default: all installed)
 list                List executor records
 show                Show one executor record
@@ -287,17 +288,17 @@ bootstrap does not touch:
 eval "$(vizfold completions bash)"          # also: zsh, fish, elvish, powershell
 ```
 
-`vizfold list examples` shows what folds without an MSA search — the bundled monomers whose
-alignments are precomputed:
+`vizfold list proteins` shows what there is to fold. `ALIGNMENTS` is `Y` where an MSA is
+precomputed and reused; `N` folds too, paying for the full search:
 
 ```text
-ID      RESIDUES  DESCRIPTION
-------  --------  -------------------------------------
-1G1J_1  43        NON-STRUCTURAL GLYCOPROTEIN NSP4
-1UBQ_1  76        UBIQUITIN
-1STM_1  157       SATELLITE PANICUM MOSAIC VIRUS
-6KWC_1  191
-2OMF_1  340       MATRIX PORIN OUTER MEMBRANE PROTEIN F
+ID      RESIDUES  ALIGNMENTS  DESCRIPTION
+------  --------  ----------  -------------------------------------
+1G1J_1  43        Y           NON-STRUCTURAL GLYCOPROTEIN NSP4
+1UBQ_1  76        Y           UBIQUITIN
+1STM_1  157       Y           SATELLITE PANICUM MOSAIC VIRUS
+6KWC_1  191       Y
+2OMF_1  340       Y           MATRIX PORIN OUTER MEMBRANE PROTEIN F
 ```
 
 The dashboard drives the same path: pick one of these in **Fold a protein** and it records,

--- a/cli/src/adapters/cli.rs
+++ b/cli/src/adapters/cli.rs
@@ -40,7 +40,7 @@ pub struct Cli {
 // `run` carries every fold flag; one enum is parsed, once, per process.
 #[allow(clippy::large_enum_variant)]
 enum Command {
-    /// Install the checkout everything runs from (`src`), or a model backend from it.
+    /// Install the checkout everything runs from (`repo`), or a model backend from it.
     Install(InstallArgs),
     /// Download a backend's data (OpenFold AlphaFold2 databases/params).
     Download(DownloadArgs),
@@ -48,9 +48,9 @@ enum Command {
     Status,
     /// Remove one part, or everything the install generated.
     Uninstall(UninstallArgs),
-    /// Move the checkout to this binary's release (`src`), or reinstall a backend from it.
+    /// Move the checkout to this binary's release (`repo`), or reinstall a backend from it.
     Update(UpdateArgs),
-    /// Replace this binary with the latest release. Run `update src` after, for the checkout.
+    /// Replace this binary with the latest release. Run `update repo` after, for the checkout.
     SelfUpdate(SelfUpdateArgs),
     /// Start the workbench dashboard, over the given backends (default: all installed).
     Serve(ServeArgs),
@@ -84,7 +84,7 @@ struct InstallArgs {
 /// What a lifecycle verb acts on: the checkout every backend installs from, or one backend.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
 enum Part {
-    Src,
+    Repo,
     Openfold,
     Esmfold,
 }
@@ -92,30 +92,30 @@ enum Part {
 impl Part {
     fn backend(self) -> Option<Backend> {
         match self {
-            Self::Src => None,
+            Self::Repo => None,
             Self::Openfold => Some(Backend::Openfold),
             Self::Esmfold => Some(Backend::Esmfold),
         }
     }
 
     fn slug(self) -> &'static str {
-        self.backend().map_or("src", Backend::slug)
+        self.backend().map_or("repo", Backend::slug)
     }
 
     /// Exactly what `install <part>` puts there, so `uninstall <part>` takes back the same set.
     fn install_paths(self, prefix: &Path, home: &Path) -> Vec<PathBuf> {
         self.backend().map_or_else(
-            || src_paths(prefix),
+            || repo_paths(prefix),
             |backend| backend.install_paths(prefix, home),
         )
     }
 }
 
 /// The checkout, and only the clone vizfold made itself: never a user-supplied `OPENFOLD_HOME`.
-fn src_paths(prefix: &Path) -> Vec<PathBuf> {
-    let src = config::vizfold_src();
-    (src == config::default_src() && !prefix.starts_with(&src))
-        .then_some(src)
+fn repo_paths(prefix: &Path) -> Vec<PathBuf> {
+    let repo = config::vizfold_repo();
+    (repo == config::default_repo() && !prefix.starts_with(&repo))
+        .then_some(repo)
         .into_iter()
         .collect()
 }
@@ -231,7 +231,7 @@ struct UpdateArgs {
     /// What to bring current: the checkout, or a backend reinstalled from it.
     #[arg(value_enum)]
     part: Part,
-    /// Tag or branch to move the checkout to. Defaults to this binary's own release tag. `src` only.
+    /// Tag or branch to move the checkout to. Defaults to this binary's own release tag. `repo` only.
     #[arg(long, value_name = "REF")]
     r#ref: Option<String>,
     /// Reinstall without the confirmation prompt.
@@ -445,7 +445,7 @@ fn prereqs(command: &Command) -> Vec<Component> {
         | Command::Uninstall(_)
         | Command::SelfUpdate(_)
         | Command::Completions(_) => vec![],
-        // A backend installs from the checkout; src's own verbs are what repair it, so they stay off it.
+        // A backend installs from the checkout; repo's own verbs are what repair it, so they stay off it.
         Command::Install(InstallArgs { part }) | Command::Update(UpdateArgs { part, .. }) => {
             std::iter::once(core_deps_health())
                 .chain(part.backend().map(|_| repo_health()))
@@ -537,27 +537,39 @@ pub async fn run() -> Result<(), DbErr> {
     Ok(())
 }
 
-/// Make a part exist. Idempotent: both backend installers short-circuit on presence, as src does.
+/// Make a part exist. Idempotent: both backend installers short-circuit on presence, as repo does.
 fn run_install(part: Part) -> Result<(), DbErr> {
     match part.backend() {
         Some(backend) => install_backend(backend),
-        None => install_src(),
+        None => install_repo(),
     }
 }
 
 /// Fetch the checkout the binary installs everything from -- it ships only itself. Never moves one.
-fn install_src() -> Result<(), DbErr> {
-    let src = config::vizfold_src();
-    if src.join(config::INSTALLER).is_file() {
-        println!("{} already is a vizfold checkout.", src.display());
-        return Ok(());
+/// The checkout, then the config that everything downstream reads: which cluster, which prefix,
+/// which AlphaFold2 mirror holds the protein databases, what the scheduler takes. Re-runnable --
+/// `config::load` restores the previous answers, so this settles what is missing and keeps the rest.
+fn install_repo() -> Result<(), DbErr> {
+    let repo = config::vizfold_repo();
+    if repo.join(config::INSTALLER).is_file() {
+        println!("{} already is a vizfold checkout.", repo.display());
+    } else {
+        clone_checkout(&repo)?;
     }
-    clone_checkout(&src)
+    run_to_completion(
+        "configure",
+        std::process::Command::new("bash")
+            .arg(repo.join(CONFIGURE))
+            .env("OPENFOLD_HOME", &repo),
+    )
 }
 
+/// Settles the site and writes the config; `install repo` owns both.
+const CONFIGURE: &str = "configure.sh";
+
 fn install_backend(backend: Backend) -> Result<(), DbErr> {
-    let src = config::vizfold_src();
-    let installer = src.join(backend.installer());
+    let repo = config::vizfold_repo();
+    let installer = repo.join(backend.installer());
     println!(
         "Installing {}: bash {}",
         backend.slug(),
@@ -567,7 +579,7 @@ fn install_backend(backend: Backend) -> Result<(), DbErr> {
         "model install",
         std::process::Command::new("bash")
             .arg(&installer)
-            .env("OPENFOLD_HOME", &src),
+            .env("OPENFOLD_HOME", &repo),
     )
 }
 
@@ -590,13 +602,13 @@ fn run_download(backend: Backend, dataset: String) -> Result<(), DbErr> {
         );
         return Ok(());
     };
-    let src = config::vizfold_src();
+    let repo = config::vizfold_repo();
     let script_name = if dataset == "all" {
         "download_alphafold_dbs.sh".to_string()
     } else {
         format!("download_{dataset}.sh")
     };
-    let script = src.join(dir).join(&script_name);
+    let script = repo.join(dir).join(&script_name);
     if !script.is_file() {
         return Err(DbErr::Custom(format!(
             "no downloader `{script_name}` at {}; pass `all` or a db name (e.g. uniref90, pdb70, bfd)",
@@ -620,7 +632,7 @@ fn run_download(backend: Backend, dataset: String) -> Result<(), DbErr> {
         std::process::Command::new("bash")
             .arg(&script)
             .arg(&dest)
-            .env("OPENFOLD_HOME", &src)
+            .env("OPENFOLD_HOME", &repo)
             .env("PATH", format!("{}:{path}", env_bin.display())),
     )
 }
@@ -782,23 +794,23 @@ fn binary_health() -> Component {
 
 /// The checkout everything runs from. Drift is flagged only for the clone vizfold made itself.
 fn repo_health() -> Component {
-    repo_health_at(&config::vizfold_src())
+    repo_health_at(&config::vizfold_repo())
 }
 
-fn repo_health_at(src: &Path) -> Component {
-    if !src.join(config::INSTALLER).is_file() {
+fn repo_health_at(repo: &Path) -> Component {
+    if !repo.join(config::INSTALLER).is_file() {
         return Component {
-            name: "src",
+            name: "repo",
             state: State::Absent,
-            detail: format!("no checkout at {}", src.display()),
-            remedy: "vizfold install src".to_owned(),
+            detail: format!("no checkout at {}", repo.display()),
+            remedy: "vizfold install repo".to_owned(),
             ..Default::default()
         };
     }
-    let at = checkout_ref(src);
+    let at = checkout_ref(repo);
     let expected = release::tag();
     let problems = match &at {
-        Some(at) if *at != expected && src == config::default_src() => {
+        Some(at) if *at != expected && repo == config::default_repo() => {
             vec![format!(
                 "the scripts are {at}, but this binary is {expected}"
             )]
@@ -806,13 +818,13 @@ fn repo_health_at(src: &Path) -> Component {
         _ => Vec::new(),
     };
     Component {
-        name: "src",
+        name: "repo",
         detail: match &at {
-            Some(at) => format!("{} at {at}", src.display()),
-            None => src.display().to_string(),
+            Some(at) => format!("{} at {at}", repo.display()),
+            None => repo.display().to_string(),
         },
         problems,
-        remedy: "vizfold update src".to_owned(),
+        remedy: "vizfold update repo".to_owned(),
         ..Default::default()
     }
 }
@@ -837,7 +849,7 @@ fn config_health() -> Component {
             name: "config",
             state: State::Absent,
             detail: "not initialized".to_owned(),
-            remedy: "vizfold install <backend>".to_owned(),
+            remedy: "vizfold install repo".to_owned(),
             ..Default::default()
         };
     }
@@ -857,7 +869,7 @@ fn config_health() -> Component {
         name: "config",
         detail: format!("{} keys", config::config_keys().len()),
         problems,
-        remedy: "vizfold install <backend>".to_owned(),
+        remedy: "vizfold install repo".to_owned(),
         ..Default::default()
     }
 }
@@ -940,11 +952,11 @@ fn backend_health(backend: Backend) -> Component {
 
 /// An editable install into the checkout: losing it breaks every fold at import, env still healthy.
 fn checkout_problem() -> Option<String> {
-    let src = config::vizfold_src();
-    (!src.join(config::INSTALLER).is_file()).then(|| {
+    let repo = config::vizfold_repo();
+    (!repo.join(config::INSTALLER).is_file()).then(|| {
         format!(
             "the checkout it is installed from is gone: {}",
-            src.display()
+            repo.display()
         )
     })
 }
@@ -1105,9 +1117,9 @@ fn summary(components: &[Component]) -> String {
 }
 
 /// Clone the checkout, pinned to `release::tag()` -- the default branch when no such tag exists.
-fn clone_checkout(src: &std::path::Path) -> Result<(), DbErr> {
+fn clone_checkout(repo: &std::path::Path) -> Result<(), DbErr> {
     let url = format!("https://github.com/{}.git", release::repo());
-    let dest = src.to_string_lossy().into_owned();
+    let dest = repo.to_string_lossy().into_owned();
     println!("Fetching the vizfold checkout into {dest} ...");
     let clone = |args: &[&str]| std::process::Command::new("git").args(args).status();
     if let Ok(status) = clone(&[
@@ -1132,9 +1144,9 @@ fn clone_checkout(src: &std::path::Path) -> Result<(), DbErr> {
 
 fn run_update(args: UpdateArgs) -> Result<(), DbErr> {
     match args.part.backend() {
-        None => update_src(args.r#ref.as_deref()),
+        None => update_repo(args.r#ref.as_deref()),
         Some(backend) if args.r#ref.is_some() => Err(DbErr::Custom(format!(
-            "--ref moves the checkout, so it belongs to `vizfold update src`, not {}",
+            "--ref moves the checkout, so it belongs to `vizfold update repo`, not {}",
             backend.slug()
         ))),
         Some(backend) => reinstall(backend, args.yes),
@@ -1178,54 +1190,54 @@ fn reinstall_paths(backend: Backend, prefix: &Path, home: &Path, data: &Path) ->
 }
 
 /// Move the checkout to a ref, by default this binary's own release tag.
-fn update_src(wanted: Option<&str>) -> Result<(), DbErr> {
-    let src = config::vizfold_src();
+fn update_repo(wanted: Option<&str>) -> Result<(), DbErr> {
+    let repo = config::vizfold_repo();
     let target = wanted.unwrap_or(&release::tag()).to_owned();
-    if !src.join(config::INSTALLER).is_file() {
+    if !repo.join(config::INSTALLER).is_file() {
         return Err(DbErr::Custom(format!(
-            "no vizfold checkout at {}; create one with `vizfold install src`",
-            src.display()
+            "no vizfold checkout at {}; create one with `vizfold install repo`",
+            repo.display()
         )));
     }
-    if !src.join(".git").exists() {
+    if !repo.join(".git").exists() {
         return Err(DbErr::Custom(format!(
             "{} is not a git checkout; nothing to update",
-            src.display()
+            repo.display()
         )));
     }
     // Tracked edits only: the install builds OpenFold's CUDA extension in this checkout.
-    match git(&src, &["status", "--porcelain", "--untracked-files=no"]) {
+    match git(&repo, &["status", "--porcelain", "--untracked-files=no"]) {
         None => {
             return Err(DbErr::Custom(format!(
                 "cannot read `git status` in {}; is git on PATH and the checkout yours to read?",
-                src.display()
+                repo.display()
             )));
         }
         Some(changes) if !changes.trim().is_empty() => {
             return Err(DbErr::Custom(format!(
                 "{} has uncommitted changes; commit or discard them first",
-                src.display()
+                repo.display()
             )));
         }
         _ => {}
     }
-    println!("Updating {} to {target} ...", src.display());
+    println!("Updating {} to {target} ...", repo.display());
     // Shallow single-branch clone: the ref must be fetched by name, and only FETCH_HEAD names it after.
     run_to_completion(
         "fetch",
         &mut git_cmd(
-            &src,
+            &repo,
             &["fetch", "--depth", "1", "--tags", "origin", &target],
         ),
     )?;
     run_to_completion(
         "checkout",
-        &mut git_cmd(&src, &["checkout", "--force", "FETCH_HEAD"]),
+        &mut git_cmd(&repo, &["checkout", "--force", "FETCH_HEAD"]),
     )?;
     println!(
         "{} is now at {}",
-        src.display(),
-        checkout_ref(&src).unwrap_or(target)
+        repo.display(),
+        checkout_ref(&repo).unwrap_or(target)
     );
     Ok(())
 }
@@ -1245,9 +1257,9 @@ fn git(dir: &Path, args: &[&str]) -> Option<String> {
         .then(|| String::from_utf8_lossy(&output.stdout).trim().to_owned())
 }
 
-fn checkout_ref(src: &Path) -> Option<String> {
-    git(src, &["describe", "--tags", "--exact-match"])
-        .or_else(|| git(src, &["rev-parse", "--short", "HEAD"]))
+fn checkout_ref(repo: &Path) -> Option<String> {
+    git(repo, &["describe", "--tags", "--exact-match"])
+        .or_else(|| git(repo, &["rev-parse", "--short", "HEAD"]))
         .filter(|value| !value.is_empty())
 }
 
@@ -1288,7 +1300,7 @@ fn run_self_update(args: SelfUpdateArgs) -> Result<(), DbErr> {
     })?;
     println!("vizfold {wanted} is installed at {}", exe.display());
     println!(
-        "The checkout still runs {current}'s scripts. Bring it along with: vizfold update src"
+        "The checkout still runs {current}'s scripts. Bring it along with: vizfold update repo"
     );
     Ok(())
 }
@@ -1358,7 +1370,7 @@ fn run_uninstall(args: UninstallArgs) -> Result<(), DbErr> {
                 let _ = std::fs::remove_dir(dir);
             }
             println!(
-                "\nKept: fold outputs, the vizfold checkout, and the binaries in ~/.local/bin (vizfold, micromamba)."
+                "\nKept: fold outputs, and the binaries in ~/.local/bin (vizfold, micromamba)."
             );
         }
     }
@@ -1409,7 +1421,7 @@ fn shared_paths(prefix: &Path, home: &Path) -> Vec<PathBuf> {
         // The package cache outlives any one backend.
         prefix.join("mamba"),
     ];
-    // The staged copy only; with no prefix settled the two are one path, the src tree.
+    // The staged copy only; with no prefix settled the two are one path, the repo tree.
     if prefix != home {
         paths.push(prefix.join("workbench"));
     }
@@ -1515,12 +1527,12 @@ fn run_serve(args: ServeArgs) -> Result<(), DbErr> {
 
 /// Where the dashboard runs from: a copy on the prefix's filesystem, so node_modules never lands on home.
 fn serve_dir() -> Result<PathBuf, DbErr> {
-    let src = config::openfold_home().join("workbench");
+    let repo = config::openfold_home().join("workbench");
     if config::prefix() == config::openfold_home() {
-        return Ok(src);
+        return Ok(repo);
     }
     let dest = config::prefix().join("workbench");
-    copy_tree(&src, &dest, &["node_modules", ".next"]).map_err(|error| {
+    copy_tree(&repo, &dest, &["node_modules", ".next"]).map_err(|error| {
         DbErr::Custom(format!(
             "failed to stage workbench at '{}': {error}",
             dest.display()
@@ -1529,10 +1541,10 @@ fn serve_dir() -> Result<PathBuf, DbErr> {
     Ok(dest)
 }
 
-/// Merge `src` into `dst`, skipping the named top-level entries (build output, neither copied nor clobbered).
-fn copy_tree(src: &Path, dst: &Path, skip: &[&str]) -> std::io::Result<()> {
+/// Merge `repo` into `dst`, skipping the named top-level entries (build output, neither copied nor clobbered).
+fn copy_tree(repo: &Path, dst: &Path, skip: &[&str]) -> std::io::Result<()> {
     std::fs::create_dir_all(dst)?;
-    for entry in std::fs::read_dir(src)? {
+    for entry in std::fs::read_dir(repo)? {
         let entry = entry?;
         let name = entry.file_name();
         if name.to_str().is_some_and(|n| skip.contains(&n)) {
@@ -2309,7 +2321,7 @@ fn canonicalize_at(field: &str, original: &str, attempted: &Path) -> Result<Stri
         })
 }
 
-/// The one sequence at a resolved FASTA path, as the src of a run's id and sequence.
+/// The one sequence at a resolved FASTA path, as the repo of a run's id and sequence.
 fn read_fasta(path: &Path) -> Result<examples::Example, DbErr> {
     examples::from_path(path).ok_or_else(|| {
         DbErr::Custom(format!(
@@ -2505,7 +2517,7 @@ mod tests {
 
     fn parses_install_part() {
         for (arg, want) in [
-            ("src", Part::Src),
+            ("repo", Part::Repo),
             ("openfold", Part::Openfold),
             ("esmfold", Part::Esmfold),
         ] {
@@ -2521,10 +2533,10 @@ mod tests {
     #[test]
     fn parses_update_part() {
         assert!(matches!(
-            Cli::try_parse_from(["vizfold", "update", "src", "--ref", "v0.1.0"])
-                .expect("update src --ref should parse")
+            Cli::try_parse_from(["vizfold", "update", "repo", "--ref", "v0.1.0"])
+                .expect("update repo --ref should parse")
                 .command,
-            Command::Update(UpdateArgs { part: Part::Src, r#ref: Some(at), yes: false }) if at == "v0.1.0"
+            Command::Update(UpdateArgs { part: Part::Repo, r#ref: Some(at), yes: false }) if at == "v0.1.0"
         ));
         assert!(matches!(
             Cli::try_parse_from(["vizfold", "update", "openfold", "--yes"])
@@ -2540,7 +2552,7 @@ mod tests {
         assert!(Cli::try_parse_from(["vizfold", "update", "vizfold"]).is_err());
     }
 
-    /// Only src takes a ref; silently ignoring it on a backend would fake a version move.
+    /// Only repo takes a ref; silently ignoring it on a backend would fake a version move.
     #[test]
     fn a_ref_on_a_backend_update_is_refused() {
         let update = |argv: &[&str]| match Cli::try_parse_from(argv).expect("argv").command {
@@ -2549,7 +2561,7 @@ mod tests {
         };
         assert!(
             super::run_update(update(&["vizfold", "update", "esmfold", "--ref", "v0.1.0"]))
-                .is_err_and(|error| format!("{error}").contains("vizfold update src"))
+                .is_err_and(|error| format!("{error}").contains("vizfold update repo"))
         );
     }
 
@@ -2712,11 +2724,11 @@ mod tests {
             })
         ));
         assert!(matches!(
-            Cli::try_parse_from(["vizfold", "uninstall", "src"])
-                .expect("uninstall src should parse")
+            Cli::try_parse_from(["vizfold", "uninstall", "repo"])
+                .expect("uninstall repo should parse")
                 .command,
             Command::Uninstall(UninstallArgs {
-                part: Some(Part::Src),
+                part: Some(Part::Repo),
                 yes: false
             })
         ));
@@ -2781,12 +2793,12 @@ mod tests {
             );
         }
         assert!(
-            super::src_paths(&prefix) == vec![config::default_src()]
-                || config::vizfold_src() != config::default_src(),
-            "src owns the default checkout and nothing else"
+            super::repo_paths(&prefix) == vec![config::default_repo()]
+                || config::vizfold_repo() != config::default_repo(),
+            "repo owns the default checkout and nothing else"
         );
         assert!(
-            super::src_paths(&config::default_src().join("prefix")).is_empty(),
+            super::repo_paths(&config::default_repo().join("prefix")).is_empty(),
             "a prefix inside the checkout keeps the checkout"
         );
         assert!(shared.contains(&config::config_file()), "config is shared");
@@ -2829,7 +2841,7 @@ mod tests {
         std::fs::remove_dir_all(&base).ok();
     }
 
-    /// The gate table by the names it produces: `status` and src's own verbs stay off `src`.
+    /// The gate table by the names it produces: `status` and repo's own verbs stay off `repo`.
     #[test]
     fn every_command_gates_on_the_prereqs_it_actually_needs() {
         let names = |argv: &[&str]| {
@@ -2842,33 +2854,33 @@ mod tests {
 
         assert_eq!(names(&["vizfold", "status"]), Vec::<&str>::new());
         assert_eq!(names(&["vizfold", "uninstall"]), Vec::<&str>::new());
-        assert_eq!(names(&["vizfold", "install", "src"]), ["micromamba"]);
-        assert_eq!(names(&["vizfold", "update", "src"]), ["micromamba"]);
+        assert_eq!(names(&["vizfold", "install", "repo"]), ["micromamba"]);
+        assert_eq!(names(&["vizfold", "update", "repo"]), ["micromamba"]);
         assert_eq!(
             names(&["vizfold", "install", "openfold"]),
-            ["micromamba", "src"]
+            ["micromamba", "repo"]
         );
         assert_eq!(
             names(&["vizfold", "update", "openfold"]),
-            ["micromamba", "src"]
+            ["micromamba", "repo"]
         );
-        assert_eq!(names(&["vizfold", "list", "proteins"]), ["src"]);
+        assert_eq!(names(&["vizfold", "list", "proteins"]), ["repo"]);
         assert_eq!(
             names(&["vizfold", "serve"]),
-            ["micromamba", "src", "config"]
+            ["micromamba", "repo", "config"]
         );
         assert_eq!(
             names(&["vizfold", "serve", "openfold", "esmfold"]),
-            ["micromamba", "src", "config", "openfold", "esmfold"]
+            ["micromamba", "repo", "config", "openfold", "esmfold"]
         );
-        assert!(Cli::try_parse_from(["vizfold", "serve", "src"]).is_err());
+        assert!(Cli::try_parse_from(["vizfold", "serve", "repo"]).is_err());
         assert_eq!(
             names(&["vizfold", "download", "openfold"]),
-            ["src", "config", "openfold"]
+            ["repo", "config", "openfold"]
         );
         assert_eq!(
             names(&["vizfold", "run", "1UBQ_1"]),
-            ["micromamba", "src", "config", "openfold"]
+            ["micromamba", "repo", "config", "openfold"]
         );
         // `--no-exec` only writes the row, so it must not gate on an installed environment.
         assert_eq!(
@@ -2907,13 +2919,13 @@ mod tests {
             absent.problems.is_empty(),
             "absent is not a list of problems"
         );
-        assert_eq!(absent.remedy, "vizfold install src");
+        assert_eq!(absent.remedy, "vizfold install repo");
         assert_ne!(
             present.state,
             State::Absent,
             "a checkout is there to be judged"
         );
-        assert_eq!(present.remedy, "vizfold update src");
+        assert_eq!(present.remedy, "vizfold update repo");
     }
 
     #[test]
@@ -2993,10 +3005,10 @@ mod tests {
         assert_eq!(
             super::summary(&[
                 component("cli", super::State::Ok),
-                component("src", super::State::Broken),
+                component("repo", super::State::Broken),
                 component("config", super::State::Broken),
             ]),
-            "2 of 3 components need attention: src, config."
+            "2 of 3 components need attention: repo, config."
         );
     }
 
@@ -3055,19 +3067,19 @@ mod tests {
     #[test]
     fn copy_tree_excludes_build_artifacts_and_preserves_dest() {
         let base = std::env::temp_dir().join(format!("vizfold-copytree-{}", std::process::id()));
-        let (src, dst) = (base.join("src"), base.join("dst"));
+        let (repo, dst) = (base.join("repo"), base.join("dst"));
         let _ = std::fs::remove_dir_all(&base);
-        std::fs::create_dir_all(src.join("node_modules")).unwrap();
-        std::fs::create_dir_all(src.join(".next")).unwrap();
-        std::fs::create_dir_all(src.join("app")).unwrap();
-        std::fs::write(src.join("package.json"), "{}").unwrap();
-        std::fs::write(src.join("node_modules/dep.js"), "src").unwrap();
-        std::fs::write(src.join("app/page.tsx"), "x").unwrap();
+        std::fs::create_dir_all(repo.join("node_modules")).unwrap();
+        std::fs::create_dir_all(repo.join(".next")).unwrap();
+        std::fs::create_dir_all(repo.join("app")).unwrap();
+        std::fs::write(repo.join("package.json"), "{}").unwrap();
+        std::fs::write(repo.join("node_modules/dep.js"), "repo").unwrap();
+        std::fs::write(repo.join("app/page.tsx"), "x").unwrap();
         // A node_modules already staged in the destination must survive the copy.
         std::fs::create_dir_all(dst.join("node_modules")).unwrap();
         std::fs::write(dst.join("node_modules/installed.js"), "keep").unwrap();
 
-        super::copy_tree(&src, &dst, &["node_modules", ".next"]).unwrap();
+        super::copy_tree(&repo, &dst, &["node_modules", ".next"]).unwrap();
 
         assert!(dst.join("package.json").is_file());
         assert!(dst.join("app/page.tsx").is_file());
@@ -3081,14 +3093,14 @@ mod tests {
     fn copy_tree_skips_a_symlinked_directory() {
         let base =
             std::env::temp_dir().join(format!("vizfold-copytree-link-{}", std::process::id()));
-        let (src, dst, outputs) = (base.join("src"), base.join("dst"), base.join("outputs"));
+        let (repo, dst, outputs) = (base.join("repo"), base.join("dst"), base.join("outputs"));
         let _ = std::fs::remove_dir_all(&base);
-        std::fs::create_dir_all(src.join("public")).unwrap();
+        std::fs::create_dir_all(repo.join("public")).unwrap();
         std::fs::create_dir_all(&outputs).unwrap();
-        std::fs::write(src.join("package.json"), "{}").unwrap();
-        std::os::unix::fs::symlink(&outputs, src.join("public/runs")).unwrap();
+        std::fs::write(repo.join("package.json"), "{}").unwrap();
+        std::os::unix::fs::symlink(&outputs, repo.join("public/runs")).unwrap();
 
-        super::copy_tree(&src, &dst, &[]).unwrap();
+        super::copy_tree(&repo, &dst, &[]).unwrap();
 
         assert!(dst.join("package.json").is_file());
         assert!(!dst.join("public/runs").exists());
@@ -3335,7 +3347,7 @@ mod tests {
             .collect();
         staged_names.sort();
         assert_eq!(staged_names, ["1UBQ_1.fasta", "6KWC_1.fasta"]);
-        // Links, not copies, so the batch directory costs nothing and cannot drift from its src.
+        // Links, not copies, so the batch directory costs nothing and cannot drift from its repo.
         assert!(staged.join("1UBQ_1.fasta").is_file());
         std::fs::remove_dir_all(&inputs).ok();
         Ok(())

--- a/cli/src/adapters/cli.rs
+++ b/cli/src/adapters/cli.rs
@@ -40,7 +40,7 @@ pub struct Cli {
 // `run` carries every fold flag; one enum is parsed, once, per process.
 #[allow(clippy::large_enum_variant)]
 enum Command {
-    /// Install the checkout everything runs from (`source`), or a model backend from it.
+    /// Install the checkout everything runs from (`src`), or a model backend from it.
     Install(InstallArgs),
     /// Download a backend's data (OpenFold AlphaFold2 databases/params).
     Download(DownloadArgs),
@@ -48,9 +48,9 @@ enum Command {
     Status,
     /// Remove one part, or everything the install generated.
     Uninstall(UninstallArgs),
-    /// Move the checkout to this binary's release (`source`), or reinstall a backend from it.
+    /// Move the checkout to this binary's release (`src`), or reinstall a backend from it.
     Update(UpdateArgs),
-    /// Replace this binary with the latest release. Run `update source` after, for the checkout.
+    /// Replace this binary with the latest release. Run `update src` after, for the checkout.
     SelfUpdate(SelfUpdateArgs),
     /// Start the workbench dashboard, over the given backends (default: all installed).
     Serve(ServeArgs),
@@ -84,7 +84,7 @@ struct InstallArgs {
 /// What a lifecycle verb acts on: the checkout every backend installs from, or one backend.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
 enum Part {
-    Source,
+    Src,
     Openfold,
     Esmfold,
 }
@@ -92,27 +92,27 @@ enum Part {
 impl Part {
     fn backend(self) -> Option<Backend> {
         match self {
-            Self::Source => None,
+            Self::Src => None,
             Self::Openfold => Some(Backend::Openfold),
             Self::Esmfold => Some(Backend::Esmfold),
         }
     }
 
     fn slug(self) -> &'static str {
-        self.backend().map_or("source", Backend::slug)
+        self.backend().map_or("src", Backend::slug)
     }
 
     /// Exactly what `install <part>` puts there, so `uninstall <part>` takes back the same set.
     fn install_paths(self, prefix: &Path, home: &Path) -> Vec<PathBuf> {
         self.backend().map_or_else(
-            || source_paths(prefix),
+            || src_paths(prefix),
             |backend| backend.install_paths(prefix, home),
         )
     }
 }
 
 /// The checkout, and only the clone vizfold made itself: never a user-supplied `OPENFOLD_HOME`.
-fn source_paths(prefix: &Path) -> Vec<PathBuf> {
+fn src_paths(prefix: &Path) -> Vec<PathBuf> {
     let src = config::vizfold_src();
     (src == config::default_src() && !prefix.starts_with(&src))
         .then_some(src)
@@ -231,7 +231,7 @@ struct UpdateArgs {
     /// What to bring current: the checkout, or a backend reinstalled from it.
     #[arg(value_enum)]
     part: Part,
-    /// Tag or branch to move the checkout to. Defaults to this binary's own release tag. `source` only.
+    /// Tag or branch to move the checkout to. Defaults to this binary's own release tag. `src` only.
     #[arg(long, value_name = "REF")]
     r#ref: Option<String>,
     /// Reinstall without the confirmation prompt.
@@ -445,7 +445,7 @@ fn prereqs(command: &Command) -> Vec<Component> {
         | Command::Uninstall(_)
         | Command::SelfUpdate(_)
         | Command::Completions(_) => vec![],
-        // A backend installs from the checkout; source's own verbs are what repair it, so they stay off it.
+        // A backend installs from the checkout; src's own verbs are what repair it, so they stay off it.
         Command::Install(InstallArgs { part }) | Command::Update(UpdateArgs { part, .. }) => {
             std::iter::once(core_deps_health())
                 .chain(part.backend().map(|_| repo_health()))
@@ -537,16 +537,16 @@ pub async fn run() -> Result<(), DbErr> {
     Ok(())
 }
 
-/// Make a part exist. Idempotent: both backend installers short-circuit on presence, as source does.
+/// Make a part exist. Idempotent: both backend installers short-circuit on presence, as src does.
 fn run_install(part: Part) -> Result<(), DbErr> {
     match part.backend() {
         Some(backend) => install_backend(backend),
-        None => install_source(),
+        None => install_src(),
     }
 }
 
 /// Fetch the checkout the binary installs everything from -- it ships only itself. Never moves one.
-fn install_source() -> Result<(), DbErr> {
+fn install_src() -> Result<(), DbErr> {
     let src = config::vizfold_src();
     if src.join(config::INSTALLER).is_file() {
         println!("{} already is a vizfold checkout.", src.display());
@@ -788,10 +788,10 @@ fn repo_health() -> Component {
 fn repo_health_at(src: &Path) -> Component {
     if !src.join(config::INSTALLER).is_file() {
         return Component {
-            name: "source",
+            name: "src",
             state: State::Absent,
             detail: format!("no checkout at {}", src.display()),
-            remedy: "vizfold install source".to_owned(),
+            remedy: "vizfold install src".to_owned(),
             ..Default::default()
         };
     }
@@ -806,13 +806,13 @@ fn repo_health_at(src: &Path) -> Component {
         _ => Vec::new(),
     };
     Component {
-        name: "source",
+        name: "src",
         detail: match &at {
             Some(at) => format!("{} at {at}", src.display()),
             None => src.display().to_string(),
         },
         problems,
-        remedy: "vizfold update source".to_owned(),
+        remedy: "vizfold update src".to_owned(),
         ..Default::default()
     }
 }
@@ -1132,9 +1132,9 @@ fn clone_checkout(src: &std::path::Path) -> Result<(), DbErr> {
 
 fn run_update(args: UpdateArgs) -> Result<(), DbErr> {
     match args.part.backend() {
-        None => update_source(args.r#ref.as_deref()),
+        None => update_src(args.r#ref.as_deref()),
         Some(backend) if args.r#ref.is_some() => Err(DbErr::Custom(format!(
-            "--ref moves the checkout, so it belongs to `vizfold update source`, not {}",
+            "--ref moves the checkout, so it belongs to `vizfold update src`, not {}",
             backend.slug()
         ))),
         Some(backend) => reinstall(backend, args.yes),
@@ -1178,12 +1178,12 @@ fn reinstall_paths(backend: Backend, prefix: &Path, home: &Path, data: &Path) ->
 }
 
 /// Move the checkout to a ref, by default this binary's own release tag.
-fn update_source(wanted: Option<&str>) -> Result<(), DbErr> {
+fn update_src(wanted: Option<&str>) -> Result<(), DbErr> {
     let src = config::vizfold_src();
     let target = wanted.unwrap_or(&release::tag()).to_owned();
     if !src.join(config::INSTALLER).is_file() {
         return Err(DbErr::Custom(format!(
-            "no vizfold checkout at {}; create one with `vizfold install source`",
+            "no vizfold checkout at {}; create one with `vizfold install src`",
             src.display()
         )));
     }
@@ -1288,7 +1288,7 @@ fn run_self_update(args: SelfUpdateArgs) -> Result<(), DbErr> {
     })?;
     println!("vizfold {wanted} is installed at {}", exe.display());
     println!(
-        "The checkout still runs {current}'s scripts. Bring it along with: vizfold update source"
+        "The checkout still runs {current}'s scripts. Bring it along with: vizfold update src"
     );
     Ok(())
 }
@@ -1409,7 +1409,7 @@ fn shared_paths(prefix: &Path, home: &Path) -> Vec<PathBuf> {
         // The package cache outlives any one backend.
         prefix.join("mamba"),
     ];
-    // The staged copy only; with no prefix settled the two are one path, the source tree.
+    // The staged copy only; with no prefix settled the two are one path, the src tree.
     if prefix != home {
         paths.push(prefix.join("workbench"));
     }
@@ -2309,7 +2309,7 @@ fn canonicalize_at(field: &str, original: &str, attempted: &Path) -> Result<Stri
         })
 }
 
-/// The one sequence at a resolved FASTA path, as the source of a run's id and sequence.
+/// The one sequence at a resolved FASTA path, as the src of a run's id and sequence.
 fn read_fasta(path: &Path) -> Result<examples::Example, DbErr> {
     examples::from_path(path).ok_or_else(|| {
         DbErr::Custom(format!(
@@ -2505,7 +2505,7 @@ mod tests {
 
     fn parses_install_part() {
         for (arg, want) in [
-            ("source", Part::Source),
+            ("src", Part::Src),
             ("openfold", Part::Openfold),
             ("esmfold", Part::Esmfold),
         ] {
@@ -2521,10 +2521,10 @@ mod tests {
     #[test]
     fn parses_update_part() {
         assert!(matches!(
-            Cli::try_parse_from(["vizfold", "update", "source", "--ref", "v0.1.0"])
-                .expect("update source --ref should parse")
+            Cli::try_parse_from(["vizfold", "update", "src", "--ref", "v0.1.0"])
+                .expect("update src --ref should parse")
                 .command,
-            Command::Update(UpdateArgs { part: Part::Source, r#ref: Some(at), yes: false }) if at == "v0.1.0"
+            Command::Update(UpdateArgs { part: Part::Src, r#ref: Some(at), yes: false }) if at == "v0.1.0"
         ));
         assert!(matches!(
             Cli::try_parse_from(["vizfold", "update", "openfold", "--yes"])
@@ -2540,7 +2540,7 @@ mod tests {
         assert!(Cli::try_parse_from(["vizfold", "update", "vizfold"]).is_err());
     }
 
-    /// Only source takes a ref; silently ignoring it on a backend would fake a version move.
+    /// Only src takes a ref; silently ignoring it on a backend would fake a version move.
     #[test]
     fn a_ref_on_a_backend_update_is_refused() {
         let update = |argv: &[&str]| match Cli::try_parse_from(argv).expect("argv").command {
@@ -2549,7 +2549,7 @@ mod tests {
         };
         assert!(
             super::run_update(update(&["vizfold", "update", "esmfold", "--ref", "v0.1.0"]))
-                .is_err_and(|error| format!("{error}").contains("vizfold update source"))
+                .is_err_and(|error| format!("{error}").contains("vizfold update src"))
         );
     }
 
@@ -2712,11 +2712,11 @@ mod tests {
             })
         ));
         assert!(matches!(
-            Cli::try_parse_from(["vizfold", "uninstall", "source"])
-                .expect("uninstall source should parse")
+            Cli::try_parse_from(["vizfold", "uninstall", "src"])
+                .expect("uninstall src should parse")
                 .command,
             Command::Uninstall(UninstallArgs {
-                part: Some(Part::Source),
+                part: Some(Part::Src),
                 yes: false
             })
         ));
@@ -2781,12 +2781,12 @@ mod tests {
             );
         }
         assert!(
-            super::source_paths(&prefix) == vec![config::default_src()]
+            super::src_paths(&prefix) == vec![config::default_src()]
                 || config::vizfold_src() != config::default_src(),
-            "source owns the default checkout and nothing else"
+            "src owns the default checkout and nothing else"
         );
         assert!(
-            super::source_paths(&config::default_src().join("prefix")).is_empty(),
+            super::src_paths(&config::default_src().join("prefix")).is_empty(),
             "a prefix inside the checkout keeps the checkout"
         );
         assert!(shared.contains(&config::config_file()), "config is shared");
@@ -2829,7 +2829,7 @@ mod tests {
         std::fs::remove_dir_all(&base).ok();
     }
 
-    /// The gate table by the names it produces: `status` and source's own verbs stay off `source`.
+    /// The gate table by the names it produces: `status` and src's own verbs stay off `src`.
     #[test]
     fn every_command_gates_on_the_prereqs_it_actually_needs() {
         let names = |argv: &[&str]| {
@@ -2842,33 +2842,33 @@ mod tests {
 
         assert_eq!(names(&["vizfold", "status"]), Vec::<&str>::new());
         assert_eq!(names(&["vizfold", "uninstall"]), Vec::<&str>::new());
-        assert_eq!(names(&["vizfold", "install", "source"]), ["micromamba"]);
-        assert_eq!(names(&["vizfold", "update", "source"]), ["micromamba"]);
+        assert_eq!(names(&["vizfold", "install", "src"]), ["micromamba"]);
+        assert_eq!(names(&["vizfold", "update", "src"]), ["micromamba"]);
         assert_eq!(
             names(&["vizfold", "install", "openfold"]),
-            ["micromamba", "source"]
+            ["micromamba", "src"]
         );
         assert_eq!(
             names(&["vizfold", "update", "openfold"]),
-            ["micromamba", "source"]
+            ["micromamba", "src"]
         );
-        assert_eq!(names(&["vizfold", "list", "proteins"]), ["source"]);
+        assert_eq!(names(&["vizfold", "list", "proteins"]), ["src"]);
         assert_eq!(
             names(&["vizfold", "serve"]),
-            ["micromamba", "source", "config"]
+            ["micromamba", "src", "config"]
         );
         assert_eq!(
             names(&["vizfold", "serve", "openfold", "esmfold"]),
-            ["micromamba", "source", "config", "openfold", "esmfold"]
+            ["micromamba", "src", "config", "openfold", "esmfold"]
         );
-        assert!(Cli::try_parse_from(["vizfold", "serve", "source"]).is_err());
+        assert!(Cli::try_parse_from(["vizfold", "serve", "src"]).is_err());
         assert_eq!(
             names(&["vizfold", "download", "openfold"]),
-            ["source", "config", "openfold"]
+            ["src", "config", "openfold"]
         );
         assert_eq!(
             names(&["vizfold", "run", "1UBQ_1"]),
-            ["micromamba", "source", "config", "openfold"]
+            ["micromamba", "src", "config", "openfold"]
         );
         // `--no-exec` only writes the row, so it must not gate on an installed environment.
         assert_eq!(
@@ -2907,13 +2907,13 @@ mod tests {
             absent.problems.is_empty(),
             "absent is not a list of problems"
         );
-        assert_eq!(absent.remedy, "vizfold install source");
+        assert_eq!(absent.remedy, "vizfold install src");
         assert_ne!(
             present.state,
             State::Absent,
             "a checkout is there to be judged"
         );
-        assert_eq!(present.remedy, "vizfold update source");
+        assert_eq!(present.remedy, "vizfold update src");
     }
 
     #[test]
@@ -2993,10 +2993,10 @@ mod tests {
         assert_eq!(
             super::summary(&[
                 component("cli", super::State::Ok),
-                component("source", super::State::Broken),
+                component("src", super::State::Broken),
                 component("config", super::State::Broken),
             ]),
-            "2 of 3 components need attention: source, config."
+            "2 of 3 components need attention: src, config."
         );
     }
 
@@ -3335,7 +3335,7 @@ mod tests {
             .collect();
         staged_names.sort();
         assert_eq!(staged_names, ["1UBQ_1.fasta", "6KWC_1.fasta"]);
-        // Links, not copies, so the batch directory costs nothing and cannot drift from its source.
+        // Links, not copies, so the batch directory costs nothing and cannot drift from its src.
         assert!(staged.join("1UBQ_1.fasta").is_file());
         std::fs::remove_dir_all(&inputs).ok();
         Ok(())

--- a/cli/src/adapters/cli.rs
+++ b/cli/src/adapters/cli.rs
@@ -40,7 +40,7 @@ pub struct Cli {
 // `run` carries every fold flag; one enum is parsed, once, per process.
 #[allow(clippy::large_enum_variant)]
 enum Command {
-    /// Install the checkout everything runs from (`base`), or a model backend from it.
+    /// Install the checkout everything runs from (`source`), or a model backend from it.
     Install(InstallArgs),
     /// Download a backend's data (OpenFold AlphaFold2 databases/params).
     Download(DownloadArgs),
@@ -48,9 +48,9 @@ enum Command {
     Status,
     /// Remove one part, or everything the install generated.
     Uninstall(UninstallArgs),
-    /// Move the checkout to this binary's release (`base`), or reinstall a backend from it.
+    /// Move the checkout to this binary's release (`source`), or reinstall a backend from it.
     Update(UpdateArgs),
-    /// Replace this binary with the latest release. Run `update base` after, for the checkout.
+    /// Replace this binary with the latest release. Run `update source` after, for the checkout.
     SelfUpdate(SelfUpdateArgs),
     /// Start the workbench dashboard, over the given backends (default: all installed).
     Serve(ServeArgs),
@@ -84,7 +84,7 @@ struct InstallArgs {
 /// What a lifecycle verb acts on: the checkout every backend installs from, or one backend.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
 enum Part {
-    Base,
+    Source,
     Openfold,
     Esmfold,
 }
@@ -92,27 +92,27 @@ enum Part {
 impl Part {
     fn backend(self) -> Option<Backend> {
         match self {
-            Self::Base => None,
+            Self::Source => None,
             Self::Openfold => Some(Backend::Openfold),
             Self::Esmfold => Some(Backend::Esmfold),
         }
     }
 
     fn slug(self) -> &'static str {
-        self.backend().map_or("base", Backend::slug)
+        self.backend().map_or("source", Backend::slug)
     }
 
     /// Exactly what `install <part>` puts there, so `uninstall <part>` takes back the same set.
     fn install_paths(self, prefix: &Path, home: &Path) -> Vec<PathBuf> {
         self.backend().map_or_else(
-            || base_paths(prefix),
+            || source_paths(prefix),
             |backend| backend.install_paths(prefix, home),
         )
     }
 }
 
 /// The checkout, and only the clone vizfold made itself: never a user-supplied `OPENFOLD_HOME`.
-fn base_paths(prefix: &Path) -> Vec<PathBuf> {
+fn source_paths(prefix: &Path) -> Vec<PathBuf> {
     let src = config::vizfold_src();
     (src == config::default_src() && !prefix.starts_with(&src))
         .then_some(src)
@@ -231,7 +231,7 @@ struct UpdateArgs {
     /// What to bring current: the checkout, or a backend reinstalled from it.
     #[arg(value_enum)]
     part: Part,
-    /// Tag or branch to move the checkout to. Defaults to this binary's own release tag. `base` only.
+    /// Tag or branch to move the checkout to. Defaults to this binary's own release tag. `source` only.
     #[arg(long, value_name = "REF")]
     r#ref: Option<String>,
     /// Reinstall without the confirmation prompt.
@@ -287,7 +287,7 @@ struct ListArgs {
 
 #[derive(Debug, Args)]
 struct RunArgs {
-    /// What to fold: bundled example ids (`vizfold list examples`), FASTA files, or directories of
+    /// What to fold: bundled protein ids (`vizfold list proteins`), FASTA files, or directories of
     /// FASTAs -- several fold in one execution. A lone run id replays that queued run instead.
     #[arg(required = true)]
     targets: Vec<String>,
@@ -355,8 +355,8 @@ struct RunArgs {
 
 #[derive(Debug, Subcommand)]
 enum ListResource {
-    /// List the bundled examples that can fold without an MSA search.
-    Examples {
+    /// List the proteins available to fold, and which carry precomputed alignments.
+    Proteins {
         /// Emit JSON including each sequence, for tools driving the CLI.
         #[arg(long)]
         json: bool,
@@ -445,14 +445,14 @@ fn prereqs(command: &Command) -> Vec<Component> {
         | Command::Uninstall(_)
         | Command::SelfUpdate(_)
         | Command::Completions(_) => vec![],
-        // A backend installs from the checkout; base's own verbs are what repair it, so they stay off it.
+        // A backend installs from the checkout; source's own verbs are what repair it, so they stay off it.
         Command::Install(InstallArgs { part }) | Command::Update(UpdateArgs { part, .. }) => {
             std::iter::once(core_deps_health())
                 .chain(part.backend().map(|_| repo_health()))
                 .collect()
         }
         Command::List(ListArgs {
-            resource: ListResource::Examples { .. },
+            resource: ListResource::Proteins { .. },
         }) => vec![repo_health()],
         // Only the backends named: bare `serve` resolves to what is installed, so it can gate on nothing.
         Command::Serve(args) => [core_deps_health(), repo_health(), config_health()]
@@ -503,8 +503,8 @@ pub async fn run() -> Result<(), DbErr> {
         Command::Serve(args) => return run_serve(args),
         Command::Completions(args) => return run_completions(args.shell),
         Command::List(ListArgs {
-            resource: ListResource::Examples { json },
-        }) => return list_examples(json),
+            resource: ListResource::Proteins { json },
+        }) => return list_proteins(json),
         _ => {}
     }
 
@@ -515,7 +515,7 @@ pub async fn run() -> Result<(), DbErr> {
             ListResource::Targets => list_targets(&database).await?,
             ListResource::Profiles => list_profiles(&database).await?,
             ListResource::Runs { status } => list_runs(&database, status.as_deref()).await?,
-            ListResource::Examples { .. } => unreachable!("handled before DB connect"),
+            ListResource::Proteins { .. } => unreachable!("handled before DB connect"),
         },
         Command::Show(show) => match show.resource {
             ShowResource::Run { run_id } => show_run(&database, run_id).await?,
@@ -537,16 +537,16 @@ pub async fn run() -> Result<(), DbErr> {
     Ok(())
 }
 
-/// Make a part exist. Idempotent: both backend installers short-circuit on presence, as base does.
+/// Make a part exist. Idempotent: both backend installers short-circuit on presence, as source does.
 fn run_install(part: Part) -> Result<(), DbErr> {
     match part.backend() {
         Some(backend) => install_backend(backend),
-        None => install_base(),
+        None => install_source(),
     }
 }
 
 /// Fetch the checkout the binary installs everything from -- it ships only itself. Never moves one.
-fn install_base() -> Result<(), DbErr> {
+fn install_source() -> Result<(), DbErr> {
     let src = config::vizfold_src();
     if src.join(config::INSTALLER).is_file() {
         println!("{} already is a vizfold checkout.", src.display());
@@ -755,7 +755,7 @@ const CORE_DEP: &str = "micromamba";
 fn core_deps_health() -> Component {
     let found = on_path(CORE_DEP);
     Component {
-        name: "core deps",
+        name: "micromamba",
         detail: found
             .as_ref()
             .map_or_else(|| CORE_DEP.to_owned(), |path| path.display().to_string()),
@@ -774,7 +774,7 @@ fn core_deps_health() -> Component {
 
 fn binary_health() -> Component {
     Component {
-        name: "binary",
+        name: "cli",
         detail: release::version_line(release::latest_tag().as_deref()),
         ..Default::default()
     }
@@ -788,10 +788,10 @@ fn repo_health() -> Component {
 fn repo_health_at(src: &Path) -> Component {
     if !src.join(config::INSTALLER).is_file() {
         return Component {
-            name: "repo",
+            name: "source",
             state: State::Absent,
             detail: format!("no checkout at {}", src.display()),
-            remedy: "vizfold install base".to_owned(),
+            remedy: "vizfold install source".to_owned(),
             ..Default::default()
         };
     }
@@ -806,13 +806,13 @@ fn repo_health_at(src: &Path) -> Component {
         _ => Vec::new(),
     };
     Component {
-        name: "repo",
+        name: "source",
         detail: match &at {
             Some(at) => format!("{} at {at}", src.display()),
             None => src.display().to_string(),
         },
         problems,
-        remedy: "vizfold update base".to_owned(),
+        remedy: "vizfold update source".to_owned(),
         ..Default::default()
     }
 }
@@ -1132,9 +1132,9 @@ fn clone_checkout(src: &std::path::Path) -> Result<(), DbErr> {
 
 fn run_update(args: UpdateArgs) -> Result<(), DbErr> {
     match args.part.backend() {
-        None => update_base(args.r#ref.as_deref()),
+        None => update_source(args.r#ref.as_deref()),
         Some(backend) if args.r#ref.is_some() => Err(DbErr::Custom(format!(
-            "--ref moves the checkout, so it belongs to `vizfold update base`, not {}",
+            "--ref moves the checkout, so it belongs to `vizfold update source`, not {}",
             backend.slug()
         ))),
         Some(backend) => reinstall(backend, args.yes),
@@ -1178,12 +1178,12 @@ fn reinstall_paths(backend: Backend, prefix: &Path, home: &Path, data: &Path) ->
 }
 
 /// Move the checkout to a ref, by default this binary's own release tag.
-fn update_base(wanted: Option<&str>) -> Result<(), DbErr> {
+fn update_source(wanted: Option<&str>) -> Result<(), DbErr> {
     let src = config::vizfold_src();
     let target = wanted.unwrap_or(&release::tag()).to_owned();
     if !src.join(config::INSTALLER).is_file() {
         return Err(DbErr::Custom(format!(
-            "no vizfold checkout at {}; create one with `vizfold install base`",
+            "no vizfold checkout at {}; create one with `vizfold install source`",
             src.display()
         )));
     }
@@ -1288,7 +1288,7 @@ fn run_self_update(args: SelfUpdateArgs) -> Result<(), DbErr> {
     })?;
     println!("vizfold {wanted} is installed at {}", exe.display());
     println!(
-        "The checkout still runs {current}'s scripts. Bring it along with: vizfold update base"
+        "The checkout still runs {current}'s scripts. Bring it along with: vizfold update source"
     );
     Ok(())
 }
@@ -1744,7 +1744,7 @@ fn preflight_status_label(status: PreflightStatus) -> &'static str {
 }
 
 /// Filesystem-only, so the dashboard can draw its dropdown without a connect and migrate.
-fn list_examples(json: bool) -> Result<(), DbErr> {
+fn list_proteins(json: bool) -> Result<(), DbErr> {
     let found = examples::scan_default();
     if json {
         println!(
@@ -1757,6 +1757,7 @@ fn list_examples(json: bool) -> Result<(), DbErr> {
                         "residues": example.residues,
                         "description": example.description,
                         "sequence": example.sequence,
+                        "alignments": example.alignments,
                     }))
                     .collect()
             )
@@ -1765,17 +1766,19 @@ fn list_examples(json: bool) -> Result<(), DbErr> {
     }
     if found.is_empty() {
         println!(
-            "No examples under {}. Re-run `vizfold install openfold`.",
+            "No proteins under {}. Re-run `vizfold install openfold`.",
             examples::monomer_dir().display()
         );
         return Ok(());
     }
+    // ALIGNMENTS is what a chooser needs: N means this one pays for the full MSA search.
     print_table(
-        &["ID", "RESIDUES", "DESCRIPTION"],
+        &["ID", "RESIDUES", "ALIGNMENTS", "DESCRIPTION"],
         found.iter().map(|example| {
             vec![
                 example.id.clone(),
                 example.residues.to_string(),
+                if example.alignments { "Y" } else { "N" }.to_owned(),
                 example.description.clone(),
             ]
         }),
@@ -1899,7 +1902,6 @@ fn queued_run_id(targets: &[String]) -> Result<Option<i32>, DbErr> {
 struct Target {
     fasta: PathBuf,
     example: examples::Example,
-    bundled: bool,
 }
 
 fn tags(resolved: &[Target]) -> Vec<&str> {
@@ -1914,13 +1916,15 @@ fn resolve_targets(targets: &[String]) -> Result<Vec<Target>, DbErr> {
     let mut resolved: Vec<Target> = Vec::new();
     for target in targets {
         let path = local_path(target);
-        let (fastas, bundled) = match examples::find(target) {
+        // `read_fasta` below re-parses each file and cannot see the alignments directory beside
+        // it, so carry the scan's answer down. Only a bundled protein can have one.
+        let (fastas, aligned) = match examples::find(target) {
             // The example's file, not its directory: a stray sibling FASTA cannot join the fold.
             Some(example) => (
                 examples::first_fasta(Path::new(&default_fasta_dir(&example.id)))
                     .into_iter()
                     .collect(),
-                true,
+                example.alignments,
             ),
             None if path.is_dir() => (examples::fasta_files(&path), false),
             // Anything path-shaped falls through to `read_fasta`, which names what it could not read.
@@ -1933,7 +1937,10 @@ fn resolve_targets(targets: &[String]) -> Result<Vec<Target>, DbErr> {
             )));
         }
         for fasta in fastas {
-            let example = read_fasta(&fasta)?;
+            let example = examples::Example {
+                alignments: aligned,
+                ..read_fasta(&fasta)?
+            };
             // The tag becomes a directory and a link name here; preflight takes nothing else either.
             if !example
                 .id
@@ -1956,11 +1963,7 @@ fn resolve_targets(targets: &[String]) -> Result<Vec<Target>, DbErr> {
             let fasta = std::fs::canonicalize(&fasta).map_err(|error| {
                 DbErr::Custom(format!("cannot resolve '{}': {error}", fasta.display()))
             })?;
-            resolved.push(Target {
-                fasta,
-                example,
-                bundled,
-            });
+            resolved.push(Target { fasta, example });
         }
     }
     Ok(resolved)
@@ -2095,10 +2098,11 @@ async fn submit_openfold_run(
         .clone()
         .unwrap_or_else(|| config::data_dir().to_string_lossy().into_owned());
     let data_dir = canonicalize_local_path("--data-dir", &data_dir_input, working_dir)?;
-    // A user's own FASTA has no alignments, and must not borrow the examples'.
+    // Keyed on the alignments each target actually has, not on being bundled: a bundled protein
+    // with no `alignments/<id>` would otherwise borrow the directory and fold against the wrong MSA.
     let use_precomputed_alignments = args
         .use_precomputed_alignments
-        .unwrap_or_else(|| resolved.iter().all(|target| target.bundled));
+        .unwrap_or_else(|| resolved.iter().all(|target| target.example.alignments));
     let alignment_dir = if use_precomputed_alignments {
         let input = args
             .alignment_dir
@@ -2501,7 +2505,7 @@ mod tests {
 
     fn parses_install_part() {
         for (arg, want) in [
-            ("base", Part::Base),
+            ("source", Part::Source),
             ("openfold", Part::Openfold),
             ("esmfold", Part::Esmfold),
         ] {
@@ -2517,10 +2521,10 @@ mod tests {
     #[test]
     fn parses_update_part() {
         assert!(matches!(
-            Cli::try_parse_from(["vizfold", "update", "base", "--ref", "v0.1.0"])
-                .expect("update base --ref should parse")
+            Cli::try_parse_from(["vizfold", "update", "source", "--ref", "v0.1.0"])
+                .expect("update source --ref should parse")
                 .command,
-            Command::Update(UpdateArgs { part: Part::Base, r#ref: Some(at), yes: false }) if at == "v0.1.0"
+            Command::Update(UpdateArgs { part: Part::Source, r#ref: Some(at), yes: false }) if at == "v0.1.0"
         ));
         assert!(matches!(
             Cli::try_parse_from(["vizfold", "update", "openfold", "--yes"])
@@ -2536,7 +2540,7 @@ mod tests {
         assert!(Cli::try_parse_from(["vizfold", "update", "vizfold"]).is_err());
     }
 
-    /// Only base takes a ref; silently ignoring it on a backend would fake a version move.
+    /// Only source takes a ref; silently ignoring it on a backend would fake a version move.
     #[test]
     fn a_ref_on_a_backend_update_is_refused() {
         let update = |argv: &[&str]| match Cli::try_parse_from(argv).expect("argv").command {
@@ -2545,7 +2549,7 @@ mod tests {
         };
         assert!(
             super::run_update(update(&["vizfold", "update", "esmfold", "--ref", "v0.1.0"]))
-                .is_err_and(|error| format!("{error}").contains("vizfold update base"))
+                .is_err_and(|error| format!("{error}").contains("vizfold update source"))
         );
     }
 
@@ -2708,11 +2712,11 @@ mod tests {
             })
         ));
         assert!(matches!(
-            Cli::try_parse_from(["vizfold", "uninstall", "base"])
-                .expect("uninstall base should parse")
+            Cli::try_parse_from(["vizfold", "uninstall", "source"])
+                .expect("uninstall source should parse")
                 .command,
             Command::Uninstall(UninstallArgs {
-                part: Some(Part::Base),
+                part: Some(Part::Source),
                 yes: false
             })
         ));
@@ -2777,16 +2781,16 @@ mod tests {
             );
         }
         assert!(
-            super::base_paths(&prefix) == vec![config::default_src()]
+            super::source_paths(&prefix) == vec![config::default_src()]
                 || config::vizfold_src() != config::default_src(),
-            "base owns the default checkout and nothing else"
+            "source owns the default checkout and nothing else"
         );
         assert!(
-            super::base_paths(&config::default_src().join("prefix")).is_empty(),
+            super::source_paths(&config::default_src().join("prefix")).is_empty(),
             "a prefix inside the checkout keeps the checkout"
         );
         assert!(shared.contains(&config::config_file()), "config is shared");
-        // Removing the base itself once took a whole home directory with it.
+        // Removing the checkout itself once took a whole home directory with it.
         assert!(
             !shared.contains(&config::env_base()),
             "the env base is the user's; only its vizfold- entries are ours"
@@ -2825,7 +2829,7 @@ mod tests {
         std::fs::remove_dir_all(&base).ok();
     }
 
-    /// The gate table by the names it produces: `status` and base's own verbs stay off `repo`.
+    /// The gate table by the names it produces: `status` and source's own verbs stay off `source`.
     #[test]
     fn every_command_gates_on_the_prereqs_it_actually_needs() {
         let names = |argv: &[&str]| {
@@ -2838,33 +2842,33 @@ mod tests {
 
         assert_eq!(names(&["vizfold", "status"]), Vec::<&str>::new());
         assert_eq!(names(&["vizfold", "uninstall"]), Vec::<&str>::new());
-        assert_eq!(names(&["vizfold", "install", "base"]), ["core deps"]);
-        assert_eq!(names(&["vizfold", "update", "base"]), ["core deps"]);
+        assert_eq!(names(&["vizfold", "install", "source"]), ["micromamba"]);
+        assert_eq!(names(&["vizfold", "update", "source"]), ["micromamba"]);
         assert_eq!(
             names(&["vizfold", "install", "openfold"]),
-            ["core deps", "repo"]
+            ["micromamba", "source"]
         );
         assert_eq!(
             names(&["vizfold", "update", "openfold"]),
-            ["core deps", "repo"]
+            ["micromamba", "source"]
         );
-        assert_eq!(names(&["vizfold", "list", "examples"]), ["repo"]);
+        assert_eq!(names(&["vizfold", "list", "proteins"]), ["source"]);
         assert_eq!(
             names(&["vizfold", "serve"]),
-            ["core deps", "repo", "config"]
+            ["micromamba", "source", "config"]
         );
         assert_eq!(
             names(&["vizfold", "serve", "openfold", "esmfold"]),
-            ["core deps", "repo", "config", "openfold", "esmfold"]
+            ["micromamba", "source", "config", "openfold", "esmfold"]
         );
-        assert!(Cli::try_parse_from(["vizfold", "serve", "base"]).is_err());
+        assert!(Cli::try_parse_from(["vizfold", "serve", "source"]).is_err());
         assert_eq!(
             names(&["vizfold", "download", "openfold"]),
-            ["repo", "config", "openfold"]
+            ["source", "config", "openfold"]
         );
         assert_eq!(
             names(&["vizfold", "run", "1UBQ_1"]),
-            ["core deps", "repo", "config", "openfold"]
+            ["micromamba", "source", "config", "openfold"]
         );
         // `--no-exec` only writes the row, so it must not gate on an installed environment.
         assert_eq!(
@@ -2903,13 +2907,13 @@ mod tests {
             absent.problems.is_empty(),
             "absent is not a list of problems"
         );
-        assert_eq!(absent.remedy, "vizfold install base");
+        assert_eq!(absent.remedy, "vizfold install source");
         assert_ne!(
             present.state,
             State::Absent,
             "a checkout is there to be judged"
         );
-        assert_eq!(present.remedy, "vizfold update base");
+        assert_eq!(present.remedy, "vizfold update source");
     }
 
     #[test]
@@ -2980,7 +2984,7 @@ mod tests {
         };
         assert_eq!(
             super::summary(&[
-                component("binary", super::State::Ok),
+                component("cli", super::State::Ok),
                 component("esmfold", super::State::Absent),
                 component("scheduler", super::State::Unverified),
             ]),
@@ -2988,11 +2992,11 @@ mod tests {
         );
         assert_eq!(
             super::summary(&[
-                component("binary", super::State::Ok),
-                component("repo", super::State::Broken),
+                component("cli", super::State::Ok),
+                component("source", super::State::Broken),
                 component("config", super::State::Broken),
             ]),
-            "2 of 3 components need attention: repo, config."
+            "2 of 3 components need attention: source, config."
         );
     }
 
@@ -3155,8 +3159,8 @@ mod tests {
                 residues: 1,
                 description: String::new(),
                 sequence: "M".to_owned(),
+                alignments: false,
             },
-            bundled: false,
         }
     }
 
@@ -3300,8 +3304,8 @@ mod tests {
         let resolved = super::resolve_targets(&args.targets)?;
 
         assert!(
-            resolved.iter().all(|target| target.bundled),
-            "bundled examples default to their precomputed alignments"
+            resolved.iter().all(|target| target.example.alignments),
+            "bundled proteins default to their precomputed alignments"
         );
         // Not the real prefix: a submit host may have it read-only, and this test writes there.
         let inputs = std::env::temp_dir().join(format!("vizfold-batch-{}", std::process::id()));
@@ -3358,7 +3362,7 @@ mod tests {
         let resolved = super::resolve_targets(&[dir.display().to_string()]).expect("6KWC exists");
         assert_eq!(super::tags(&resolved), ["6KWC_1"]);
         assert!(
-            !resolved[0].bundled,
+            !resolved[0].example.alignments,
             "a path is the user's own, so it borrows no alignments"
         );
 

--- a/cli/src/core/config.rs
+++ b/cli/src/core/config.rs
@@ -87,15 +87,15 @@ pub fn openfold_home() -> PathBuf {
 pub const INSTALLER: &str = "backends/openfold/install/install.sh";
 
 /// Checkout holding `INSTALLER`: `OPENFOLD_HOME`, else the default clone location.
-pub fn vizfold_src() -> PathBuf {
+pub fn vizfold_repo() -> PathBuf {
     resolved("OPENFOLD_HOME")
         .map(PathBuf::from)
-        .unwrap_or_else(default_src)
+        .unwrap_or_else(default_repo)
 }
 
-/// Where `vizfold install base` clones -- the only checkout `vizfold uninstall` may delete.
-pub fn default_src() -> PathBuf {
-    PathBuf::from(format!("{}/vizfold-src", home_dir()))
+/// Where `vizfold install repo` clones -- the only checkout `vizfold uninstall` may delete.
+pub fn default_repo() -> PathBuf {
+    PathBuf::from(format!("{}/vizfold-repo", home_dir()))
 }
 
 /// The one root every OpenFold data path resolves under, weights included. Mirrors `setup::config`.
@@ -272,7 +272,7 @@ fn repository_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .parent()
         .filter(|root| root.join(INSTALLER).is_file())
-        .map_or_else(default_src, Path::to_path_buf)
+        .map_or_else(default_repo, Path::to_path_buf)
 }
 
 #[cfg(test)]

--- a/cli/src/core/examples.rs
+++ b/cli/src/core/examples.rs
@@ -1,5 +1,6 @@
-//! The bundled monomer examples: `fasta_dir_<stem>/<stem>.fasta` beside `alignments/<id>` under
-//! `<OPENFOLD_HOME>/examples/monomer`. Both must exist, or the fold falls back to a full MSA search.
+//! The bundled monomer proteins: `fasta_dir_<stem>/<stem>.fasta` under
+//! `<OPENFOLD_HOME>/examples/monomer`, with `alignments/<id>` beside it where an MSA is precomputed.
+//! One without is still foldable -- it just pays for the full MSA search.
 
 use std::path::{Path, PathBuf};
 
@@ -12,6 +13,8 @@ pub struct Example {
     /// The FASTA header's molecule-name field, empty when the header carries only an id.
     pub description: String,
     pub sequence: String,
+    /// `alignments/<id>` is there to reuse. False means folding it runs the full MSA search.
+    pub alignments: bool,
 }
 
 pub fn monomer_dir() -> PathBuf {
@@ -39,7 +42,7 @@ pub fn fasta_file(path: &Path) -> Option<PathBuf> {
     }
 }
 
-/// Every complete example in `dir`, cheapest first -- residue count is what someone chooses on.
+/// Every protein in `dir`, cheapest first -- residue count is what someone chooses on.
 pub fn scan(dir: &Path) -> Vec<Example> {
     let alignments = dir.join("alignments");
     let Ok(entries) = std::fs::read_dir(dir) else {
@@ -55,7 +58,10 @@ pub fn scan(dir: &Path) -> Vec<Example> {
         })
         .filter_map(|entry| first_fasta(&entry.path()))
         .filter_map(|fasta| parse(&std::fs::read_to_string(fasta).ok()?))
-        .filter(|example| alignments.join(&example.id).is_dir())
+        .map(|example| Example {
+            alignments: alignments.join(&example.id).is_dir(),
+            ..example
+        })
         .collect();
     found.sort_by(|a, b| a.residues.cmp(&b.residues).then_with(|| a.id.cmp(&b.id)));
     found
@@ -99,6 +105,7 @@ fn parse(text: &str) -> Option<Example> {
         id,
         description,
         sequence,
+        alignments: false, // only scan() can see the alignments dir beside the FASTA
     })
 }
 
@@ -144,6 +151,7 @@ mod tests {
                 residues: 15,
                 description: "UBIQUITIN".into(),
                 sequence: "MQIFVKTLTGKTITL".into(),
+                alignments: true,
             }]
         );
         std::fs::remove_dir_all(&dir).unwrap();
@@ -159,8 +167,10 @@ mod tests {
         std::fs::remove_dir_all(&dir).unwrap();
     }
 
+    /// Listed either way, but the flag has to be right: it is what decides whether a fold reuses
+    /// the alignments or pays for the full MSA search, and `list proteins` prints it as a column.
     #[test]
-    fn excludes_an_example_with_no_alignment_directory() {
+    fn records_whether_each_protein_has_alignments() {
         let dir = tree(
             "unaligned",
             &[
@@ -168,8 +178,14 @@ mod tests {
                 ("1UBQ", ">1UBQ_1|Chain A|UBIQUITIN\nMQIFVKTL\n", true),
             ],
         );
-        let ids: Vec<String> = scan(&dir).into_iter().map(|e| e.id).collect();
-        assert_eq!(ids, vec!["1UBQ_1"]);
+        let found: Vec<(String, bool)> = scan(&dir)
+            .into_iter()
+            .map(|e| (e.id, e.alignments))
+            .collect();
+        assert_eq!(
+            found,
+            vec![("1UBQ_1".to_owned(), true), ("2OMF_1".to_owned(), false)]
+        );
         std::fs::remove_dir_all(&dir).unwrap();
     }
 

--- a/configure.sh
+++ b/configure.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# What `vizfold install repo` runs once the checkout is there: settle which cluster this is, where
+# the install prefix goes, which AlphaFold2 mirror holds the protein databases, and what the
+# scheduler will accept -- then write all of it to ~/.config/vizfold/vizfold.json. A backend install
+# afterwards only builds its environment; without this it would have to settle the site itself.
+set -euo pipefail
+
+. "${OPENFOLD_HOME:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}/lib/slurm.sh"
+
+main() {
+    vizfold::settle_site
+    export OPENFOLD_HOME=$REPO VIZFOLD_ENV_BASE=$(vizfold::env_base)
+    # Defers to whatever is set: overwriting it would move someone's run history.
+    export VIZFOLD_DB=${VIZFOLD_DB:-$(vizfold::prefix)/vizfold.db}
+    # Recorded, so it has to exist: status reads a configured-but-absent prefix as a broken config.
+    mkdir -p "$(vizfold::env_base)"
+    config::save
+    cat <<MSG
+
+The proteins are under $REPO/examples/monomer, alignments beside them:
+
+  vizfold list proteins
+
+Then a backend to fold with: vizfold install openfold (or esmfold).
+MSG
+}
+
+# Sourced (tests/configure_repo.sh) this file is just its definitions; only an execution configures.
+[ "${BASH_SOURCE[0]}" = "$0" ] || return 0
+main "$@"

--- a/docs/esmfold.md
+++ b/docs/esmfold.md
@@ -11,7 +11,7 @@ Python 3.11, PyTorch, Transformers, the `esmfold` package) and records `ESMFOLD_
 `~/.config/vizfold/vizfold.json`.
 
 ```bash
-vizfold install base    # once per machine: the checkout the installers live in
+vizfold install source    # once per machine: the checkout the installers live in
 vizfold install esmfold
 vizfold status          # resolved config + which backends are installed
 ```

--- a/docs/esmfold.md
+++ b/docs/esmfold.md
@@ -11,7 +11,7 @@ Python 3.11, PyTorch, Transformers, the `esmfold` package) and records `ESMFOLD_
 `~/.config/vizfold/vizfold.json`.
 
 ```bash
-vizfold install src    # once per machine: the checkout the installers live in
+vizfold install repo    # once per machine: the checkout the installers live in
 vizfold install esmfold
 vizfold status          # resolved config + which backends are installed
 ```

--- a/docs/esmfold.md
+++ b/docs/esmfold.md
@@ -11,7 +11,7 @@ Python 3.11, PyTorch, Transformers, the `esmfold` package) and records `ESMFOLD_
 `~/.config/vizfold/vizfold.json`.
 
 ```bash
-vizfold install source    # once per machine: the checkout the installers live in
+vizfold install src    # once per machine: the checkout the installers live in
 vizfold install esmfold
 vizfold status          # resolved config + which backends are installed
 ```

--- a/docs/esmfold_backend_repro.md
+++ b/docs/esmfold_backend_repro.md
@@ -5,7 +5,7 @@ Verifying the ESMFold backend end to end: inference, trace extraction, and the a
 ## Environment Setup
 
 ```bash
-vizfold install base                    # the checkout the installer lives in
+vizfold install source                    # the checkout the installer lives in
 vizfold install esmfold
 vizfold status                          # prints ESMFOLD_ENV_PREFIX
 
@@ -71,7 +71,7 @@ checks the GPU, the base command, `input_id`, that the FASTA is a readable file,
 
 ```bash
 ssh <gt_username>@login-ice.pace.gatech.edu
-vizfold install base
+vizfold install source
 vizfold install esmfold
 vizfold run 6KWC_1 --backend esmfold
 ```

--- a/docs/esmfold_backend_repro.md
+++ b/docs/esmfold_backend_repro.md
@@ -5,7 +5,7 @@ Verifying the ESMFold backend end to end: inference, trace extraction, and the a
 ## Environment Setup
 
 ```bash
-vizfold install source                    # the checkout the installer lives in
+vizfold install src                    # the checkout the installer lives in
 vizfold install esmfold
 vizfold status                          # prints ESMFOLD_ENV_PREFIX
 
@@ -71,7 +71,7 @@ checks the GPU, the base command, `input_id`, that the FASTA is a readable file,
 
 ```bash
 ssh <gt_username>@login-ice.pace.gatech.edu
-vizfold install source
+vizfold install src
 vizfold install esmfold
 vizfold run 6KWC_1 --backend esmfold
 ```

--- a/docs/esmfold_backend_repro.md
+++ b/docs/esmfold_backend_repro.md
@@ -5,7 +5,7 @@ Verifying the ESMFold backend end to end: inference, trace extraction, and the a
 ## Environment Setup
 
 ```bash
-vizfold install src                    # the checkout the installer lives in
+vizfold install repo                    # the checkout the installer lives in
 vizfold install esmfold
 vizfold status                          # prints ESMFOLD_ENV_PREFIX
 
@@ -71,7 +71,7 @@ checks the GPU, the base command, `input_id`, that the FASTA is a readable file,
 
 ```bash
 ssh <gt_username>@login-ice.pace.gatech.edu
-vizfold install src
+vizfold install repo
 vizfold install esmfold
 vizfold run 6KWC_1 --backend esmfold
 ```

--- a/install.sh
+++ b/install.sh
@@ -88,7 +88,7 @@ main() {
     bootstrap::micromamba
     bootstrap::path
     bootstrap::completions
-    echo "vizfold installed at $BIN/vizfold. Run \`vizfold install src\` for the checkout, then \`vizfold install openfold\` (or \`esmfold\`)."
+    echo "vizfold installed at $BIN/vizfold. Run \`vizfold install repo\` for the checkout, then \`vizfold install openfold\` (or \`esmfold\`)."
 }
 
 # Not the backend installers' `BASH_SOURCE = $0` guard: under `curl | bash` there is no BASH_SOURCE at

--- a/install.sh
+++ b/install.sh
@@ -88,7 +88,7 @@ main() {
     bootstrap::micromamba
     bootstrap::path
     bootstrap::completions
-    echo "vizfold installed at $BIN/vizfold. Run \`vizfold install source\` for the checkout, then \`vizfold install openfold\` (or \`esmfold\`)."
+    echo "vizfold installed at $BIN/vizfold. Run \`vizfold install src\` for the checkout, then \`vizfold install openfold\` (or \`esmfold\`)."
 }
 
 # Not the backend installers' `BASH_SOURCE = $0` guard: under `curl | bash` there is no BASH_SOURCE at

--- a/install.sh
+++ b/install.sh
@@ -88,7 +88,7 @@ main() {
     bootstrap::micromamba
     bootstrap::path
     bootstrap::completions
-    echo "vizfold installed at $BIN/vizfold. Run \`vizfold install base\` for the checkout, then \`vizfold install openfold\` (or \`esmfold\`)."
+    echo "vizfold installed at $BIN/vizfold. Run \`vizfold install source\` for the checkout, then \`vizfold install openfold\` (or \`esmfold\`)."
 }
 
 # Not the backend installers' `BASH_SOURCE = $0` guard: under `curl | bash` there is no BASH_SOURCE at

--- a/tests/configure_repo.sh
+++ b/tests/configure_repo.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# What `vizfold install repo` leaves behind: a full config, a prefix that exists, and the run
+# database it was already pointed at. Run: bash tests/configure_repo.sh
+#
+# The prefix matters as much as the keys: status reads a recorded-but-absent prefix as a broken
+# config, so writing the answer without creating the directory would redden a fresh install.
+set -uo pipefail
+
+REPO=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+SANDBOX=${TMPDIR:-/tmp}/vizfold-configure-$$
+trap 'rm -rf "$SANDBOX"' EXIT
+fail=0
+mkdir -p "$SANDBOX"
+
+run() { # $1... extra env
+    rm -rf "$SANDBOX/pfx" "$SANDBOX/config.json"
+    env OPENFOLD_HOME="$REPO" VIZFOLD_CONFIG="$SANDBOX/config.json" OPENFOLD_SITE=local \
+        OPENFOLD_PREFIX="$SANDBOX/pfx" "$@" bash "$REPO/configure.sh" >/dev/null 2>&1
+}
+
+check() { if [ "$2" = "$3" ]; then echo "ok   $1"; else
+    echo "FAIL $1"; echo "  want $3"; echo "  got  $2"; fail=1; fi; }
+
+run
+keys=$(python3 -c 'import json,sys; print(len(json.load(open(sys.argv[1]))))' "$SANDBOX/config.json" 2>/dev/null)
+check "the config carries the whole 19-key schema" "$keys" "19"
+check "the recorded prefix exists" "$([ -d "$SANDBOX/pfx/envs" ] && echo yes || echo no)" "yes"
+
+get() { python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get(sys.argv[2],""))' "$SANDBOX/config.json" "$1"; }
+check "OPENFOLD_HOME is the checkout that ran it" "$(get OPENFOLD_HOME)" "$REPO"
+check "VIZFOLD_DB defaults under the prefix" "$(get VIZFOLD_DB)" "$SANDBOX/pfx/vizfold.db"
+
+# A second install must not move someone's run history.
+run VIZFOLD_DB="$SANDBOX/mine.db"
+check "an existing VIZFOLD_DB is left alone" "$(get VIZFOLD_DB)" "$SANDBOX/mine.db"
+
+exit $fail

--- a/workbench/README.md
+++ b/workbench/README.md
@@ -1,7 +1,7 @@
 # VizFold Workbench
 
 Next.js dashboard for the vizfold executor. Reads the executor's SQLite read-only via `node:sqlite`
-and shells out to the `vizfold` binary (`list proteins`, `run <id> --no-exec`, `run <id>`).
+and shells out to the `vizfold` binary (`list proteins`, `run <proteins…> --no-exec`, `run <id>`).
 
 ## Running it
 

--- a/workbench/README.md
+++ b/workbench/README.md
@@ -1,7 +1,7 @@
 # VizFold Workbench
 
 Next.js dashboard for the vizfold executor. Reads the executor's SQLite read-only via `node:sqlite`
-and shells out to the `vizfold` binary (`list examples`, `run <id> --no-exec`, `run <id>`).
+and shells out to the `vizfold` binary (`list proteins`, `run <id> --no-exec`, `run <id>`).
 
 ## Running it
 

--- a/workbench/app/FoldCard.tsx
+++ b/workbench/app/FoldCard.tsx
@@ -2,33 +2,46 @@
 
 import { useRouter } from "next/navigation";
 import { useState } from "react";
-import type { Example } from "@/lib/vizfold";
+import type { Protein } from "@/lib/vizfold";
 
 export default function FoldCard({
-  examples,
+  proteins,
   backends,
 }: {
-  examples: Example[];
+  proteins: Protein[];
   backends: string[];
 }) {
   const router = useRouter();
-  const [inputId, setInputId] = useState(examples[0]?.id ?? "");
+  const [selected, setSelected] = useState<string[]>([]);
   const [backend, setBackend] = useState(backends[0] ?? "");
   const [attn, setAttn] = useState(true);
   const [folding, setFolding] = useState(false);
   const [error, setError] = useState("");
 
-  if (examples.length === 0) {
+  // ESMFold folds one target per run; OpenFold takes the whole selection in one execution.
+  const single = backend === "esmfold";
+
+  if (proteins.length === 0) {
     return (
       <section className="panel">
         <div className="panel-header">
-          <h2>Fold a protein</h2>
+          <h2>Fold proteins</h2>
         </div>
         <p className="field-note">
-          No examples found. They come from <code>examples/monomer</code> in the VizFold checkout —
-          run <code>vizfold install openfold</code>, then reload.
+          No proteins found. They come from <code>examples/monomer</code> in the VizFold checkout —
+          run <code>vizfold install repo</code>, then reload.
         </p>
       </section>
+    );
+  }
+
+  function toggle(id: string) {
+    setSelected((current) =>
+      single
+        ? [id]
+        : current.includes(id)
+          ? current.filter((one) => one !== id)
+          : [...current, id],
     );
   }
 
@@ -40,7 +53,7 @@ export default function FoldCard({
       const response = await fetch("/api/runs", {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ inputId, attn, backend }),
+        body: JSON.stringify({ ids: selected, attn, backend }),
       });
       const body = await response.json();
       if (!response.ok) throw new Error(body.error ?? "Could not start the fold.");
@@ -54,34 +67,50 @@ export default function FoldCard({
   return (
     <section className="panel">
       <div className="panel-header">
-        <h2>Fold a protein</h2>
-        <p>Bundled examples fold in about a minute — their alignments are precomputed.</p>
+        <h2>Fold proteins</h2>
+        <p>
+          {single
+            ? "ESMFold folds one at a time, so pick one. Alignments Y"
+            : "Pick one or more — they fold as a single run, with the model loaded once. Alignments Y"}
+          means they are precomputed and the fold takes about a minute; N pays for the full MSA
+          search.
+        </p>
       </div>
 
       <form className="run-form" onSubmit={fold}>
-        <label className="field">
-          <span>Protein</span>
-          <select
-            value={inputId}
-            onChange={(event) => setInputId(event.target.value)}
-            disabled={folding}
-          >
-            {examples.map((example) => (
-              <option key={example.id} value={example.id}>
-                {example.id}
-                {example.description ? ` — ${example.description}` : ""} ({example.residues}{" "}
-                residues)
-              </option>
+        <div className="field">
+          <span>Proteins</span>
+          <ul className="picker">
+            {proteins.map((protein) => (
+              <li key={protein.id}>
+                <label>
+                  <input
+                    type="checkbox"
+                    checked={selected.includes(protein.id)}
+                    onChange={() => toggle(protein.id)}
+                    disabled={folding}
+                  />
+                  <strong>{protein.id}</strong>
+                  <span className="tag">{protein.residues} residues</span>
+                  <span className={protein.alignments ? "tag tag-on" : "tag"}>
+                    alignments {protein.alignments ? "Y" : "N"}
+                  </span>
+                  <span className="note">{protein.description}</span>
+                </label>
+              </li>
             ))}
-          </select>
-        </label>
+          </ul>
+        </div>
 
         {backends.length > 1 ? (
           <label className="field">
             <span>Model</span>
             <select
               value={backend}
-              onChange={(event) => setBackend(event.target.value)}
+              onChange={(event) => {
+                setBackend(event.target.value);
+                if (event.target.value === "esmfold") setSelected((current) => current.slice(0, 1));
+              }}
               disabled={folding}
             >
               {backends.map((slug) => (
@@ -110,8 +139,8 @@ export default function FoldCard({
 
         {error ? <p className="field-note">{error}</p> : null}
 
-        <button className="primary-button" type="submit" disabled={folding}>
-          {folding ? "Starting…" : "Fold"}
+        <button className="primary-button" type="submit" disabled={folding || selected.length === 0}>
+          {folding ? "Starting…" : selected.length > 1 ? `Fold ${selected.length} proteins` : "Fold"}
         </button>
       </form>
     </section>

--- a/workbench/app/api/runs/route.ts
+++ b/workbench/app/api/runs/route.ts
@@ -1,14 +1,24 @@
 import { NextResponse } from "next/server";
-import { BACKENDS, foldInBackground, listExamples, queueRun } from "@/lib/vizfold";
+import { BACKENDS, foldInBackground, listProteins, queueRun } from "@/lib/vizfold";
 
 export async function POST(request: Request) {
-  const { inputId, attn = true, backend = "" } = await request.json();
+  const { ids, attn = true, backend = "" } = await request.json();
 
-  // Trust boundary: only an id the CLI itself listed is ever handed back to it.
-  const example = (await listExamples()).find((one) => one.id === inputId);
-  if (!example) {
+  // Trust boundary: only ids the CLI itself listed are ever handed back to it.
+  const known = new Set((await listProteins()).map((protein) => protein.id));
+  const wanted: unknown[] = Array.isArray(ids) ? ids : [];
+  const picked = wanted.filter((id): id is string => typeof id === "string" && known.has(id));
+  if (picked.length === 0 || picked.length !== wanted.length) {
     return NextResponse.json(
-      { error: `Unknown example "${inputId}".` },
+      { error: "Pick one or more listed proteins." },
+      { status: 400 },
+    );
+  }
+  // Serving nothing means nothing can fold; an unnamed backend would otherwise fall through to
+  // the CLI's default, which is exactly the backend `serve` found no installation of.
+  if (BACKENDS?.length === 0) {
+    return NextResponse.json(
+      { error: "No backend is being served." },
       { status: 400 },
     );
   }
@@ -21,7 +31,7 @@ export async function POST(request: Request) {
   }
 
   try {
-    const runId = await queueRun(example, Boolean(attn), backend);
+    const runId = await queueRun(picked, Boolean(attn), backend);
     foldInBackground(runId);
     return NextResponse.json({ runId }, { status: 201 });
   } catch (error) {

--- a/workbench/app/globals.css
+++ b/workbench/app/globals.css
@@ -325,6 +325,71 @@ textarea {
   color: #fff;
 }
 
+.hero-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 28px;
+  margin: 20px 0 0;
+}
+
+.hero-stats dt {
+  color: var(--text-soft);
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.hero-stats dd {
+  margin: 4px 0 0;
+  font-weight: 700;
+}
+
+.picker {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 6px;
+}
+
+.picker label {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--surface-muted);
+  cursor: pointer;
+}
+
+/* Two classes each: `.field span` is bold and would otherwise win. */
+.picker .tag {
+  padding: 2px 8px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--surface);
+  color: var(--text-soft);
+  font-size: 0.78rem;
+}
+
+.picker .tag-on {
+  border-color: #bfe6cd;
+  background: #e2f5e9;
+  color: #1a7f43;
+}
+
+.picker .note {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-soft);
+  font-weight: 400;
+  font-size: 0.9rem;
+}
+
 @media (max-width: 900px) {
   .page-shell {
     padding-inline: 16px;

--- a/workbench/app/page.tsx
+++ b/workbench/app/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { listRuns } from "@/lib/db";
-import { FOLDABLE, listExamples } from "@/lib/vizfold";
+import { FOLDABLE, listProteins } from "@/lib/vizfold";
 import FoldCard from "@/app/FoldCard";
 import Poller from "@/app/Poller";
 
@@ -11,7 +11,11 @@ export default async function HomePage() {
   const runs = listRuns();
   // Past runs stay browsable when the CLI is unreachable: an empty picker explains itself, a 500
   // does not.
-  const examples = await listExamples().catch(() => []);
+  const proteins = await listProteins().catch(() => []);
+  // A batch run records its tags joined with `+`, so one row can carry several proteins.
+  const folded = new Set(
+    runs.filter((run) => run.status === "completed").flatMap((run) => run.input_id.split("+")),
+  );
 
   return (
     <main className="page-shell">
@@ -24,9 +28,23 @@ export default async function HomePage() {
             attention behind it.
           </p>
         </div>
+        <dl className="hero-stats">
+          <div>
+            <dt>Serving</dt>
+            <dd>{FOLDABLE.join(", ") || "no backend"}</dd>
+          </div>
+          <div>
+            <dt>Folded</dt>
+            <dd>{folded.size}</dd>
+          </div>
+          <div>
+            <dt>Available to fold</dt>
+            <dd>{proteins.length}</dd>
+          </div>
+        </dl>
       </section>
 
-      <FoldCard examples={examples} backends={FOLDABLE} />
+      <FoldCard proteins={proteins} backends={FOLDABLE} />
 
       <section className="panel">
         <div className="panel-header">
@@ -39,14 +57,14 @@ export default async function HomePage() {
         {runs.length === 0 ? (
           <div className="empty-state">
             <p>No runs yet.</p>
-            <p>Pick a protein above and hit Fold.</p>
+            <p>Pick one or more proteins above and hit Fold.</p>
           </div>
         ) : (
           <table className="runs-table">
             <thead>
               <tr>
                 <th>#</th>
-                <th>Input</th>
+                <th>Proteins</th>
                 <th>Model</th>
                 <th>Target</th>
                 <th>Status</th>
@@ -60,7 +78,7 @@ export default async function HomePage() {
                     <Link href={`/runs/${run.id}`}>{run.id}</Link>
                   </td>
                   <td>
-                    <Link href={`/runs/${run.id}`}>{run.input_id}</Link>
+                    <Link href={`/runs/${run.id}`}>{run.input_id.split("+").join(", ")}</Link>
                   </td>
                   <td>{run.model_slug}</td>
                   <td>{run.target_slug}</td>

--- a/workbench/app/runs/[runId]/page.tsx
+++ b/workbench/app/runs/[runId]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from "next/navigation";
 import path from "node:path";
 import { readdirSync } from "node:fs";
 import { getRun, listArtifacts, type ArtifactRow } from "@/lib/db";
+import { RUNS_DIR } from "@/lib/vizfold";
 import StructureViewer from "@/app/StructureViewer";
 import Poller from "@/app/Poller";
 
@@ -57,8 +58,26 @@ export default async function RunPage({
   if (!run) notFound();
 
   const artifacts = listArtifacts(id);
-  const own = runRoot(artifacts, id);
-  const runsRoot = own ? path.dirname(own) : null;
+  // Artifacts register only once the run lands, so fall back to where the executor is writing —
+  // structures show up per protein while the fold is still going.
+  const own = runRoot(artifacts, id) ?? path.join(RUNS_DIR, String(id));
+  const runsRoot = path.dirname(own);
+  const structures = browse(own, runsRoot).filter((file) => file.isStructure);
+
+  // A batch writes one structure per FASTA tag, and the run records those tags joined with `+`.
+  // The tag ends at `_model_`: a bare prefix test would give 1G1J_1 every 1G1J_10 file too.
+  const tagOf = (name: string) => name.split("_model_")[0];
+
+  const tags = run.input_id.split("+");
+  const folds = tags.map((tag) => {
+    // A lone target owns every file: ESMFold writes `structure/predicted.pdb`, without the tag.
+    const landed =
+      tags.length === 1
+        ? structures
+        : structures.filter((file) => tagOf(path.basename(file.name)) === tag);
+    // The relaxed structure is the one to look at; the rest stay linked under Artifacts.
+    return { tag, file: landed.find((file) => !file.name.includes("unrelaxed")) ?? landed[0] };
+  });
 
   return (
     <main className="page-shell">
@@ -69,7 +88,7 @@ export default async function RunPage({
             <Link href="/">← All runs</Link>
           </p>
           <h1 className="brand-title">Run {run.id}</h1>
-          <p className="subtitle">{run.input_id}</p>
+          <p className="subtitle">{tags.join(", ")}</p>
         </div>
       </section>
 
@@ -92,6 +111,31 @@ export default async function RunPage({
 
       <section className="panel">
         <div className="panel-header">
+          <h2>Structures</h2>
+          <p>
+            {folds.filter((fold) => fold.file).length} of {tags.length} landed.
+          </p>
+        </div>
+
+        {folds.map((fold) => (
+          <div key={fold.tag} className="artifact-block">
+            <h3>
+              {fold.tag}{" "}
+              <span className="field-note">
+                {fold.file
+                  ? fold.file.name
+                  : run.status === "failed"
+                    ? "no structure written"
+                    : "folding…"}
+              </span>
+            </h3>
+            {fold.file ? <StructureViewer url={fold.file.url} name={fold.file.name} /> : null}
+          </div>
+        ))}
+      </section>
+
+      <section className="panel">
+        <div className="panel-header">
           <h2>Artifacts</h2>
           <p>
             {artifacts.length} registered.
@@ -101,13 +145,13 @@ export default async function RunPage({
         {artifacts.length === 0 ? (
           <div className="empty-state">
             <p>No artifacts registered for this run.</p>
+            <p>They register when the run lands.</p>
           </div>
         ) : (
           artifacts.map((artifact) => {
             // A file artifact is just a one-entry listing, so both kinds render the same way.
-            const files = !runsRoot
-              ? []
-              : artifact.format === "directory"
+            const files =
+              artifact.format === "directory"
                 ? browse(artifact.storage_uri, runsRoot)
                 : [entry(artifact.storage_uri, runsRoot)];
             return (
@@ -132,9 +176,6 @@ export default async function RunPage({
                           ) : null}
                           {file.name}
                         </a>
-                        {file.isStructure ? (
-                          <StructureViewer url={file.url} name={file.name} />
-                        ) : null}
                       </li>
                     ))}
                   </ul>

--- a/workbench/lib/vizfold.ts
+++ b/workbench/lib/vizfold.ts
@@ -17,45 +17,49 @@ export const BACKENDS: string[] | null =
  *  uninstalled one. */
 export const FOLDABLE = BACKENDS ?? ["openfold", "esmfold"];
 
+/** Where the executor writes each run: `<RUNS_DIR>/<run id>`, alongside its submit log. */
+export const RUNS_DIR = `${PREFIX}/runs`;
+
 const run = promisify(execFile);
 
-export type Example = {
+export type Protein = {
   id: string;
   residues: number;
   description: string;
   sequence: string;
+  /** `alignments/<id>` is there to reuse; false pays for the full MSA search. */
+  alignments: boolean;
 };
 
-export async function listExamples(): Promise<Example[]> {
-  const { stdout } = await run(BIN, ["list", "examples", "--json"]);
+export async function listProteins(): Promise<Protein[]> {
+  const { stdout } = await run(BIN, ["list", "proteins", "--json"]);
   return JSON.parse(stdout);
 }
 
-/** `--no-exec` writes only the run row, so this is near-instant. */
+/** One run for the whole selection — the CLI folds every target in a single execution, with the
+ *  model loaded once. `--no-exec` writes only the run row, so this is near-instant. */
 export async function queueRun(
-  example: Example,
+  ids: string[],
   attn: boolean,
   backend?: string,
 ): Promise<number> {
-  // --attn takes a value and defaults to true, so pass it either way; the CLI reads the id and
-  // sequence out of the example's FASTA itself.
-  const args = ["run", example.id, `--attn=${attn}`, "--no-exec"];
+  // --attn takes a value and defaults to true, so pass it either way; the CLI reads each id's
+  // sequence out of its FASTA itself.
+  const args = ["run", ...ids, `--attn=${attn}`, "--no-exec", "--json"];
   if (backend) args.push("--backend", backend);
   const { stdout } = await run(BIN, args);
-  // Each backend queues under its own label — match the line's shape, not the name in it.
-  const id = stdout.match(/Queued \S+ run (\d+)/)?.[1];
-  if (!id) throw new Error(`no run id in run output: ${stdout.trim()}`);
-  return Number(id);
+  const { run_id: id } = JSON.parse(stdout);
+  if (typeof id !== "number") throw new Error(`no run id in run output: ${stdout.trim()}`);
+  return id;
 }
 
 /** Detached: a fold runs for minutes, far longer than a request may be held open. The page polls
  *  from there, and `fold` registers the artifacts itself once it lands. */
 export function foldInBackground(runId: number): void {
-  // Unset, `${PREFIX}/runs` is "/runs" — mkdir at the filesystem root, after the row is written.
+  // Unset, RUNS_DIR is "/runs" — mkdir at the filesystem root, after the row is written.
   if (!PREFIX) throw new Error("OPENFOLD_PREFIX is unset; start the dashboard with `vizfold serve`");
-  const logs = `${PREFIX}/runs`;
-  mkdirSync(logs, { recursive: true });
-  const log = openSync(`${logs}/${runId}.submit.log`, "a");
+  mkdirSync(RUNS_DIR, { recursive: true });
+  const log = openSync(`${RUNS_DIR}/${runId}.submit.log`, "a");
   const child = spawn(BIN, ["run", String(runId)], {
     detached: true,
     stdio: ["ignore", log, log],


### PR DESCRIPTION
Reshapes the CLI and dashboard around the PEARC26 workshop script, where everything now happens
inside the CS Bridge session rather than beforehand on a login node.

## Naming

`base` → `repo`. The status component and the internals (`config::vizfold_repo`, `default_repo`)
already used that word, so the user-facing name and the code now agree, and the clone moves from
`~/vizfold-src` to `~/vizfold-repo`.

`vizfold status` reports **micromamba, cli, repo, config, openfold, esmfold, scheduler**.

`vizfold list examples` → **`vizfold list proteins`**, with an `ALIGNMENTS` column:

```
ID      RESIDUES  ALIGNMENTS  DESCRIPTION
1G1J_1  43        Y           NON-STRUCTURAL GLYCOPROTEIN NSP4
6KWC_1  191       N
```

That column forced a real behaviour change. `scan()` was *excluding* any protein without
`alignments/<id>`, so the column would have read `Y` forever. They are now listed, which makes
bundled-ness the wrong key for `--use-precomputed-alignments` — a bundled protein with no alignments
would have borrowed the directory and folded against the wrong MSA. The default now follows the
alignments each target actually has, and `Target::bundled` went with it.

## `install repo` owns the configuration

New `configure.sh`, run after the clone: settle the site, then write all 19 keys — cluster, install
prefix, the AlphaFold2 mirror holding the protein databases, and what the scheduler takes. It also
creates the prefix it records, since `status` reads a recorded-but-absent prefix as a broken config.

```
$ vizfold install repo          # then, with no backend installed at all:
micromamba  ok      …
cli         ok      0.9.0 (latest)
repo        ok      …
config      ok      19 keys
openfold    absent  not installed (…)
```

A backend install now only builds its environment. The `config` remedy names `vizfold install repo`
rather than `vizfold install <backend>`, because that is what writes it.

Installing a backend already gated on the checkout; that gate now reads
`repo: no checkout at <path>` → `vizfold install repo`.

## Dashboard

A header strip of **Serving / Folded / Available to fold**; a checkbox picker over the registered
proteins showing each one's residues and `alignments Y|N`; one `vizfold run a b c` per selection
(one execution, model loaded once — not a loop); and a per-protein viewer that fills in as each
structure lands, with an "N of M landed" count.

No upload and no path entry — the dashboard folds proteins already registered with vizfold.
Picking ESMFold collapses the selection to one, because the CLI rejects a batch there
(`ESMFold folds one target at a time`), verified rather than assumed.

## Defects found by review, and fixed

- **Bare `vizfold uninstall` printed "Kept: … the vizfold checkout" while removing it** — `repo` is a
  part, so the bare path takes it. The message was the wrong half; it no longer claims that.
- **Per-protein structures cross-matched tag prefixes.** `startsWith(tag)` gave `1G1J_1` every file
  belonging to `1G1J_10`. Now matched on the tag boundary (`_model_`).
- **A dashboard serving no backend could still submit a fold.** With `VIZFOLD_BACKENDS` set-empty the
  client's default `backend: ""` is falsy, so the served-backend guard was skipped and the CLI's own
  default backend took the run — the very backend `serve` found no installation of.
- Stale `install base` in a `config.rs` doc comment.

## Test plan

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` (0), `cargo test` (140).
- `bash -n` over every tracked script; `launch_args`, `site_config`, `vocabulary`, `link_mirror`,
  `esmfold_env`, `install_rc`, and **`configure_repo.sh`** (new, in `install_tests.yml`): 5
  assertions over what `install repo` leaves behind — the 19-key config, a prefix that exists,
  `OPENFOLD_HOME` pointing at the checkout that ran it, and an existing `VIZFOLD_DB` left alone so a
  reinstall cannot move someone's run history. Both mutations tried are caught (dropping the
  `mkdir`, clobbering `VIZFOLD_DB`).
- Dashboard verified against a real `next dev` server with a fabricated half-landed batch: header
  reads `Serving openfold, esmfold / Folded 2 / Available to fold 5`; `/runs/3` shows `1 of 2
  landed` with exactly one canvas; `POST /api/runs` returns 201 for a valid selection and 400 for
  `../etc/passwd`, `[]`, and an unserved backend. `tsc --noEmit` clean under `strict`.
- `vizfold list proteins` re-checked with two `alignments/` directories removed: those rows read `N`,
  and `--json` carries `alignments: false`.
