### PR TITLE
Fetch what the mirror does not carry, instead of dying at verify

### DIFF
--- a/backends/openfold/install/setup.sh
+++ b/backends/openfold/install/setup.sh
@@ -143,6 +143,9 @@ setup::build_openfold() {
 setup::link_mirror() {
     log datasets
     for d in "$AF2"/*; do
+        # An empty or unreadable mirror leaves the glob literal, and `ln` would happily make a
+        # dangling link named `*` -- succeeding, so the install runs on and dies at verify instead.
+        [ -e "$d" ] || continue
         [ "${d##*/}" = uniclust30 ] && continue
         # Explicit link name: GNU ln -sfn onto a real dir errors instead of linking inside it.
         ln -sfn "$d" "$DATA/${d##*/}"
@@ -204,16 +207,25 @@ assert util.find_spec("flash_attn"), "flash_attn is not importable"
 assert os.path.isdir(os.environ.get("CUTLASS_PATH", "")), "CUTLASS_PATH is unset"
 print("flash_attn ok, CUTLASS_PATH", os.environ["CUTLASS_PATH"])
 PY
+    # What every fold reads, precomputed alignments or not.
     local b p required=("$DATA/params/params_model_1_ptm.npz" "$STEREO" "$DATA/pdb_mmcif/mmcif_files")
-    [ "$MIRROR" = yes ] && required+=(
-        "$DATA/uniref90/uniref90.fasta"
-        "$DATA/mgnify/mgy_clusters_2022_05.fa"
-        "$DATA/pdb70/pdb70"
-        "$UNICLUST/uniclust30_2018_08"
-        "$DATA/bfd/bfd_metaclust_clu_complete_id30_c90_final_seq.sorted_opt"
-    )
     for b in jackhmmer hhblits hhsearch; do command -v "$b" >/dev/null || die "missing binary: $b"; done
     for p in "${required[@]}"; do have "$p" || die "missing: $p"; done
+
+    # The MSA databases are read only when folding a sequence that has no alignments beside it, so a
+    # mirror without them is a working install with a smaller reach -- not a failed one. Dying here
+    # instead would name a mirror path the person running the install usually cannot do anything about.
+    local msa=() m
+    for m in "$DATA/uniref90/uniref90.fasta" "$DATA/mgnify/mgy_clusters_2022_05.fa" \
+             "$DATA/pdb70/pdb70" "$UNICLUST/uniclust30_2018_08" \
+             "$DATA/bfd/bfd_metaclust_clu_complete_id30_c90_final_seq.sorted_opt"; do
+        have "$m" || msa+=("${m#"$DATA"/}")
+    done
+    if [ ${#msa[@]} -gt 0 ]; then
+        echo "== note: no MSA databases under ${AF2:-$DATA} -- ${msa[*]}"
+        echo "   The bundled proteins fold: their alignments ship with the checkout."
+        echo "   Folding a sequence of your own needs them: vizfold download openfold all"
+    fi
 }
 
 setup::fold_vars() {
@@ -260,12 +272,12 @@ main() {
         setup::nvrtc_preload
     fi
     setup::openfold_present || setup::build_openfold
-    if [ "$MIRROR" = yes ]; then
-        setup::link_mirror
-    else
-        step params setup::fetch_params
-        setup::fetch_templates
-    fi
+    [ "$MIRROR" = yes ] && setup::link_mirror
+    # Whatever the mirror did not carry, fetch. A mirror holding only the weights, or only the
+    # databases, is normal, and verify's `missing: <path>` names somewhere the user cannot act on.
+    # Both fetches are bounded: one 4 GB tar, and only the mmCIFs the bundled examples cite.
+    have "$DATA/params/params_model_1_ptm.npz" || step params setup::fetch_params
+    [ -n "$(ls -A "$DATA/pdb_mmcif/mmcif_files" 2>/dev/null | head -1)" ] || setup::fetch_templates
     setup::stereo
     setup::verify
     setup::fold_vars

--- a/tests/link_mirror.sh
+++ b/tests/link_mirror.sh
@@ -69,6 +69,14 @@ assert_link "$UNICLUST/uniclust30_2018_08_cs219.ffindex"
     { echo "FAIL [uniref30-only] the alias does not point at the uniref30 file"; exit 1; }
 echo "ok   with no uniclust30, uniref30 is aliased under the uniclust30 names"
 
+# An unreadable or empty mirror globs to nothing, and `ln` would make a dangling link named `*` --
+# succeeding, so the install marches on and dies at verify naming a path nobody can act on.
+populate_nothing() { :; }
+run_case "empty-mirror" populate_nothing
+dangling=$(find "$DATA" -maxdepth 1 -type l | while read -r l; do [ -e "$l" ] || echo "$l"; done)
+[ -z "$dangling" ] || { echo "FAIL [empty-mirror] dangling link: $dangling"; exit 1; }
+echo "ok   an empty mirror links nothing, not a dangling '*'"
+
 # The mirror is read-only in practice.
 run_case "mirror-untouched" populate_flat
 [ -z "$(find "$AF2" -type l)" ] || { echo "FAIL [mirror-untouched] a link was created inside the mirror"; exit 1; }


### PR DESCRIPTION
```
== verify (+1328s)
torch 2.6.0 cuda_devices 1
flash_attn ok, CUTLASS_PATH /home/<you>/vizfold/openfold/cutlass
FATAL: missing: /home/<you>/vizfold/openfold/data/params/params_model_1_ptm.npz
model install: exit status: 1
```

OpenFold builds fine; `verify` refuses the install over data the mirror did not carry.

## Three things, one symptom

**1. The link glob was unguarded.** `for d in "$AF2"/*` stays literal when the mirror is empty or
unreadable, so `ln` created a dangling link named `*` — and *succeeded*, so `set -e` never fired and
the install ran on to fail much later at verify. Reproduced:

```
$ ls -l data/
lrwxr-xr-x  * -> /…/empty-mirror/*
```

**2. A partial mirror had no path forward.** Both fetch routines already exist for the no-mirror
case, and both are bounded — the weights are one 4 GB tar, and `fetch_templates` pulls only the
mmCIFs the bundled proteins' `.hhr` files cite, not the 200 GB `pdb_mmcif` set. They now run for
whatever the mirror is missing, mirror or not.

**3. Missing MSA databases were fatal.** `uniref90`, `mgnify`, `pdb70`, `uniclust30` and `bfd` are
read only when folding a sequence that has no alignments beside it. A mirror without them is a
working install with a smaller reach, so verify now reports instead of dying:

```
== note: no MSA databases under /projects/alphafold2/database -- uniref90/… mgnify/… pdb70/…
   The bundled proteins fold: their alignments ship with the checkout.
   Folding a sequence of your own needs them: vizfold download openfold all
```

What every fold needs — params, stereo chemical props, template mmCIFs — is still fatal when absent.

## Why this matters now

Nexus staging's mirror at `/projects/alphafold2/database` holds **only** the weights (10.6 GB, no
databases at all). Before this, no install there could finish and therefore nothing could fold.

## Test plan

- `tests/link_mirror.sh` gains an `empty-mirror` case asserting no dangling link is created; the
  mutation that removes the guard fails it with `dangling link: …/data/*`.
- `bash -n` over every tracked script; `launch_args`, `site_config`, `vocabulary`, `link_mirror`,
  `esmfold_env`, `install_rc`, `configure_repo`, `libcuda_stub`, `slurm_account`. `cargo test` (141).
- End-to-end on nexus-staging after release — this is the branch that unblocks that run.
