### PR TITLE
Bump version to 0.10.6

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "executor"
-version = "0.10.5"
+version = "0.10.6"
 dependencies = [
  "async-trait",
  "chrono",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "executor"
-version = "0.10.5"
+version = "0.10.6"
 edition = "2024"
 default-run = "vizfold"
 


### PR DESCRIPTION
Patch: ships the NFS-visibility wait (#164).