### PR TITLE
Provision the dashboard in `install repo`, not on first `serve`

### DIFF
--- a/DEMO.md
+++ b/DEMO.md
@@ -202,7 +202,8 @@ ID  TYPE ID  FORMAT     STORAGE URI
 vizfold serve            # every installed backend; name them to serve a subset
 ```
 
-This stages and starts the Next.js workbench (installing its dependencies on first run) at
+This starts the Next.js workbench — `vizfold install repo` staged it and installed its
+dependencies — at
 `http://localhost:3000`, linking `$OPENFOLD_PREFIX/runs` under the app's `public/` so the browser
 can load each run's outputs. The dashboard renders the predicted structure in an interactive 3D
 viewer and shows the attention maps. It folds with, and lists runs from, the backends it serves —

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ vizfold install openfold
 ```
 
 The binary ships only itself, so `install repo` clones the matching checkout to `$HOME/vizfold-repo`
-for the installer scripts, the bundled proteins and the dashboard. It then settles the site and
+for the installer scripts, the bundled proteins and the dashboard, and provisions the dashboard's
+Node environment and dependencies so `serve` starts rather than installs. It then settles the site and
 writes `~/.config/vizfold/vizfold.json` — which cluster, which prefix, which AlphaFold2 mirror holds
 the protein databases, what the scheduler takes — so `status` reads `config ok` before any backend is
 installed, and a backend install only has to build its environment. Nothing clones as a side effect:

--- a/cli/src/adapters/cli.rs
+++ b/cli/src/adapters/cli.rs
@@ -561,7 +561,25 @@ fn install_repo() -> Result<(), DbErr> {
         std::process::Command::new("bash")
             .arg(repo.join(CONFIGURE))
             .env("OPENFOLD_HOME", &repo),
-    )
+    )?;
+    // The dashboard too, so `serve` starts rather than provisioning: on a cluster that is a Node
+    // environment and an npm install, minutes of it, and `serve` is run when someone wants to look.
+    ensure_dashboard(&serve_dir()?, "")?;
+    Ok(())
+}
+
+/// Stage the dashboard, provision Node, and install its dependencies. Idempotent, and the reason
+/// `serve` still calls it: an install that predates the dashboard, or a cleared prefix, self-heals.
+fn ensure_dashboard(workbench: &Path, backends: &str) -> Result<PathBuf, DbErr> {
+    let node_bin = ensure_node()?;
+    let node_modules = workbench.join("node_modules");
+    let empty =
+        std::fs::read_dir(&node_modules).map_or(true, |mut entries| entries.next().is_none());
+    if empty {
+        println!("Installing workbench dependencies (npm install)...");
+        run_npm(workbench, &node_bin, &["install"], backends)?;
+    }
+    Ok(node_bin)
 }
 
 /// Settles the site and writes the config; `install repo` owns both.
@@ -1496,17 +1514,8 @@ fn run_serve(args: ServeArgs) -> Result<(), DbErr> {
         }
     }
 
-    let node_bin = ensure_node()?;
-
     let backends = args.backends_env();
-
-    let node_modules = workbench.join("node_modules");
-    let empty =
-        std::fs::read_dir(&node_modules).map_or(true, |mut entries| entries.next().is_none());
-    if empty {
-        println!("Installing workbench dependencies (npm install)...");
-        run_npm(&workbench, &node_bin, &["install"], &backends)?;
-    }
+    let node_bin = ensure_dashboard(&workbench, &backends)?;
 
     let port = args.port.unwrap_or(3000);
     println!(


### PR DESCRIPTION
`vizfold serve` was provisioning a Node environment and running `npm install` on first use — minutes
of work, triggered at the moment someone wants to look at a result. That moves into `install repo`,
which is where the other minutes-long setup already lives.

Both paths call one idempotent `ensure_dashboard`: stage the workbench, provision Node if neither the
env nor a system Node has it, `npm install` when `node_modules` is empty. `serve` still calls it, so
an install that predates this change, or a cleared prefix, self-heals rather than failing.

## Verified

`vizfold install repo` against a fresh prefix, with the checkout already present:

```
$ vizfold install repo
…
=== did node_modules land? ===
  packages: 281
```

Exit 0, and the workbench staged to `$PREFIX/workbench`.

## Test plan

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` (0), `cargo test` (140).
- `bash -n` over every tracked script; `launch_args`, `site_config`, `vocabulary`, `link_mirror`,
  `esmfold_env`, `install_rc`, `configure_repo`, `libcuda_stub`.
- README and DEMO no longer promise a first-run install.
