### PR TITLE
Run the workbench suite in CI, on both platforms

### DIFF
--- a/.github/workflows/workbench_tests.yml
+++ b/.github/workflows/workbench_tests.yml
@@ -1,0 +1,22 @@
+name: workbench tests
+on: [pull_request, push]
+jobs:
+  workbench-tests:
+    # Both, because the dashboard resolves paths: a macOS temp dir is a symlink and Linux's is not,
+    # and a run directory reached through one is what the file and attention routes are gated on.
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        working-directory: workbench
+    steps:
+      - uses: actions/checkout@v7
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - run: bun install --frozen-lockfile
+      - run: bun test
+      - run: bun run typecheck

--- a/workbench/src/server/runfiles.test.ts
+++ b/workbench/src/server/runfiles.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -45,11 +45,14 @@ describe("listFiles", () => {
 });
 
 describe("resolveInside", () => {
-  test("resolves a path within the run", () => {
+  test("resolves a path within the run to the file it names", () => {
     const root = join(sandbox(), "run");
-    expect(resolveInside(root, "attention/1UBQ_1/msa_row_attn_layer0.txt")).toBe(
-      join(root, "attention/1UBQ_1/msa_row_attn_layer0.txt"),
-    );
+    const wanted = "attention/1UBQ_1/msa_row_attn_layer0.txt";
+    const resolved = resolveInside(root, wanted);
+    // Containment is decided on the run root's real path, so a symlinked root resolves through it:
+    // on macOS the temp directory is exactly that, `/var/…` standing for `/private/var/…`.
+    expect(resolved).toBe(realpathSync(join(root, wanted)));
+    expect(readFileSync(resolved!, "utf8")).toBe("Layer 0, Head 0\n");
   });
 
   test("refuses to climb out of the run", () => {


### PR DESCRIPTION
The dashboard's tests only ever ran by hand — CI covers the Rust CLI, the installers and the Python name check, but nothing under `workbench/`. They also only passed on one platform, which is how this was found: running them on a Mac fails.

```
Expected: /var/folders/…/run/attention/1UBQ_1/msa_row_attn_layer0.txt
Received: /private/var/folders/…/run/attention/1UBQ_1/msa_row_attn_layer0.txt
```

The product code is right. `resolveInside` decides containment on the run root's **real** path — that is what stops a symlink inside a run directory from serving a file outside it — so the path it hands back is resolved too. The test compared that answer to the unresolved `join(root, …)`, which holds on Linux and breaks the moment the root is reached through a symlink. A macOS temp directory is exactly that: `/var/folders/…` standing for `/private/var/folders/…`.

The assertion now checks the behaviour that matters — it reads the file the call resolved to — rather than a path spelling.

## CI

A `workbench tests` workflow runs `bun test` and `bun run typecheck`, matrixed over `ubuntu-latest` and `macos-latest`. Both, deliberately: this is code whose job is resolving paths inside a run directory, and the two platforms disagree about what a path is. `oven-sh/setup-bun@v2` with `bun install --frozen-lockfile`, matching how the other workflows pin their toolchains.

## Test plan

- `bun test` on macOS — 18 pass (was 17 pass / 1 fail before this change)
- `bun run typecheck` — clean
- Workflow YAML parsed and checked for shape; both matrix legs run on this PR