### PR TITLE
Fall back to the sole association when a cluster sets no DefaultAccount

### DIFF
--- a/.github/workflows/install_tests.yml
+++ b/.github/workflows/install_tests.yml
@@ -19,3 +19,4 @@ jobs:
       - run: bash tests/install_rc.sh
       - run: bash tests/configure_repo.sh
       - run: bash tests/libcuda_stub.sh
+      - run: bash tests/slurm_account.sh

--- a/lib/slurm.sh
+++ b/lib/slurm.sh
@@ -44,7 +44,18 @@ slurm::nvme_alloc() {
     return 0
 }
 
-slurm::default_account() { echo "${OPENFOLD_ACCOUNT:-$(sacctmgr -nP show user "$USER" format=DefaultAccount 2>/dev/null)}"; }
+# DefaultAccount is blank wherever a cluster never set one -- Nexus is one -- so fall back to the
+# associations. Exactly one is the answer; with several, which to charge is the user's call and the
+# prompt stays empty rather than guessing.
+slurm::default_account() {
+    local default assoc
+    [ -n "${OPENFOLD_ACCOUNT:-}" ] && { echo "$OPENFOLD_ACCOUNT"; return; }
+    default=$(sacctmgr -nP show user "$USER" format=DefaultAccount 2>/dev/null | head -1)
+    [ -n "$default" ] && { echo "$default"; return; }
+    assoc=$(sacctmgr -nP show assoc user="$USER" format=Account 2>/dev/null | sort -u | grep -c .)
+    [ "$assoc" = 1 ] && sacctmgr -nP show assoc user="$USER" format=Account 2>/dev/null | sort -u
+    return 0
+}
 
 # Three sources: Delta's login nodes cannot always reach slurmctld. Lower-cased to match sites/.
 slurm::cluster() {
@@ -97,6 +108,10 @@ vizfold::settle_site() {
     [ -n "${OPENFOLD_PREFIX:-}" ] || slurm::discover    # the atoms the <site>.json templates need
     config::site_defaults "$SITES/$site.sh"             # fill + expand <site>.json off those atoms
     config::load                                        # then the previous install's answers
+
+    # Before the prefix, so `vizfold install repo` records it too: that path writes the config
+    # without ever reaching slurm::run, which is where the account is otherwise settled.
+    export OPENFOLD_ACCOUNT=${OPENFOLD_ACCOUNT:-$(slurm::default_account)}
 
     prefix=$(interactive::resolve OPENFOLD_PREFIX "install prefix" \
         "${OPENFOLD_PREFIX:-$(slurm::default_prefix)}")

--- a/tests/slurm_account.sh
+++ b/tests/slurm_account.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Which account an install charges. Run: bash tests/slurm_account.sh
+#
+# Nexus sets no DefaultAccount, so the old lookup returned nothing and the prompt came up empty with
+# no hint that `pearc26-tutorial` was sitting right there in the associations.
+set -uo pipefail
+
+REPO=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd); export REPO OPENFOLD_HOME=$REPO
+export USER=x-test VIZFOLD_CONFIG=/nonexistent/vizfold-test.json
+. "$REPO/lib/slurm.sh"
+set +e
+fail=0
+
+# $1 what `show user … DefaultAccount` prints, $2 what `show assoc … Account` prints.
+stub() {
+    DEFAULT=$1 ASSOC=$2
+    sacctmgr() { case "$*" in *DefaultAccount*) printf '%s' "$DEFAULT" ;; *Account*) printf '%s' "$ASSOC" ;; esac; }
+}
+check() { if [ "$2" = "$3" ]; then echo "ok   $1"; else
+    echo "FAIL $1"; echo "  want [$3]"; echo "  got  [$2]"; fail=1; fi; }
+
+stub 'bbka' 'bbka
+other'
+check "a DefaultAccount is taken as given" "$(OPENFOLD_ACCOUNT= slurm::default_account)" "bbka"
+
+# The reported bug: Nexus prints nothing for DefaultAccount.
+stub '' 'pearc26-tutorial'
+check "no DefaultAccount falls back to the one association" "$(OPENFOLD_ACCOUNT= slurm::default_account)" "pearc26-tutorial"
+
+# sacctmgr repeats an account per association; one account is still one answer.
+stub '' 'pearc26-tutorial
+pearc26-tutorial'
+check "a repeated association is still one account" "$(OPENFOLD_ACCOUNT= slurm::default_account)" "pearc26-tutorial"
+
+stub '' 'alpha
+beta'
+check "several associations name none: charging one is the user's call" "$(OPENFOLD_ACCOUNT= slurm::default_account)" ""
+
+stub '' ''
+check "no slurm accounting at all is not an error" "$(OPENFOLD_ACCOUNT= slurm::default_account)" ""
+
+stub 'bbka' 'bbka'
+check "an explicit OPENFOLD_ACCOUNT wins" "$(OPENFOLD_ACCOUNT=mine slurm::default_account)" "mine"
+
+# `vizfold install repo` writes the config from settle_site alone, never reaching slurm::run, so the
+# account has to be settled there or it lands empty in a config that claims to be complete.
+stub '' 'pearc26-tutorial'
+got=$( export OPENFOLD_SITE=nexus-dev OPENFOLD_BASE=/projects/x-test OPENFOLD_ACCOUNT= OPENFOLD_PREFIX=/tmp/x
+       interactive::resolve() { echo "$3"; }
+       vizfold::settle_site >/dev/null 2>&1; echo "$OPENFOLD_ACCOUNT" )
+check "settle_site records it, for the config install repo writes" "$got" "pearc26-tutorial"
+
+exit $fail


