### PR TITLE
Bump version to 0.10.2

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "executor"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "async-trait",
  "chrono",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "executor"
-version = "0.10.1"
+version = "0.10.2"
 edition = "2024"
 default-run = "vizfold"
 


### PR DESCRIPTION
Patch: ships the dashboard preinstall (#156).

The binary clones the installer scripts at its own release tag, so script-side changes need a release to reach anyone.