### PR TITLE
Link `-lcuda` against the toolkit stub, not a driver symlink that may not exist

### DIFF
--- a/.github/workflows/install_tests.yml
+++ b/.github/workflows/install_tests.yml
@@ -18,3 +18,4 @@ jobs:
       - run: bash tests/esmfold_env.sh
       - run: bash tests/install_rc.sh
       - run: bash tests/configure_repo.sh
+      - run: bash tests/libcuda_stub.sh

--- a/backends/openfold/install/setup.sh
+++ b/backends/openfold/install/setup.sh
@@ -59,17 +59,31 @@ setup::env() {
     micromamba create -y --no-rc -p "$ENV_DIR" -f "$ENV_YML" "cuda-version<=$MAX_CUDA"
 }
 
+# `-lcuda` names the driver, which installs only libcuda.so.1 -- nothing a linker can resolve. The
+# toolkit's stub supplies the missing .so, and carries SONAME libcuda.so.1, so anything linked
+# against it still loads the real driver. Triton needs this when it builds its cuda_utils shim,
+# which it does on the first fold as well as during verify.
+setup::libcuda_stubs() {
+    local stub
+    for stub in "$CONDA_PREFIX"/lib/stubs/libcuda.so "$CONDA_PREFIX"/targets/*/lib/stubs/libcuda.so; do
+        [ -e "$stub" ] && { dirname "$stub"; return; }
+    done
+}
+
 # activate.d is the one place a fold's runtime variables come from; `micromamba run -p` applies it.
 setup::activate() {
     log activate
     mamba::activate "$ENV_DIR"
     mkdir -p "$CONDA_PREFIX/etc/conda/activate.d"
+    # Link time only. On LD_LIBRARY_PATH the stub would shadow the real driver and every fold would
+    # come up with no GPU, which is a far quieter failure than the link error it fixes.
+    local stubs; stubs=$(setup::libcuda_stubs)
     cat > "$CONDA_PREFIX/etc/conda/activate.d/openfold.sh" <<ACTIVATE
 export CUTLASS_PATH=$CUTLASS
 export KMP_AFFINITY=none
 export OPENFOLD_DATA_DIR=$DATA
 export TRITON_CACHE_DIR=\${TRITON_CACHE_DIR:-/tmp/vizfold-triton-\$(id -u)}
-export LIBRARY_PATH=\$CONDA_PREFIX/lib:\${LIBRARY_PATH:-}
+export LIBRARY_PATH=\$CONDA_PREFIX/lib${stubs:+:$stubs}:\${LIBRARY_PATH:-}
 export LD_LIBRARY_PATH=\$CONDA_PREFIX/lib:\${LD_LIBRARY_PATH:-}
 ACTIVATE
     . "$CONDA_PREFIX/etc/conda/activate.d/openfold.sh"

--- a/tests/libcuda_stub.sh
+++ b/tests/libcuda_stub.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Where the CUDA driver stub goes, and where it must not. Run: bash tests/libcuda_stub.sh
+#
+# Triton links `-lcuda` when it JITs its cuda_utils shim. The driver installs only libcuda.so.1, so
+# on a node without the .so dev symlink the link fails and every fold dies before it starts. The
+# stub fixes it -- but only on LIBRARY_PATH. On LD_LIBRARY_PATH it would load ahead of the real
+# driver and the GPU would silently disappear, which is the worse bug of the two.
+set -uo pipefail
+
+REPO=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd); export REPO OPENFOLD_HOME=$REPO
+SANDBOX=${TMPDIR:-/tmp}/vizfold-libcuda-$$
+trap 'rm -rf "$SANDBOX"' EXIT
+fail=0
+
+VIZFOLD_CONFIG=/nonexistent/vizfold-test.json; export VIZFOLD_CONFIG
+. "$REPO/backends/openfold/install/setup.sh"
+set +e                                        # the installer's own set -e, not this harness's
+log() { :; }
+mamba::activate() { :; }                      # no micromamba in CI; CONDA_PREFIX is set per case
+
+# $1 case name, $2 relative path to plant the stub at (empty: plant none)
+plant() {
+    CASE=$1
+    rm -rf "$SANDBOX"; mkdir -p "$SANDBOX/lib"
+    export CONDA_PREFIX=$SANDBOX ENV_DIR=$SANDBOX CUTLASS=$SANDBOX/cutlass DATA=$SANDBOX/data
+    [ -n "$2" ] && { mkdir -p "$SANDBOX/$(dirname "$2")"; : > "$SANDBOX/$2"; }
+    setup::activate
+    RC=$SANDBOX/etc/conda/activate.d/openfold.sh
+}
+
+check() { if [ "$2" = "$3" ]; then echo "ok   $4"; else
+    echo "FAIL [$CASE] $4"; echo "  want $3"; echo "  got  $2"; fail=1; fi; }
+
+line() { grep -m1 "^export $1=" "$RC" | sed "s/^export $1=//"; }
+
+plant symlinked lib/stubs/libcuda.so
+check . "$(setup::libcuda_stubs)" "$SANDBOX/lib/stubs" "the stub beside lib/ is found"
+case "$(line LIBRARY_PATH)" in *"$SANDBOX/lib/stubs"*) echo "ok   and lands on LIBRARY_PATH";;
+    *) echo "FAIL [$CASE] the stub is not on LIBRARY_PATH"; fail=1;; esac
+
+# The arch dir is not always x86_64: DeltaAI is aarch64, and only the glob finds it there.
+plant arch-nested targets/sbsa-linux/lib/stubs/libcuda.so
+check . "$(setup::libcuda_stubs)" "$SANDBOX/targets/sbsa-linux/lib/stubs" "a targets/<arch>/ stub is found too"
+
+plant absent ""
+check . "$(setup::libcuda_stubs)" "" "no stub, no path"
+check . "$(line LIBRARY_PATH)" '$CONDA_PREFIX/lib:${LIBRARY_PATH:-}' "and LIBRARY_PATH keeps its shape"
+
+# The one that matters: loading the stub would cost the GPU, quietly.
+plant never-runtime lib/stubs/libcuda.so
+case "$(line LD_LIBRARY_PATH)" in *stubs*)
+      echo "FAIL [$CASE] the stub reached LD_LIBRARY_PATH; folds would lose the GPU"; fail=1;;
+    *) echo "ok   and never reaches LD_LIBRARY_PATH";; esac
+
+exit $fail


### PR DESCRIPTION
`vizfold install openfold` on Nexus completed the whole build and then died in `verify`:

```
/usr/bin/ld: cannot find -lcuda
collect2: error: ld returned 1 exit status
  File ".../triton/backends/nvidia/driver.py", line 80, in __init__
    mod = compile_module_from_src(... "cuda_utils")
```

## Cause

Triton JIT-compiles a small `cuda_utils` shim the first time it is imported — which openfold
triggers via `primitives.py` → `deepspeed.ops` → triton — and links it with `-lcuda`.

`-lcuda` is the **driver**, not the toolkit. The driver installs `libcuda.so.1`; the unversioned
`libcuda.so` a linker needs is a development symlink that a compute node may simply not have. The
link ran with `-L/lib64` (where ldconfig found `libcuda.so.1`) and `LIBRARY_PATH=$CONDA_PREFIX/lib`,
and neither holds a `libcuda.so`.

**Why this never showed up on Delta:** Delta's nodes ship the symlink.

```
$ ls -l /usr/lib64/libcuda.so*                       # Delta
libcuda.so   -> libcuda.so.570.148.08                # ← present, so `-lcuda` resolves
libcuda.so.1 -> libcuda.so.570.148.08
```

Nexus's `xl1` has only the versioned one, so the same install fails there. Every fold would have hit
it too — the shim is built lazily on first use, and `verify` was simply the first use.

## Fix

conda-forge's `cuda-driver-dev` — already in the environment — ships the missing `.so` as a stub:

```
$ENV/lib/stubs/libcuda.so -> ../../targets/x86_64-linux/lib/stubs/libcuda.so
$ objdump -p .../stubs/libcuda.so | grep SONAME
  SONAME               libcuda.so.1
```

That SONAME is the point: linking against the stub produces a binary that loads the **real** driver
at run time. Verified on Delta with the system path excluded:

```
$ gcc t.c -o t -L"$ENV/lib/stubs" -lcuda      # link: OK
$ objdump -p t | grep NEEDED.*cuda
  NEEDED               libcuda.so.1                  # ← the driver, not the stub
```

`setup::activate` now puts that directory on **`LIBRARY_PATH` only**, resolved by glob so it works
on `targets/sbsa-linux` (DeltaAI, aarch64) as well as `x86_64-linux`.

**Not `LD_LIBRARY_PATH`.** The stub is a link-time artifact with no implementation; loading it ahead
of the real driver would leave every fold reporting no GPU — a far quieter failure than the link
error it fixes. The test asserts this explicitly.

## Test plan

- `tests/libcuda_stub.sh` (new, in `install_tests.yml`), 6 assertions: the stub is found at
  `lib/stubs`, found at `targets/<arch>/lib/stubs` under a non-x86 arch name, absent without one,
  lands on `LIBRARY_PATH`, leaves `LIBRARY_PATH` well-formed when there is no stub, and **never**
  reaches `LD_LIBRARY_PATH`. All three mutations tried are caught: dropping the stub from
  `LIBRARY_PATH`, adding it to `LD_LIBRARY_PATH`, and dropping the `targets/*` glob.
- `bash -n` over every tracked script; `launch_args`, `site_config`, `vocabulary`, `link_mirror`,
  `esmfold_env`, `install_rc`, `configure_repo`. `cargo test` (140).

Not reproduced end to end on Nexus — I have no account there. The diagnosis and the fix are both
verified against a real cluster environment on Delta as shown above.