### PR DESCRIPTION
```
[yjayawardana@nexus-login ~]$ vizfold install openfold
slurm account []:
```

`pearc26-tutorial` was there the whole time — just not where the lookup was pointed.

```
$ sacctmgr -nP show user $USER format=DefaultAccount     # what we asked
                                                          ← empty
$ sacctmgr -nP show assoc user=$USER format=Account      # what exists
pearc26-tutorial
```

Nexus never set a `DefaultAccount`, so `slurm::default_account` returned nothing and the prompt
defaulted to empty, with no hint that an allocation was available.

## Fix

`slurm::default_account` now tries, in order: an explicit `OPENFOLD_ACCOUNT`, the cluster's
`DefaultAccount`, then the associations — taking a single association as the answer.

**Several associations still yield nothing.** Which allocation to charge is not a guess worth
making on someone's behalf; the prompt stays empty and they name it.

Also settled in `vizfold::settle_site`, not just `slurm::run`. `vizfold install repo` writes the
config from `settle_site` alone and never reaches `slurm::run`, so without this the account landed
empty in a config that reports itself complete.

## Why the snapshot never caught it

`tests/site_config.sh` stubs `sacctmgr() { echo bbka; }`, which answers *every* query — so
`DefaultAccount` was never empty under test, and nexus-dev's entry has always read
`"OPENFOLD_ACCOUNT": "bbka"`. The new test stubs the two queries separately, which is the only way
to reproduce a cluster that has associations but no default.

## Test plan

- `tests/slurm_account.sh` (new, in `install_tests.yml`), 7 assertions: a `DefaultAccount` is taken
  as given; no default falls back to the one association; a repeated association is still one
  account (sacctmgr prints one row per association); several associations name none; no accounting
  at all is not an error; an explicit `OPENFOLD_ACCOUNT` wins; and `settle_site` records it.
  Both mutations tried are caught — dropping the fallback (3 failures) and dropping it from
  `settle_site` (1).
- `bash -n` over every tracked script; `launch_args`, `site_config`, `vocabulary`, `link_mirror`,
  `esmfold_env`, `install_rc`, `configure_repo`, `libcuda_stub`. `site_config.expected` unchanged.

Verified against the real cluster: the two queries above are actual nexus-staging output.
