### PR TITLE
Refuse a run workspace that is not this run's

### DIFF
--- a/DEMO.md
+++ b/DEMO.md
@@ -273,6 +273,15 @@ target is a bundled example, so a FASTA of your own runs the full search unless 
 otherwise. Pass `--use-precomputed-alignments=false` to run the full MSA search instead (much slower; needs the full
 databases).
 
+### `run N has never run, but '…/runs/N' already holds output`
+
+The workspace is `$OPENFOLD_PREFIX/runs/<run-id>`, so a run id that comes round again — a rebuilt
+database, a deleted row, a directory that outlived the run that wrote it — would land on someone
+else's output and register every file in it as this run's. A run that has never started refuses one.
+Move the directory aside and re-run, or pass `--reuse-workspace` when you know the output is this
+run's. Re-running a run that already started is unaffected: its own partial output is what a retry
+should find.
+
 ### `srun: Requested time limit is invalid` / `Invalid account or account/partition combination`
 
 The GPU partition and time cap come from the site profile (`sites/<ClusterName>.json`); the account

--- a/cli/src/adapters/cli/args.rs
+++ b/cli/src/adapters/cli/args.rs
@@ -302,6 +302,11 @@ pub(super) struct RunArgs {
     /// Print only the run as JSON, for tools driving the CLI.
     #[arg(long)]
     pub(super) json: bool,
+    /// Fold into the run's workspace even when it already holds output. A run that has never run
+    /// refuses one, since an id that comes round again would otherwise inherit -- and register --
+    /// files it never produced.
+    #[arg(long)]
+    pub(super) reuse_workspace: bool,
     /// OpenFold data directory. Defaults to the config `OPENFOLD_DATA_DIR`.
     #[arg(long)]
     pub(super) data_dir: Option<String>,

--- a/cli/src/adapters/cli/run.rs
+++ b/cli/src/adapters/cli/run.rs
@@ -122,9 +122,10 @@ pub(super) async fn register_artifacts(
 pub(super) async fn report_execution(
     database: &sea_orm::DatabaseConnection,
     run_id: i32,
+    reuse_workspace: bool,
 ) -> Result<(), DbErr> {
     println!("Executing run {run_id}");
-    let outcome = execute_run(database, run_id, &LocalCommandRunner).await?;
+    let outcome = execute_run(database, run_id, &LocalCommandRunner, reuse_workspace).await?;
 
     let label = if outcome.report.has_failures() {
         "failed"
@@ -203,9 +204,9 @@ pub(super) async fn run_run(
     };
 
     if args.json {
-        execute_run(database, run_id, &LocalCommandRunner).await?;
+        execute_run(database, run_id, &LocalCommandRunner, args.reuse_workspace).await?;
     } else {
-        report_execution(database, run_id).await?;
+        report_execution(database, run_id, args.reuse_workspace).await?;
         println!();
     }
     run_artifacts::register_run_artifacts(database, run_id).await?;

--- a/cli/src/core/services/run_execution.rs
+++ b/cli/src/core/services/run_execution.rs
@@ -44,10 +44,34 @@ pub struct ExecutionOutcome {
     pub output: Option<CommandOutput>,
 }
 
+/// A run's workspace is `<output location>/<run id>`, so an id that comes round again -- a database
+/// rebuilt, a row deleted, a directory outliving the run that made it -- lands on someone else's
+/// output. Registration would then attribute every one of those files to this run, and the
+/// dashboard would draw them: the arcs of a protein this run never folded.
+///
+/// A run that has already started owns what is there; that is a retry, and its own partial output
+/// is exactly what it should find. A run that has never started must find nothing.
+fn claim_workspace(workspace: &Path, run: &run_entity::Model, reuse: bool) -> Result<(), DbErr> {
+    if reuse || run.started_at.is_some() {
+        return Ok(());
+    }
+    let occupied = std::fs::read_dir(workspace).is_ok_and(|mut entries| entries.next().is_some());
+    if !occupied {
+        return Ok(());
+    }
+    Err(DbErr::Custom(format!(
+        "run {} has never run, but '{}' already holds output; move it aside, or pass \
+         --reuse-workspace to fold into it anyway",
+        run.id,
+        workspace.display()
+    )))
+}
+
 pub async fn execute_run(
     db: &DatabaseConnection,
     run_id: i32,
     runner: &dyn CommandRunner,
+    reuse_workspace: bool,
 ) -> Result<ExecutionOutcome, DbErr> {
     let run = run_entity::Entity::find_by_id(run_id)
         .one(db)
@@ -64,6 +88,7 @@ pub async fn execute_run(
 
         // Created up front, so a fresh install needs no mkdir; OpenFold also seeds its attention/ dir.
         let workspace = resolve_output_location(&invocation_profile, &run)?;
+        claim_workspace(&workspace, &run, reuse_workspace)?;
         let to_create = match kind {
             BackendKind::Openfold => workspace.join("attention"),
             BackendKind::Esmfold => workspace.clone(),
@@ -550,10 +575,75 @@ mod tests {
     async fn missing_run_returns_clear_error() -> Result<(), DbErr> {
         let db = crate::core::test_support::seeded_db().await?;
         let (runner, _, _) = runner(0, "");
-        let error = execute_run(&db, 999, &runner)
+        let error = execute_run(&db, 999, &runner, false)
             .await
             .expect_err("missing run should error");
         assert!(error.to_string().contains("run 999 does not exist"));
+        Ok(())
+    }
+
+    /// Delta handed us the real case: `runs/4` still held a complete ESMFold run from ten days
+    /// earlier, and a fresh OpenFold run folded into it. Every one of those files then registered
+    /// as run 4's, and the dashboard drew a 43-residue protein this run never folded.
+    #[tokio::test]
+    async fn a_run_that_never_ran_refuses_a_workspace_that_is_not_empty() -> Result<(), DbErr> {
+        let db = crate::core::test_support::seeded_db().await?;
+        let layout = TestLayout::new("test_input");
+        let run = create_run(&db, &layout, false).await?;
+        let workspace = layout.output_location.join(run.id.to_string());
+        std::fs::create_dir_all(&workspace).expect("workspace");
+        std::fs::write(workspace.join("predicted.pdb"), "ATOM\n").expect("someone else's output");
+
+        let (refused, never_called, _) = runner(0, "");
+        let error = execute_run(&db, run.id, &refused, false)
+            .await
+            .expect_err("a fresh run must not inherit output it did not write");
+        assert!(
+            error.to_string().contains("already holds output"),
+            "unexpected error: {error}"
+        );
+        assert!(
+            !never_called.load(Ordering::SeqCst),
+            "nothing should have folded"
+        );
+
+        // The escape hatch, for output the user knows is theirs.
+        let (allowed, called, _) = runner(0, "");
+        execute_run(&db, run.id, &allowed, true).await?;
+        assert!(called.load(Ordering::SeqCst));
+        Ok(())
+    }
+
+    /// A retry is the one case where finding output is right: it is the run's own, from the attempt
+    /// that failed, and `started_at` is what says so.
+    #[tokio::test]
+    async fn a_run_that_already_started_keeps_its_own_workspace() -> Result<(), DbErr> {
+        let db = crate::core::test_support::seeded_db().await?;
+        let layout = TestLayout::new("test_input");
+        let run = create_run(&db, &layout, false).await?;
+        let (failing, _, _) = runner(1, "boom");
+        execute_run(&db, run.id, &failing, false).await?;
+        let failed = run_entity::Entity::find_by_id(run.id)
+            .one(&db)
+            .await?
+            .expect("run exists");
+        assert_eq!(failed.status, "failed");
+        assert!(failed.started_at.is_some());
+        std::fs::write(
+            layout
+                .output_location
+                .join(run.id.to_string())
+                .join("partial.pdb"),
+            "ATOM\n",
+        )
+        .expect("partial output");
+
+        let (retry, called, _) = runner(0, "");
+        execute_run(&db, run.id, &retry, false).await?;
+        assert!(
+            called.load(Ordering::SeqCst),
+            "a retry must be allowed to run"
+        );
         Ok(())
     }
 
@@ -563,7 +653,7 @@ mod tests {
         let layout = TestLayout::new("test_input");
         let run = create_run(&db, &layout, false).await?;
         let (runner, called, command) = runner(0, "");
-        execute_run(&db, run.id, &runner).await?;
+        execute_run(&db, run.id, &runner, false).await?;
         assert!(called.load(Ordering::SeqCst));
         let command = command
             .lock()
@@ -611,7 +701,7 @@ mod tests {
         let run = create_esmfold_run(&db, &layout).await?;
         let (runner, called, command) = runner(0, "");
 
-        execute_run(&db, run.id, &runner).await?;
+        execute_run(&db, run.id, &runner, false).await?;
 
         assert!(called.load(Ordering::SeqCst));
         let command = command
@@ -649,7 +739,7 @@ mod tests {
         let layout = TestLayout::new("test_input");
         let run = create_run(&db, &layout, false).await?;
         let (runner, _, _) = runner(7, "OpenFold failed");
-        execute_run(&db, run.id, &runner).await?;
+        execute_run(&db, run.id, &runner, false).await?;
         let updated = run_entity::Entity::find_by_id(run.id)
             .one(&db)
             .await?
@@ -665,7 +755,7 @@ mod tests {
         let layout = TestLayout::new("test_input");
         let run = create_run(&db, &layout, true).await?;
         let (runner, called, _) = runner(0, "");
-        let result = execute_run(&db, run.id, &runner).await?;
+        let result = execute_run(&db, run.id, &runner, false).await?;
         assert!(!called.load(Ordering::SeqCst));
         assert!(result.output.is_none());
         assert!(result.report.has_failures());
@@ -690,7 +780,7 @@ mod tests {
         let run = create_run(&db, &layout, false).await?;
         let runner = FakeCommandRunner::fails("boom");
 
-        let error = execute_run(&db, run.id, &runner)
+        let error = execute_run(&db, run.id, &runner, false)
             .await
             .expect_err("runner error should propagate");
         assert!(error.to_string().contains("boom"));


### PR DESCRIPTION
A run writes to `<output location>/<run id>`, and nothing checked that the directory belongs to the run claiming it. Run ids come round again — a rebuilt database, a deleted row, a directory outliving the run that made it — and the second occupant silently inherits the first one's files.

## What this looked like on Delta

`runs/4` still held a complete ESMFold run of a 43-residue protein from **Jul 27 01:37**. A fresh OpenFold fold of 6KWC wrote into the same directory on **Aug 6 00:51**.

Registration is total by design, so all **315 files became run 4's artifacts — about 211 of which it never produced**. The dashboard then did exactly what it is built to do with them:

- the Attention tab defaulted to the stale dump and drew a **43-residue, 40-head** diagram for a **191-residue** protein;
- the Activations tab reported **`facebook/esmfold_v1`, written 2026-07-27**, on an OpenFold run submitted 2026-08-06;
- `structure/predicted.pdb` (43 residues, 371 atoms — a different protein) was offered beside the real 2839-atom prediction.

Nothing above is a classification bug. Every file was classified correctly for what it is; the *attribution* was wrong.

## The check

The discriminator is already in the row, so this needs no new state on disk:

- a run that **has started** owns whatever is in its workspace — that is a retry, and its own partial output is precisely what it should find;
- a run that **has never started** must find nothing.

```rust
fn claim_workspace(workspace: &Path, run: &run_entity::Model, reuse: bool) -> Result<(), DbErr> {
    if reuse || run.started_at.is_some() { return Ok(()); }
    ...
}
```

It runs before the workspace is created, so a refused run has written nothing and changed no state.

```
$ vizfold run 5
Executing run 5
error: run 5 has never run, but '/work/nvme/.../runs/5' already holds output;
       move it aside, or pass --reuse-workspace to fold into it anyway
```

`--reuse-workspace` folds into an occupied workspace anyway, for output the user knows is theirs.

## Why not the alternatives

- **Filter registration by `started_at`** — smaller, but fixes only what the database reports. The Files tab reads the directory for an in-flight run, so it would still list a stranger's files.
- **Move the stale directory aside automatically** — self-healing, but it relocates data the user never asked anyone to touch, on a shared cluster filesystem.

## Test plan

- Two new tests: a fresh run refuses a non-empty workspace and the runner is never invoked, then `--reuse-workspace` lets the same run through; and a run whose first attempt failed is allowed to retry into its own partial output.
- `cargo test` — **151 passed**; `clippy --all-targets -- -D warnings` and `fmt --check` clean.
- `DEMO.md` gains the failure mode under "Common failure modes".