### PR TITLE
Bump version to 0.10.4

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "executor"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "async-trait",
  "chrono",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "executor"
-version = "0.10.3"
+version = "0.10.4"
 edition = "2024"
 default-run = "vizfold"
 


### PR DESCRIPTION
Patch: ships the config-reload fix (#160), found by a cold install on Nexus.