### PR TITLE
Wait for the compute node to see the checkout before running it

### DIFF
--- a/.github/workflows/install_tests.yml
+++ b/.github/workflows/install_tests.yml
@@ -20,3 +20,4 @@ jobs:
       - run: bash tests/configure_repo.sh
       - run: bash tests/libcuda_stub.sh
       - run: bash tests/slurm_account.sh
+      - run: bash tests/wait_then_exec.sh

--- a/lib/slurm.sh
+++ b/lib/slurm.sh
@@ -147,5 +147,14 @@ slurm::run() {
     local LAUNCH=()
     while IFS= read -r arg; do LAUNCH+=("$arg"); done < <(slurm::launch_args "$ACCOUNT" "${PARTITION:-}" "$PTY")
     echo "${LAUNCH[0]} $SETUP"
-    exec "${LAUNCH[@]}" "$SETUP"
+    exec "${LAUNCH[@]}" bash -c "$(slurm::wait_then_exec)" _ "$SETUP"
+}
+
+# `install repo` can finish seconds before this runs, and $HOME is NFS on most of these clusters: the
+# compute node's attribute cache may not hold the checkout yet, and srun execve'ing a script it
+# cannot see dies with a bare "No such file or directory". bash is local to the node, so it starts
+# either way and waits for the view to catch up; when the file is already there this costs nothing.
+slurm::wait_then_exec() {
+    echo 'for _ in $(seq 60); do [ -r "$1" ] && break; sleep 1; done
+exec bash "$1"'
 }

--- a/tests/wait_then_exec.sh
+++ b/tests/wait_then_exec.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# The gap between `install repo` writing the checkout and a compute node being able to see it.
+# Run: bash tests/wait_then_exec.sh
+#
+# $HOME is NFS on these clusters. srun execve'ing a script the node's attribute cache does not hold
+# yet fails with a bare "No such file or directory" -- naming a file that is plainly there on the
+# login node, which is exactly the report this guards against.
+set -uo pipefail
+
+REPO=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd); export REPO OPENFOLD_HOME=$REPO
+export VIZFOLD_CONFIG=/nonexistent/vizfold-test.json
+. "$REPO/lib/slurm.sh"
+set +e
+SANDBOX=${TMPDIR:-/tmp}/vizfold-wait-$$; mkdir -p "$SANDBOX"
+trap 'rm -rf "$SANDBOX"' EXIT
+fail=0
+
+check() { if [ "$2" = "$3" ]; then echo "ok   $1"; else
+    echo "FAIL $1"; echo "  want [$3]"; echo "  got  [$2]"; fail=1; fi; }
+
+script=$SANDBOX/setup.sh
+printf '#!/bin/bash\necho ran\n' > "$script"; chmod +x "$script"
+check "a script already visible runs at once" \
+    "$(bash -c "$(slurm::wait_then_exec)" _ "$script")" "ran"
+
+# The reported failure: the file lands a moment after the step starts.
+late=$SANDBOX/late.sh
+( sleep 3; printf '#!/bin/bash\necho ran late\n' > "$late" ) &
+check "a script that appears late is waited for" \
+    "$(bash -c "$(slurm::wait_then_exec)" _ "$late")" "ran late"
+wait
+
+# It must not wait forever on a file that never lands -- that would hang an install with no output.
+# `seq` is shadowed so the bound is reached in two ticks instead of sixty; the loop is what is under
+# test, not the wall time.
+out=$(bash -c "seq() { command seq 2; }; $(slurm::wait_then_exec)" _ "$SANDBOX/never.sh" 2>&1)
+check "a file that never appears gives up rather than hanging" "$?" "127"
+
+exit $fail


### PR DESCRIPTION
A cold run on Nexus, `install repo` immediately followed by `install openfold`:

```
srun /home/<you>/vizfold-repo/backends/openfold/install/setup.sh
slurmstepd: error: execve(): /home/<you>/vizfold-repo/backends/openfold/install/setup.sh: No such file or directory
model install: exit status: 2
```

The file was there the whole time — mode `755`, 14170 bytes, at the right tag. Minutes later
`srun ls -l` on the same node showed it fine.

`$HOME` is NFS-exported to the compute nodes. The clone had finished ~2 seconds earlier, and the
node's attribute cache did not hold the new tree yet, so `execve` returned `ENOENT` on a file that
plainly exists. The workshop flow walks straight into this: `install repo`, then `install openfold`.

## Fix

The wait has to happen **on the compute node**, where the stale cache is — nothing the login node
does can flush it. `bash` is local to every node, so it starts regardless, then waits for the
checkout to come into view:

```
exec "${LAUNCH[@]}" bash -c "$(slurm::wait_then_exec)" _ "$SETUP"
```

Bounded at 60 seconds, and free when the file is already visible. A file that never appears falls
through to `bash`'s own error rather than hanging.

## Test plan

- `tests/wait_then_exec.sh` (new, in `install_tests.yml`), 3 assertions: an already-visible script
  runs at once; **a script that appears three seconds late is waited for** — the reported failure;
  and one that never appears gives up instead of hanging. The last shadows `seq` so the bound is hit
  in two ticks, keeping the suite fast without weakening what it checks.
  Removing the wait fails it.
- `bash -n` over every tracked script; the other nine suites; `cargo test` (141).
