### PR TITLE
Re-read the config after `install repo` writes it

### DIFF
--- a/cli/src/adapters/cli.rs
+++ b/cli/src/adapters/cli.rs
@@ -562,6 +562,9 @@ fn install_repo() -> Result<(), DbErr> {
             .arg(repo.join(CONFIGURE))
             .env("OPENFOLD_HOME", &repo),
     )?;
+    // configure.sh just wrote the prefix; without this the dashboard would be staged under the
+    // default this process started with, which is a directory the install never settled on.
+    config::reload();
     // The dashboard too, so `serve` starts rather than provisioning: on a cluster that is a Node
     // environment and an npm install, minutes of it, and `serve` is run when someone wants to look.
     ensure_dashboard(&serve_dir()?, "")?;

--- a/cli/src/core/config.rs
+++ b/cli/src/core/config.rs
@@ -1,6 +1,6 @@
 use serde_json::{Map, Value};
 use std::path::{Path, PathBuf};
-use std::sync::OnceLock;
+use std::sync::{OnceLock, PoisonError, RwLock, RwLockReadGuard};
 
 /// The flat JSON map `config::save` writes at install time: source of every resolved path.
 pub fn config_file() -> PathBuf {
@@ -51,15 +51,32 @@ fn home_dir() -> String {
     std::env::var("HOME").unwrap_or_else(|_| ".".to_owned())
 }
 
-fn vizfold_config() -> &'static Map<String, Value> {
-    static CONFIG: OnceLock<Map<String, Value>> = OnceLock::new();
-    CONFIG.get_or_init(|| {
-        std::fs::read_to_string(config_file())
-            .ok()
-            .and_then(|c| serde_json::from_str::<Value>(&c).ok())
-            .and_then(|v| v.as_object().cloned())
-            .unwrap_or_default()
-    })
+fn read_config() -> Map<String, Value> {
+    std::fs::read_to_string(config_file())
+        .ok()
+        .and_then(|c| serde_json::from_str::<Value>(&c).ok())
+        .and_then(|v| v.as_object().cloned())
+        .unwrap_or_default()
+}
+
+fn config_cache() -> &'static RwLock<Map<String, Value>> {
+    static CONFIG: OnceLock<RwLock<Map<String, Value>>> = OnceLock::new();
+    CONFIG.get_or_init(|| RwLock::new(read_config()))
+}
+
+fn vizfold_config() -> RwLockReadGuard<'static, Map<String, Value>> {
+    config_cache()
+        .read()
+        .unwrap_or_else(PoisonError::into_inner)
+}
+
+/// Re-read the file. `install repo` writes the config mid-process, and everything prefix-derived
+/// after that would otherwise still answer from the defaults this process started with.
+pub fn reload() {
+    let fresh = read_config();
+    *config_cache()
+        .write()
+        .unwrap_or_else(PoisonError::into_inner) = fresh;
 }
 
 /// Empty is unset: the key set is fixed, so an unsettled name is present-but-empty.
@@ -356,5 +373,47 @@ mod tests {
                 "case: {name}"
             );
         }
+    }
+
+    /// `install repo` writes the config partway through its own process, so a cache that answered
+    /// once for the lifetime of that process staged the dashboard under the default prefix instead
+    /// of the settled one. Serialised against the other config readers by the lock it takes.
+    #[test]
+    fn reload_sees_a_config_written_after_the_first_read() {
+        let path = std::env::temp_dir().join(format!("vizfold-reload-{}.json", std::process::id()));
+        let previous = std::env::var("VIZFOLD_CONFIG").ok();
+        // SAFETY: the reload below is the only reader of this file, and the variable is restored.
+        unsafe { std::env::set_var("VIZFOLD_CONFIG", &path) };
+
+        let _ = std::fs::remove_file(&path);
+        super::reload();
+        assert_eq!(
+            super::resolved("OPENFOLD_PREFIX"),
+            None,
+            "no file yet, so nothing is settled"
+        );
+
+        std::fs::write(&path, r#"{"OPENFOLD_PREFIX": "/settled/by/configure"}"#).unwrap();
+        assert_eq!(
+            super::resolved("OPENFOLD_PREFIX"),
+            None,
+            "and the cache does not notice on its own -- this is the bug"
+        );
+
+        super::reload();
+        assert_eq!(
+            super::resolved("OPENFOLD_PREFIX").as_deref(),
+            Some("/settled/by/configure")
+        );
+
+        let _ = std::fs::remove_file(&path);
+        // SAFETY: single-threaded restore; the reload puts the shared cache back.
+        unsafe {
+            match previous {
+                Some(value) => std::env::set_var("VIZFOLD_CONFIG", value),
+                None => std::env::remove_var("VIZFOLD_CONFIG"),
+            }
+        }
+        super::reload();
     }
 }


### PR DESCRIPTION
A cold install on Nexus died in the dashboard step I added in #156:

```
error libmamba Error opening for reading "/home/yjayawardana/openfold/mamba/pkgs/.../index.json"
critical libmamba Found incorrect downloads. Aborting
provisioning Node: exit status: 1
```

Note the path: **`~/openfold`**, which is `default_prefix()` — not `~/vizfold`, which is what
`configure.sh` had settled seconds earlier in the same command.

`vizfold_config()` was an `OnceLock`, initialised the first time anything read the config — which is
the prereq gate at startup, before `install repo` has written one. Everything prefix-derived after
that answered from the defaults the process started with. It only became reachable when #156 put
work *after* `configure.sh` in the same process.

The cache is now an `RwLock` with an explicit `config::reload()`, called once, after `configure.sh`.

## Test plan

- `reload_sees_a_config_written_after_the_first_read` (new): asserts the stale read explicitly —
  that after writing the file the cache still answers `None` — then that `reload()` picks it up.
  It restores `VIZFOLD_CONFIG` and reloads on the way out.
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` (0), `cargo test` (141).

**Coverage gap, stated plainly:** the test covers `reload()`, not that `install_repo` calls it —
deleting the call keeps the suite green, because reaching that line needs a clone and a scheduler.
The verification for the call site is a cold install on Nexus, which is what surfaced it.
