### PR TITLE
Bump version to 0.10.0

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "executor"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "executor"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 default-run = "vizfold"
 


### PR DESCRIPTION
Minor, not patch: `base` became `repo`, `list examples` became `list proteins`, the `status`
component names changed, and the clone moved to `~/vizfold-repo`.

Ships #152.